### PR TITLE
Wisp 1.0.11: correct build author attribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Views2k <292889387+Views2k@users.noreply.github.com> Wisp Test Build <wisp-test@localhost>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.0.11 - 2026-09-04
+
+### Maintenance
+
+- Mapped the temporary build-author alias to Views2k for repository tools that support author aliases.
+- Updated the application and installer version to 1.0.11. Application behavior is unchanged from 1.0.10.
+
 ## 1.0.10 - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 ## New in 1.0.10
 
+Current download: [1.0.11](https://github.com/Views2k/Wisp/releases/tag/v1.0.11),
+a maintenance release correcting a repository author alias. It retains the
+features and behavior described below.
+
 **Save your HUD setups, choose your own colors, and track more of each drive.**
 Version 1.0.10 brings the following additions and fixes since 1.0.8.
 

--- a/Wisp-1.0.11-release-notes.md
+++ b/Wisp-1.0.11-release-notes.md
@@ -1,0 +1,11 @@
+# Wisp 1.0.11
+
+A small maintenance release that corrects the repository's temporary build-author
+alias. Application behavior is unchanged from 1.0.10.
+
+- Maps the build-author alias to Views2k in repository tools that support author aliases.
+- Updates the application and installer version to 1.0.11.
+- Retains all 1.0.10 features, settings, HUD profiles, and telemetry behavior.
+
+Update from Extras using **Check for updates**, or download the installer below.
+Wisp shows this summary before asking you to confirm the download.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.10"
+#define MyAppVersion "1.0.11"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1841,7 +1841,7 @@
                                         <StackPanel>
                                             <TextBlock Text="VERSION HISTORY" Style="{StaticResource EyebrowTextStyle}" />
                                             <TextBlock Text="What changed in Wisp" Style="{StaticResource SectionTitleStyle}" Margin="0,4,0,0" />
-                                            <TextBlock Text="Feature updates, hotfixes, and important refinements from every documented public release. The current 1.0.10 entry summarizes this release."
+                                            <TextBlock Text="Feature updates, hotfixes, and important refinements from every documented public release. The current 1.0.11 entry summarizes this release."
                                                        Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap"
                                                        LineHeight="19" Margin="0,7,0,0" />
                                         </StackPanel>
@@ -2028,7 +2028,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.10" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.11" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,22 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.0.11",
+            "September 4, 2026",
+            "MAINTENANCE",
+            "Corrects the repository's build-author alias. Application behavior is unchanged from 1.0.10.",
+            true,
+            [
+                Group("Maintenance",
+                    "Maps the temporary build-author identity to Views2k in repository tools that support author aliases.",
+                    "Updates the application and installer version to 1.0.11. All 1.0.10 features, settings, and telemetry behavior are retained.")
+            ]),
+        new(
             "1.0.10",
             "September 4, 2026",
             "FEATURE UPDATE",
             "A quality-of-life update focused on clearer live information, easier customization, safer updates, and practical diagnostics.",
-            true,
+            false,
             [
                 Group("Added",
                     "Live torque now appears on the Wheel Speed Ready card with the same restrained smoothing and typography as horsepower. Torque can be shown in Nm or lb-ft.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.10</Version>
-    <FileVersion>1.0.10.0</FileVersion>
-    <AssemblyVersion>1.0.10.0</AssemblyVersion>
+    <Version>1.0.11</Version>
+    <FileVersion>1.0.11.0</FileVersion>
+    <AssemblyVersion>1.0.11.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.10.0" name="Wisp.App" />
+  <assemblyIdentity version="1.0.11.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.10</Version>
-    <FileVersion>1.0.10.0</FileVersion>
-    <AssemblyVersion>1.0.10.0</AssemblyVersion>
+    <Version>1.0.11</Version>
+    <FileVersion>1.0.11.0</FileVersion>
+    <AssemblyVersion>1.0.11.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));
@@ -20,11 +20,11 @@ public sealed class ReleaseNotesCatalogTests
     }
 
     [Fact]
-    public void CurrentReleaseDocumentsTheMajorQualityOfLifeWorkAndFixes()
+    public void QualityOfLifeReleaseDocumentsTheMajorWorkAndFixes()
     {
         var text = string.Join(
             ' ',
-            ReleaseNotesCatalog.Entries[0].Groups.SelectMany(group => group.Items));
+            ReleaseNotesCatalog.Entries.Single(entry => entry.Version == "1.0.10").Groups.SelectMany(group => group.Items));
 
         foreach (var expected in new[]
                  {

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -220,7 +220,7 @@ public sealed class XamlContractTests
         var footer = document.Descendants(Presentation + "TextBlock")
             .Single(element => element.Attribute("Text")?.Value?.StartsWith(
                 "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.10", footer.Attribute("Text")?.Value);
+        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.11", footer.Attribute("Text")?.Value);
     }
 
     [Fact]


### PR DESCRIPTION
Corrects the temporary build-author alias with a repository mailmap and advances Wisp to 1.0.11. The new commit uses Views2k's author identity and contains no additional co-author trailer.

Application behavior is unchanged from 1.0.10. Version fields, in-app release notes, and the release description are updated so 1.0.10 users can receive this maintenance release through the existing update flow.

Repository policy, consistent version fields, diff checks, and the author mapping passed locally. Required CI validates the packaged installer before merge. The 1.0.10 release and its tag remain intact; the mailmap does not erase its original commit message.
