### PR TITLE
Fix background HUD update throttling

### DIFF
--- a/.github/scripts/Test-InstallerLifecycle.ps1
+++ b/.github/scripts/Test-InstallerLifecycle.ps1
@@ -81,6 +81,7 @@ function Invoke-CheckedProcess {
     $process = Start-Process -FilePath $Path -ArgumentList $Arguments -PassThru
     try {
         if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            Write-Warning "$Label exceeded its $TimeoutSeconds-second timeout; terminating its process tree."
             $process.Kill($true)
             if (-not $process.WaitForExit(10000)) {
                 Write-Warning "$Label did not terminate after it was stopped."
@@ -141,6 +142,7 @@ function Assert-RegisteredInstallation {
 function Assert-FirstRunSetupLaunch {
     param([string]$ApplicationPath)
 
+    Write-Output 'First-run Wisp Setup launch started.'
     $process = Start-Process -FilePath $ApplicationPath -PassThru
     try {
         $deadline = [DateTime]::UtcNow.AddSeconds(30)
@@ -162,15 +164,18 @@ function Assert-FirstRunSetupLaunch {
             throw 'The installed application did not show Wisp Setup before the deadline.'
         }
 
+        Write-Output 'First-run Wisp Setup window detected.'
         if (-not $process.CloseMainWindow()) {
             throw 'The Wisp Setup window did not accept a bounded close request.'
         }
+        Write-Output 'First-run Wisp Setup close requested.'
         if (-not $process.WaitForExit(10000)) {
             throw 'The installed application did not exit after its setup window closed.'
         }
         if ($process.ExitCode -ne 0) {
             throw "The installed application returned exit code $($process.ExitCode) after closing Wisp Setup."
         }
+        Write-Output 'First-run Wisp Setup launch completed.'
     }
     finally {
         if (-not $process.HasExited) {
@@ -276,8 +281,10 @@ try {
 }
 finally {
     if ($ownsCanaryState) {
+        Write-Output 'Installer lifecycle cleanup started.'
         Remove-CanaryPath $uninstallKey 'uninstall registration'
         Remove-CanaryPath $canaryRoot 'installation directory'
         Remove-CanaryPath $stateDirectory 'local-state directory'
+        Write-Output 'Installer lifecycle cleanup completed.'
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
         run: ./installer/Build-Installer.ps1 -InnoCompiler (Resolve-Path .\work\innosetup\ISCC.exe).Path
 
       - name: Test installer lifecycle
+        timeout-minutes: 5
         shell: pwsh
         run: |
           $project = [xml](Get-Content -LiteralPath .\src\Wisp.App\Wisp.App.csproj -Raw)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Notable changes to Wisp are recorded here.
 
 - Decoupled live HUD telemetry delivery from WPF presentation callbacks so background compositor throttling cannot stall Wisp's HUD state.
 - Smoothed and rate-limited the dashboard horsepower readout so rapidly changing power telemetry remains readable without altering raw power data.
+- Fixed native tachometer source discovery across race/menu transitions so stale unrelated local-player HUD sources cannot invalidate the active car's tachometer state.
 - Refreshed gallery image identities so browsers do not reuse stale 1.0.5 screenshots.
 
 ## 1.0.6 - 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.0.7 - 2026-09-03
+
+### Fixed
+
+- Decoupled live HUD telemetry delivery from WPF presentation callbacks so background compositor throttling cannot stall Wisp's HUD state.
+- Refreshed gallery image identities so browsers do not reuse stale 1.0.5 screenshots.
+
 ## 1.0.6 - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to Wisp are recorded here.
 ### Fixed
 
 - Decoupled live HUD telemetry delivery from WPF presentation callbacks so background compositor throttling cannot stall Wisp's HUD state.
+- Smoothed and rate-limited the dashboard horsepower readout so rapidly changing power telemetry remains readable without altering raw power data.
 - Refreshed gallery image identities so browsers do not reuse stale 1.0.5 screenshots.
 
 ## 1.0.6 - 2026-09-02

--- a/Wisp-1.0.7-release-notes.md
+++ b/Wisp-1.0.7-release-notes.md
@@ -5,6 +5,7 @@ Wisp 1.0.7 is a focused hotfix for HUD responsiveness and stale gallery images.
 ## Fixed
 
 - Live telemetry delivery no longer depends on WPF's presentation callback. This prevents system-specific background compositor throttling from reducing Wisp's HUD update rate.
+- Smoothed and rate-limited the dashboard horsepower readout so rapidly changing power telemetry remains readable without altering the underlying telemetry.
 - Gallery screenshots now use new image identities so browsers load the current captures instead of cached copies.
 
 ## Install

--- a/Wisp-1.0.7-release-notes.md
+++ b/Wisp-1.0.7-release-notes.md
@@ -1,0 +1,17 @@
+# Wisp 1.0.7
+
+Wisp 1.0.7 is a focused hotfix for HUD responsiveness and stale gallery images.
+
+## Fixed
+
+- Live telemetry delivery no longer depends on WPF's presentation callback. This prevents system-specific background compositor throttling from reducing Wisp's HUD update rate.
+- Gallery screenshots now use new image identities so browsers load the current captures instead of cached copies.
+
+## Install
+
+Download `Wisp-Setup-1.0.7.exe`, or download and extract
+`Wisp-Setup-1.0.7.zip`. The installer is self-contained, installs for the
+current Windows user, and does not require a separate .NET runtime.
+
+The installer is not code-signed, so Windows may show an unknown-publisher
+warning. Verify the SHA-256 file supplied with the release before running it.

--- a/Wisp-1.0.7-release-notes.md
+++ b/Wisp-1.0.7-release-notes.md
@@ -1,11 +1,12 @@
 # Wisp 1.0.7
 
-Wisp 1.0.7 is a focused hotfix for HUD responsiveness and stale gallery images.
+Wisp 1.0.7 is a focused hotfix for HUD reliability, responsiveness, and stale gallery images.
 
 ## Fixed
 
 - Live telemetry delivery no longer depends on WPF's presentation callback. This prevents system-specific background compositor throttling from reducing Wisp's HUD update rate.
 - Smoothed and rate-limited the dashboard horsepower readout so rapidly changing power telemetry remains readable without altering the underlying telemetry.
+- Fixed native tachometer source discovery during race and menu transitions so unrelated stale FH6 HUD sources cannot blank the Digital tachometer or Analogue tachometer material.
 - Gallery screenshots now use new image identities so browsers load the current captures instead of cached copies.
 
 ## Install

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.6"
+#define MyAppVersion "1.0.7"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -1124,11 +1124,10 @@ public sealed class AppController : IAsyncDisposable
 
     private void OnPacketAvailable(object? sender, EventArgs eventArgs)
     {
-        // A visible HUD consumes the newest packet on CompositionTarget.Rendering.
-        // Packet callbacks only wake the dispatcher to make initial race-on
-        // activation immediate; menus and hidden foreground states use the timer.
+        // Keep live telemetry independent from WPF's presentation cadence. Some
+        // systems throttle CompositionTarget.Rendering while Wisp is in the
+        // background, but packet delivery must still advance the HUD promptly.
         if (_disposed || _runtimeSuspended || Settings.RequiresSetup || _dispatcher.HasShutdownStarted ||
-            Volatile.Read(ref _wasDrivingConnected) ||
             _receiver.Latest is not { IsRaceOn: true } ||
             Interlocked.Exchange(ref _activationDispatchPending, 1) != 0)
         {
@@ -1137,7 +1136,7 @@ public sealed class AppController : IAsyncDisposable
 
         try
         {
-            _dispatcher.BeginInvoke(DispatcherPriority.Background, ProcessPendingActivation);
+            _dispatcher.BeginInvoke(DispatcherPriority.Render, ProcessPendingActivation);
         }
         catch (InvalidOperationException)
         {
@@ -1193,12 +1192,6 @@ public sealed class AppController : IAsyncDisposable
             }
         }
 
-        if (!hasNewPacket)
-        {
-            return;
-        }
-
-        ProcessUiUpdate(processLatestPacket: true);
     }
 
     private void OnUiTimer(object? sender, EventArgs eventArgs)
@@ -1210,7 +1203,7 @@ public sealed class AppController : IAsyncDisposable
                 _ = CheckNativeCompatibilityUpdatesAsync();
             }
 
-            ProcessUiUpdate(processLatestPacket: !_compositionRenderingAttached);
+            ProcessUiUpdate(processLatestPacket: true);
         }
     }
 

--- a/src/Wisp.App/DashboardPowerDisplayModel.cs
+++ b/src/Wisp.App/DashboardPowerDisplayModel.cs
@@ -1,0 +1,96 @@
+using System.Globalization;
+
+namespace Wisp.App;
+
+internal sealed class DashboardPowerDisplayModel
+{
+    private const double WattsPerHorsepower = 745.69987158227022;
+    private const double SmoothingTimeConstantMilliseconds = 250d;
+    private const int PublishIntervalMilliseconds = 125;
+    private const int MaximumContinuousSampleGapMilliseconds = 2_000;
+
+    private bool _initialized;
+    private int _carOrdinal;
+    private uint _lastSampleTimestamp;
+    private uint _lastPublishedTimestamp;
+    private double _smoothedHorsepower;
+    private int _displayHorsepower;
+
+    internal string Observe(
+        int carOrdinal,
+        uint gameTimestampMilliseconds,
+        double powerWatts)
+    {
+        if (carOrdinal <= 0 || !double.IsFinite(powerWatts))
+        {
+            Reset();
+            return "—";
+        }
+
+        var horsepower = powerWatts / WattsPerHorsepower;
+        if (!_initialized || _carOrdinal != carOrdinal)
+        {
+            return Initialize(carOrdinal, gameTimestampMilliseconds, horsepower);
+        }
+
+        var sampleElapsedMilliseconds =
+            unchecked((int)(gameTimestampMilliseconds - _lastSampleTimestamp));
+        if (sampleElapsedMilliseconds < 0 ||
+            sampleElapsedMilliseconds > MaximumContinuousSampleGapMilliseconds)
+        {
+            return Initialize(carOrdinal, gameTimestampMilliseconds, horsepower);
+        }
+
+        if (sampleElapsedMilliseconds > 0)
+        {
+            var alpha = 1d - Math.Exp(
+                -sampleElapsedMilliseconds / SmoothingTimeConstantMilliseconds);
+            _smoothedHorsepower +=
+                (horsepower - _smoothedHorsepower) * alpha;
+            _lastSampleTimestamp = gameTimestampMilliseconds;
+        }
+
+        var publishElapsedMilliseconds =
+            unchecked((int)(gameTimestampMilliseconds - _lastPublishedTimestamp));
+        if (publishElapsedMilliseconds >= PublishIntervalMilliseconds)
+        {
+            _displayHorsepower = RoundHorsepower(_smoothedHorsepower);
+            _lastPublishedTimestamp = gameTimestampMilliseconds;
+        }
+
+        return Format(_displayHorsepower);
+    }
+
+    internal void Reset()
+    {
+        _initialized = false;
+        _carOrdinal = 0;
+        _lastSampleTimestamp = 0;
+        _lastPublishedTimestamp = 0;
+        _smoothedHorsepower = 0;
+        _displayHorsepower = 0;
+    }
+
+    private string Initialize(
+        int carOrdinal,
+        uint gameTimestampMilliseconds,
+        double horsepower)
+    {
+        _initialized = true;
+        _carOrdinal = carOrdinal;
+        _lastSampleTimestamp = gameTimestampMilliseconds;
+        _lastPublishedTimestamp = gameTimestampMilliseconds;
+        _smoothedHorsepower = horsepower;
+        _displayHorsepower = RoundHorsepower(horsepower);
+        return Format(_displayHorsepower);
+    }
+
+    private static int RoundHorsepower(double horsepower) =>
+        (int)Math.Clamp(
+            Math.Round(horsepower, MidpointRounding.AwayFromZero),
+            int.MinValue,
+            int.MaxValue);
+
+    private static string Format(int horsepower) =>
+        $"{horsepower.ToString("+0;-0;0", CultureInfo.InvariantCulture)} HP";
+}

--- a/src/Wisp.App/DiagnosticsViewModel.cs
+++ b/src/Wisp.App/DiagnosticsViewModel.cs
@@ -9,7 +9,7 @@ namespace Wisp.App;
 
 public sealed class DiagnosticsViewModel : INotifyPropertyChanged
 {
-    private const double WattsPerHorsepower = 745.69987158227022;
+    private readonly DashboardPowerDisplayModel _dashboardPowerDisplayModel = new();
     private readonly GForceDisplayModel _gForceDisplayModel = new();
     private readonly BoostDisplayModel _boostDisplayModel = new();
     private readonly TireTemperatureDisplayModel _tireTemperatureDisplayModel = new();
@@ -89,6 +89,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     private bool _tractionCueEnabled;
     private bool _isTractionCueActive;
     private bool _canRelearnCurrentTires;
+    private string _dashboardPower = "—";
     private string _applicationUpdateStatus = "Updates are checked only when requested.";
     private string _applicationUpdateAction = "Check for updates";
     private bool _canCheckApplicationUpdate = true;
@@ -194,9 +195,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
             };
         }
     }
-    public string DashboardPower => HasLiveTelemetry
-        ? $"{NativeGaugeFrame.PowerWatts / WattsPerHorsepower:+0.0;-0.0;0.0} HP"
-        : "—";
+    public string DashboardPower => HasLiveTelemetry ? _dashboardPower : "—";
     public string DashboardTorque => HasLiveTelemetry
         ? $"{NativeGaugeFrame.TorqueNm:+0;-0;0} Nm"
         : "—";
@@ -226,10 +225,17 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         {
             if (Set(ref _hasLiveTelemetry, value))
             {
+                if (!value)
+                {
+                    _dashboardPowerDisplayModel.Reset();
+                    _dashboardPower = "—";
+                }
+
                 OnPropertyChanged(nameof(IsPreviewLive));
                 OnPropertyChanged(nameof(NativePreviewFrame));
                 OnPropertyChanged(nameof(PreviewSpeed));
                 OnPropertyChanged(nameof(PreviewCaption));
+                OnPropertyChanged(nameof(DashboardPower));
                 NotifyDashboardFrame();
             }
         }
@@ -257,12 +263,29 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         ? TireTemperatureDisplay
         : HudPreviewSample.TireTemperature;
 
+    private void UpdateDashboardPower(VehicleState state)
+    {
+        var next = _dashboardPowerDisplayModel.Observe(
+            state.CarOrdinal,
+            state.GameTimestampMilliseconds,
+            state.PowerWatts);
+        if (string.Equals(_dashboardPower, next, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _dashboardPower = next;
+        if (HasLiveTelemetry)
+        {
+            OnPropertyChanged(nameof(DashboardPower));
+        }
+    }
+
     private void NotifyDashboardFrame()
     {
         OnPropertyChanged(nameof(DashboardSpeed));
         OnPropertyChanged(nameof(DashboardSpeedUnit));
         OnPropertyChanged(nameof(DashboardGear));
-        OnPropertyChanged(nameof(DashboardPower));
         OnPropertyChanged(nameof(DashboardTorque));
         OnPropertyChanged(nameof(DashboardVehicleType));
     }
@@ -499,6 +522,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         TireTemperatureDisplay = _tireTemperatureDisplayModel.Calculate(
             state.CarOrdinal,
             state.TireTemperatureFahrenheit);
+        UpdateDashboardPower(state);
         var nextNativeGaugeFrame = new NativeGaugeFrame(
             speed.IsAvailable,
             displayedSpeed,

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1654,7 +1654,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.6" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.7" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/NativeHudMemoryResolver.cs
+++ b/src/Wisp.App/NativeHudMemoryResolver.cs
@@ -102,13 +102,48 @@ public sealed class NativeHudMemoryResolver
             return Unavailable(NativeAssistProviderStatus.InvalidSourceVector, generation, carOrdinal);
         }
 
-        var matches = new List<(ulong Source, ulong Provider)>();
+        var localPlayerCandidates = new List<(ulong Source, ulong Provider)>();
         foreach (var source in sources)
         {
             if (TryGetLocalPlayerProvider(memory, moduleBase, source, out var provider))
             {
-                matches.Add((source, provider));
+                localPlayerCandidates.Add((source, provider));
             }
+        }
+
+        if (localPlayerCandidates.Count == 0)
+        {
+            return Unavailable(NativeAssistProviderStatus.PlayerNotUnique, generation, carOrdinal);
+        }
+
+        // FH6 can briefly retain more than one local-player HUD source across
+        // menu/race transitions. Disambiguate those sources using the live Data
+        // Out vehicle identity before deciding that the player is ambiguous.
+        var matches = new List<(ulong Source, ulong Provider)>();
+        var failureStatus = NativeAssistProviderStatus.TelemetryMismatch;
+        foreach (var candidate in localPlayerCandidates)
+        {
+            if (TryMatchTelemetryIdentity(
+                    memory,
+                    candidate.Source,
+                    candidate.Provider,
+                    carOrdinal,
+                    currentEngineRpm,
+                    maximumEngineRpm,
+                    out var candidateFailure))
+            {
+                matches.Add(candidate);
+            }
+            else if (candidateFailure == NativeAssistProviderStatus.ReadFailure ||
+                     failureStatus == NativeAssistProviderStatus.TelemetryMismatch)
+            {
+                failureStatus = candidateFailure;
+            }
+        }
+
+        if (matches.Count == 0)
+        {
+            return Unavailable(failureStatus, generation, carOrdinal);
         }
 
         if (matches.Count != 1)
@@ -313,6 +348,45 @@ public sealed class NativeHudMemoryResolver
                memory.TryReadByte(provider + LocalPlayerFlagOffset, out var localPlayer) &&
                memory.TryReadByte(provider + LocalPlayerProviderFlagOffset, out var localProvider) &&
                localPlayer == 1 && localProvider == 1;
+    }
+
+    private bool TryMatchTelemetryIdentity(
+        IReadOnlyProcessMemory memory,
+        ulong source,
+        ulong provider,
+        int carOrdinal,
+        float currentEngineRpm,
+        float maximumEngineRpm,
+        out NativeAssistProviderStatus failureStatus)
+    {
+        failureStatus = NativeAssistProviderStatus.ReadFailure;
+        if (!memory.TryReadUInt32(source + SourceCarOrdinalOffset, out var sourceCarOrdinal) ||
+            !memory.TryReadSingle(provider + ProviderRpmOffset, out var angularVelocity) ||
+            !memory.TryReadSingle(
+                provider + ProviderTachometerMaximumAngularVelocityOffset,
+                out var tachometerMaximumAngularVelocity))
+        {
+            return false;
+        }
+
+        failureStatus = NativeAssistProviderStatus.TelemetryMismatch;
+        if (sourceCarOrdinal != (uint)carOrdinal ||
+            !ProviderRpmMatches(angularVelocity, currentEngineRpm, maximumEngineRpm))
+        {
+            return false;
+        }
+
+        if (!TryValidateMaximum(
+                tachometerMaximumAngularVelocity,
+                maximumEngineRpm,
+                out _,
+                out failureStatus))
+        {
+            return false;
+        }
+
+        failureStatus = NativeAssistProviderStatus.Ready;
+        return true;
     }
 
     private NativeHudSnapshot ResolveValidatedProvider(

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.6</Version>
-    <FileVersion>1.0.6.0</FileVersion>
-    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <Version>1.0.7</Version>
+    <FileVersion>1.0.7.0</FileVersion>
+    <AssemblyVersion>1.0.7.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.6.0" name="Wisp.App" />
+  <assemblyIdentity version="1.0.7.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.6</Version>
-    <FileVersion>1.0.6.0</FileVersion>
-    <AssemblyVersion>1.0.6.0</AssemblyVersion>
+    <Version>1.0.7</Version>
+    <FileVersion>1.0.7.0</FileVersion>
+    <AssemblyVersion>1.0.7.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/DashboardPowerDisplayModelTests.cs
+++ b/tests/Wisp.App.Tests/DashboardPowerDisplayModelTests.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class DashboardPowerDisplayModelTests
+{
+    private const double WattsPerHorsepower = 745.69987158227022;
+
+    [Theory]
+    [InlineData(113, "+113 HP")]
+    [InlineData(-113, "-113 HP")]
+    [InlineData(0, "0 HP")]
+    public void FirstSamplePublishesImmediatelyAsWholeHorsepower(
+        double horsepower,
+        string expected)
+    {
+        var model = new DashboardPowerDisplayModel();
+
+        var display = model.Observe(1, 1_000, horsepower * WattsPerHorsepower);
+
+        Assert.Equal(expected, display);
+    }
+
+    [Fact]
+    public void RapidSamplesAreSmoothedAndRateLimited()
+    {
+        var model = new DashboardPowerDisplayModel();
+
+        Assert.Equal(
+            "+100 HP",
+            model.Observe(1, 1_000, 100 * WattsPerHorsepower));
+
+        Assert.Equal(
+            "+100 HP",
+            model.Observe(1, 1_050, 1_000 * WattsPerHorsepower));
+
+        Assert.Equal(
+            "+454 HP",
+            model.Observe(1, 1_125, 1_000 * WattsPerHorsepower));
+    }
+
+    [Fact]
+    public void NewCarAndExplicitResetPublishTheNewValueImmediately()
+    {
+        var model = new DashboardPowerDisplayModel();
+
+        _ = model.Observe(1, 1_000, 100 * WattsPerHorsepower);
+        _ = model.Observe(1, 1_125, 1_000 * WattsPerHorsepower);
+
+        Assert.Equal(
+            "+250 HP",
+            model.Observe(2, 1_130, 250 * WattsPerHorsepower));
+
+        model.Reset();
+
+        Assert.Equal(
+            "-100 HP",
+            model.Observe(2, 1_131, -100 * WattsPerHorsepower));
+    }
+}

--- a/tests/Wisp.App.Tests/DiagnosticsViewModelTests.cs
+++ b/tests/Wisp.App.Tests/DiagnosticsViewModelTests.cs
@@ -76,9 +76,9 @@ public sealed class DiagnosticsViewModelTests
     }
 
     [Theory]
-    [InlineData(84_500, 310.25, "+113.3 HP", "+310 Nm")]
-    [InlineData(-84_500, -310.25, "-113.3 HP", "-310 Nm")]
-    [InlineData(0, 0, "0.0 HP", "0 Nm")]
+    [InlineData(84_500, 310.25, "+113 HP", "+310 Nm")]
+    [InlineData(-84_500, -310.25, "-113 HP", "-310 Nm")]
+    [InlineData(0, 0, "0 HP", "0 Nm")]
     public void DashboardPowerAndTorqueRemainSignedAndUseDisplayUnits(
         double powerWatts,
         double torqueNm,

--- a/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
@@ -185,7 +185,7 @@ public sealed class NativeHudMemoryResolverTests
     }
 
     [Fact]
-    public void NonUniqueLocalPlayerFailsClosed()
+    public void UnrelatedLocalPlayerSourceDoesNotInvalidateMatchingTelemetrySource()
     {
         var memory = ValidMemory();
         const ulong source2 = 0x0000000310000000;
@@ -194,6 +194,28 @@ public sealed class NativeHudMemoryResolverTests
         memory.SetUInt64(Module + NativeHudBuildContract.SourceVectorRva + 16, SourceList + 16);
         memory.SetUInt64(SourceList + 8, source2);
         ConfigureSource(memory, source2, provider2, 999);
+        ConfigureProvider(memory, provider2, absOn: true, tcrOn: true, stmOn: true, lcOn: true);
+
+        var result = new NativeHudMemoryResolver().Resolve(
+            memory, Module, 314, 4_000, 8_000, 1, forceSourceAudit: true);
+
+        Assert.True(result.Available);
+        Assert.Equal(NativeAssistProviderStatus.Ready, result.Status);
+        Assert.Equal(314, result.CarOrdinal);
+        Assert.Equal(6_500, result.ExactRedline.Rpm, 2);
+        Assert.Equal(8_000, result.TachometerMaximumRpm, 2);
+    }
+
+    [Fact]
+    public void MultipleTelemetryMatchingLocalPlayerSourcesStillFailClosed()
+    {
+        var memory = ValidMemory();
+        const ulong source2 = 0x0000000310000000;
+        const ulong provider2 = 0x0000000420000000;
+        memory.SetUInt64(Module + NativeHudBuildContract.SourceVectorRva + 8, SourceList + 16);
+        memory.SetUInt64(Module + NativeHudBuildContract.SourceVectorRva + 16, SourceList + 16);
+        memory.SetUInt64(SourceList + 8, source2);
+        ConfigureSource(memory, source2, provider2, 314);
         ConfigureProvider(memory, provider2, absOn: true, tcrOn: true, stmOn: true, lcOn: true);
 
         var result = new NativeHudMemoryResolver().Resolve(

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -261,7 +261,7 @@ public sealed class XamlContractTests
         var footer = document.Descendants(Presentation + "TextBlock")
             .Single(element => element.Attribute("Text")?.Value?.StartsWith(
                 "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.6", footer.Attribute("Text")?.Value);
+        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.7", footer.Attribute("Text")?.Value);
     }
 
     [Fact]
@@ -772,21 +772,29 @@ public sealed class XamlContractTests
     }
 
     [Fact]
-    public void VisibleHudPublishesNativeGaugeOnlyWhenTheUdpObjectIsUnchanged()
+    public void VisibleHudConsumesTelemetryIndependentlyFromWpfPresentation()
     {
         var source = File.ReadAllText(Path.Combine(AppSourceDirectory(), "AppController.cs"));
 
         Assert.Contains("CompositionTarget.Rendering += OnCompositionRendering", source, StringComparison.Ordinal);
         Assert.Contains("_displayFrameRateCounter.Observe(currentRendering.RenderingTime)", source, StringComparison.Ordinal);
-        Assert.Contains("var latest = _receiver.Latest;", source, StringComparison.Ordinal);
-        Assert.Contains("var hasNewPacket = !ReferenceEquals(latest, _lastProcessedState);", source, StringComparison.Ordinal);
-        Assert.Contains("ProcessUiUpdate(processLatestPacket: !_compositionRenderingAttached)", source, StringComparison.Ordinal);
-        var nativeRequest = source.IndexOf("_nativeHudProcessService.RequestNativeGaugeSample();", StringComparison.Ordinal);
-        var unchangedPacketBranch = source.IndexOf("if (!hasNewPacket)", nativeRequest, StringComparison.Ordinal);
-        var nativePublish = source.IndexOf("PublishNativeHudSnapshot(latest);", StringComparison.Ordinal);
-        var unchangedPacketExit = source.IndexOf("if (!hasNewPacket)", unchangedPacketBranch + 1, StringComparison.Ordinal);
-        Assert.True(nativeRequest >= 0 && nativeRequest < unchangedPacketBranch);
-        Assert.True(unchangedPacketBranch < nativePublish && nativePublish < unchangedPacketExit);
+        Assert.Contains("_dispatcher.BeginInvoke(DispatcherPriority.Render, ProcessPendingActivation)", source,
+            StringComparison.Ordinal);
+        Assert.Contains("ProcessUiUpdate(processLatestPacket: true)", source, StringComparison.Ordinal);
+
+        var packetStart = source.IndexOf("private void OnPacketAvailable", StringComparison.Ordinal);
+        var packetEnd = source.IndexOf("private void ProcessPendingActivation", packetStart, StringComparison.Ordinal);
+        Assert.True(packetStart >= 0 && packetEnd > packetStart);
+        var packetHandler = source[packetStart..packetEnd];
+        Assert.DoesNotContain("_wasDrivingConnected", packetHandler, StringComparison.Ordinal);
+        var renderStart = source.IndexOf("private void OnCompositionRendering", StringComparison.Ordinal);
+        var renderEnd = source.IndexOf("private void OnUiTimer", renderStart, StringComparison.Ordinal);
+        Assert.True(renderStart >= 0 && renderEnd > renderStart);
+        var renderHandler = source[renderStart..renderEnd];
+        Assert.DoesNotContain("ProcessUiUpdate", renderHandler, StringComparison.Ordinal);
+        Assert.Contains("_nativeHudProcessService.RequestNativeGaugeSample();", renderHandler,
+            StringComparison.Ordinal);
+        Assert.Contains("PublishNativeHudSnapshot(latest);", renderHandler, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- decouple live telemetry consumption from WPF presentation callbacks
- retain WPF rendering for final frame presentation and native gauge sampling
- bump the focused hotfix release to 1.0.7

Closes #30