### PR TITLE
Prepare Wisp 1.0.4 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -16,7 +16,7 @@ body:
     attributes:
       label: Wisp version
       description: Find this in the lower-right corner of the Wisp window.
-      placeholder: "1.0.3"
+      placeholder: "1.0.4"
     validations:
       required: true
 
@@ -89,7 +89,7 @@ body:
     attributes:
       label: Last known working version
       description: Leave blank if the problem has always existed or is unknown.
-      placeholder: "1.0.3"
+      placeholder: "1.0.4"
 
   - type: textarea
     id: diagnostics

--- a/.github/ISSUE_TEMPLATE/fh6-compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/fh6-compatibility.yml
@@ -15,7 +15,7 @@ body:
     id: wisp_version
     attributes:
       label: Wisp version
-      placeholder: "1.0.3"
+      placeholder: "1.0.4"
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
           --name "wisp-installer-$GITHUB_SHA"
           --dir outputs
 
-      - name: Publish immutable release with stable download alias
+      - name: Publish immutable release
         shell: bash
         run: |
           set -euo pipefail
@@ -229,17 +229,11 @@ jobs:
           test -f "${installer}.sha256"
           test -f "$archive"
           test -f "${archive}.sha256"
-          cp -- "$installer" outputs/Wisp-Setup.exe
-          cmp --silent "$installer" outputs/Wisp-Setup.exe
-          stable_hash="$(sha256sum outputs/Wisp-Setup.exe | cut -d ' ' -f 1)"
-          printf '%s *Wisp-Setup.exe\n' "$stable_hash" > outputs/Wisp-Setup.exe.sha256
           gh release create "$GITHUB_REF_NAME" \
             --draft \
             --verify-tag \
             --title "Wisp ${version}" \
             --notes-file "Wisp-${version}-release-notes.md" \
             "$installer" \
-            "$archive" \
-            outputs/Wisp-Setup.exe \
-            outputs/Wisp-Setup.exe.sha256
+            "$archive"
           gh release edit "$GITHUB_REF_NAME" --draft=false --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.0.4 - 2026-09-01
+
+### Changed
+
+- Reduced uploaded release files to one versioned installer and one installer
+  archive. GitHub's generated source archives remain available.
+- Kept application behavior unchanged from 1.0.3.
+
 ## 1.0.3 - 2026-09-01
 
 ### Added

--- a/Wisp-1.0.4-release-notes.md
+++ b/Wisp-1.0.4-release-notes.md
@@ -1,0 +1,34 @@
+# Wisp 1.0.4
+
+Wisp 1.0.4 keeps the stable 1.0.3 application and simplifies its release
+downloads.
+
+## Changes
+
+- The release contains one versioned installer and one installer ZIP.
+- GitHub continues to provide the source ZIP and source tarball.
+- Application behavior is unchanged from 1.0.3.
+
+## Installation
+
+Download `Wisp-Setup-1.0.4.exe`, or download and extract
+`Wisp-Setup-1.0.4.zip`. The installer is self-contained, installs for the
+current Windows user, and does not require administrator access or a separate
+.NET runtime. It is not code-signed, so Windows may show an
+unfamiliar-publisher warning.
+
+## Application updates
+
+The **Check for updates** action in Extras runs only when selected. Wisp accepts
+only a non-draft, non-prerelease, immutable GitHub release whose versioned
+installer has the expected byte length and SHA-256 digest. The staged helper
+validates the installer again, waits for Wisp to exit, applies the current-user
+package, verifies the installed version, and restarts Wisp.
+
+## Compatibility
+
+The bundled exact Native compatibility contract supports Steam FH6 build
+`6.430.771.0`. Standard local Data Out telemetry continues to provide speed,
+RPM, gear, G-force, wheel rotation, tire slip, and power. Native
+process-derived values are enabled only when the executable fingerprint matches
+the bundled contract.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.3"
+#define MyAppVersion "1.0.4"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1329,7 +1329,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.3" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.4" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.3</Version>
-    <FileVersion>1.0.3.0</FileVersion>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <Version>1.0.4</Version>
+    <FileVersion>1.0.4.0</FileVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.3.0" name="Wisp.App" />
+  <assemblyIdentity version="1.0.4.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.3</Version>
-    <FileVersion>1.0.3.0</FileVersion>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <Version>1.0.4</Version>
+    <FileVersion>1.0.4.0</FileVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -249,7 +249,7 @@ public sealed class XamlContractTests
         var footer = document.Descendants(Presentation + "TextBlock")
             .Single(element => element.Attribute("Text")?.Value?.StartsWith(
                 "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.3", footer.Attribute("Text")?.Value);
+        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.4", footer.Attribute("Text")?.Value);
     }
 
     [Fact]


### PR DESCRIPTION
Publish the stable application as 1.0.4 with a simpler release surface: one versioned installer and one installer archive. Version metadata, release notes, issue templates, and the release workflow move together; application behavior is unchanged from 1.0.3.