### PR TITLE
Fix Native HUD speed smoothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.0.6 - 2026-09-02
+
+### Fixed
+
+- Fixed the speed-smoothing control being ignored by Native HUD layouts.
+
 ## 1.0.5 - 2026-09-02
 
 ### Added

--- a/Wisp-1.0.6-release-notes.md
+++ b/Wisp-1.0.6-release-notes.md
@@ -1,0 +1,17 @@
+# Wisp 1.0.6
+
+Wisp 1.0.6 is a focused hotfix for the speed-smoothing control.
+
+## Fixed
+
+- Speed smoothing now works in Native Digital and Native Analogue HUD layouts.
+- The existing response curve and 1.5 MPH live-speed deviation limit remain unchanged.
+
+## Install
+
+Download `Wisp-Setup-1.0.6.exe`, or download and extract
+`Wisp-Setup-1.0.6.zip`. The installer is self-contained, installs for the
+current Windows user, and does not require a separate .NET runtime.
+
+The installer is not code-signed, so Windows may show an unknown-publisher
+warning. Verify the SHA-256 file supplied with the release before running it.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.5"
+#define MyAppVersion "1.0.6"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -1502,9 +1502,7 @@ public sealed class AppController : IAsyncDisposable
     internal static double ResolveSpeedSmoothing(
         HudLayoutMode layoutMode,
         double configuredSmoothing) =>
-        layoutMode == HudLayoutMode.Native
-            ? 0
-            : Math.Clamp(configuredSmoothing, 0, 1);
+        Math.Clamp(configuredSmoothing, 0, 1);
 
     internal static (NativeGameplayVisibility Visibility, bool Fresh) EvaluateNativeGameplayVisibility(
         NativeHudSnapshot snapshot,

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1654,7 +1654,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.5" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.6" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.5</Version>
-    <FileVersion>1.0.5.0</FileVersion>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <Version>1.0.6</Version>
+    <FileVersion>1.0.6.0</FileVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.5.0" name="Wisp.App" />
+  <assemblyIdentity version="1.0.6.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.5</Version>
-    <FileVersion>1.0.5.0</FileVersion>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <Version>1.0.6</Version>
+    <FileVersion>1.0.6.0</FileVersion>
+    <AssemblyVersion>1.0.6.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/AppControllerLifecycleTests.cs
+++ b/tests/Wisp.App.Tests/AppControllerLifecycleTests.cs
@@ -10,10 +10,10 @@ public sealed class AppControllerLifecycleTests
 {
     [Theory]
     [InlineData(HudLayoutMode.Native, 0, 0)]
-    [InlineData(HudLayoutMode.Native, 1, 0)]
+    [InlineData(HudLayoutMode.Native, 1, 1)]
     [InlineData(HudLayoutMode.Minimal, 0.35, 0.35)]
     [InlineData(HudLayoutMode.Combined, 2, 1)]
-    public void NativeSpeedAlwaysUsesTheLiveUnsmoothenedWheelValue(
+    public void SpeedSmoothingIsAppliedAndClampedForEveryLayout(
         HudLayoutMode layoutMode,
         double configuredSmoothing,
         double expected)

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -261,7 +261,7 @@ public sealed class XamlContractTests
         var footer = document.Descendants(Presentation + "TextBlock")
             .Single(element => element.Attribute("Text")?.Value?.StartsWith(
                 "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.5", footer.Attribute("Text")?.Value);
+        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.6", footer.Attribute("Text")?.Value);
     }
 
     [Fact]


### PR DESCRIPTION
Focused hotfix: enables the existing speed-smoothing curve in Native Digital and Native Analogue layouts, retains the existing response curve and 1.5 MPH limit, and bumps Wisp to 1.0.6. Focused regression: 4 passed. Repository policy validation: passed.