### PR TITLE
Wisp 1.0.12: diagnostics and race HUD recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.0.12 - 2026-09-04
+
+### Improved
+
+- Local debug reports correlate telemetry reception and processing, dispatcher delay, native-data freshness, composition callbacks, focus transitions, and Wisp CPU/memory usage. Background collection continues when the UI stalls.
+- Diagnostic summaries include observation times, supporting measurements, the likely affected component, uncertainty, and a next step. Menus, hidden overlays, and ordinary disconnection are not treated as rendering faults. Collection remains local, opt-in, and bounded.
+
+### Fixed
+
+- Recover native race providers whose secondary local-provider flag is cleared, while retaining validated contracts and a unique live car/RPM match.
+- Remove the outer outline from the update confirmation dialog.
+
 ## 1.0.11 - 2026-09-04
 
 ### Maintenance

--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
-## New in 1.0.10
+## New in 1.0.12
 
-Current download: [1.0.11](https://github.com/Views2k/Wisp/releases/tag/v1.0.11),
-a maintenance release correcting a repository author alias. It retains the
-features and behavior described below.
+[Download 1.0.12](https://github.com/Views2k/Wisp/releases/tag/v1.0.12) ·
+[Release notes](Wisp-1.0.12-release-notes.md)
+
+Local debug reports now separate telemetry, UI, native-data, and composition
+problems with timestamped evidence and practical next steps. Background collection
+continues during UI stalls and stays local, opt-in, and bounded. This release also
+improves native race-provider recovery after settings transitions and removes the
+update-confirmation outline. Reports state their limits; they do not measure game
+FPS or guarantee a Windows/GPU root cause.
+
+## The 1.0.10 quality-of-life update
 
 **Save your HUD setups, choose your own colors, and track more of each drive.**
 Version 1.0.10 brings the following additions and fixes since 1.0.8.

--- a/Wisp-1.0.12-release-notes.md
+++ b/Wisp-1.0.12-release-notes.md
@@ -1,0 +1,14 @@
+# Wisp 1.0.12
+
+## Better diagnostic reports
+
+Local debug logging now records telemetry reception and processing separately, dispatcher delays, native-data freshness and failures, composition gaps, focus transitions, and Wisp's CPU and memory usage. Collection runs in the background so a stalled UI does not stop the evidence trail.
+
+Exports include a readable summary: what was observed and when, which measurements support it, the likely affected component, what remains uncertain, and the next useful diagnostic step. Normal menus, hidden overlays, and ordinary telemetry disconnection are distinguished from rendering faults.
+
+Logging is still opt-in, local, limited to 24 hours per activation, and bounded in storage. You decide whether to attach the ZIP to an issue. Game FPS and GPU presentation latency are not measured, and a report cannot guarantee the exact cause of a Windows or driver problem.
+
+## Fixes
+
+- Native HUD provider recovery handles a cleared secondary local-provider flag during races and settings transitions. The provider must still pass the existing contract checks and uniquely match the live car, RPM, and maximum RPM.
+- Removed the outer outline from the update confirmation dialog. Release details and explicit download confirmation are unchanged.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.11"
+#define MyAppVersion "1.0.12"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -31,6 +31,7 @@ public sealed class AppController : IAsyncDisposable
     private readonly TransmissionDisplayFilter _transmissionDisplayFilter = new();
     private readonly DisplayFrameRateCounter _displayFrameRateCounter = new();
     private readonly DebugLogService _debugLog = new();
+    private readonly DebugHealthMonitor _debugHealthMonitor;
     private readonly ForzaFocusService _forzaFocusService = new();
     private readonly IStartupRegistrationService _startupRegistrationService;
     private readonly NativeHudProcessService _nativeHudProcessService = new();
@@ -153,6 +154,19 @@ public sealed class AppController : IAsyncDisposable
 
         ViewModel = new DiagnosticsViewModel(settings);
         _dispatcher = Dispatcher.CurrentDispatcher;
+        _debugHealthMonitor = new DebugHealthMonitor(
+            _receiver,
+            _nativeHudProcessService,
+            _debugLog,
+            () => Interlocked.Read(ref _debugProcessedPackets),
+            callback =>
+            {
+                if (!_dispatcher.HasShutdownStarted)
+                {
+                    _ = _dispatcher.BeginInvoke(DispatcherPriority.Background, callback);
+                }
+            },
+            OnDebugHealthLoggingExpired);
         _uiTimer = new DispatcherTimer(DispatcherPriority.Normal, _dispatcher)
         {
             Interval = IdleTimerInterval
@@ -167,6 +181,10 @@ public sealed class AppController : IAsyncDisposable
             _settingsSaveTimer.Stop();
             SaveSettings();
         };
+        if (_debugLog.IsEnabled && settings.DebugLoggingExpiresAtUtc is { } expiresAtUtc)
+        {
+            _debugHealthMonitor.Start(expiresAtUtc);
+        }
         UpdateCompatibilityDiagnostics();
     }
 
@@ -238,10 +256,12 @@ public sealed class AppController : IAsyncDisposable
             Settings.DebugLoggingEnabled = true;
             Settings.DebugLoggingExpiresAtUtc = expiresAtUtc;
             ResetDebugSampleBaselines(nowUtc);
+            _debugHealthMonitor.Start(expiresAtUtc);
             UpdateDebugLoggingStatus();
         }
         else
         {
+            await _debugHealthMonitor.StopAsync().ConfigureAwait(true);
             await _debugLog.DisableAsync().ConfigureAwait(true);
             Settings.DebugLoggingEnabled = false;
             Settings.DebugLoggingExpiresAtUtc = null;
@@ -1746,6 +1766,7 @@ public sealed class AppController : IAsyncDisposable
         }
         try
         {
+            await _debugHealthMonitor.DisposeAsync().ConfigureAwait(false);
             await _debugLog.DisposeAsync().ConfigureAwait(false);
         }
         catch
@@ -1813,6 +1834,7 @@ public sealed class AppController : IAsyncDisposable
         {
             _lastCompositionRenderingTime = currentRendering.RenderingTime;
             _renderRate = _displayFrameRateCounter.Observe(currentRendering.RenderingTime);
+            _debugHealthMonitor.RecordCompositionFrame(Stopwatch.GetTimestamp(), _renderRate);
         }
 
         var latest = _receiver.Latest;
@@ -1875,10 +1897,12 @@ public sealed class AppController : IAsyncDisposable
     {
         if (Settings.RequiresSetup)
         {
+            PublishDebugHealthContext();
             return;
         }
         if (_runtimeSuspended)
         {
+            PublishDebugHealthContext();
             return;
         }
 
@@ -1896,7 +1920,7 @@ public sealed class AppController : IAsyncDisposable
         if (hasNewPacket)
         {
             _lastProcessedState = latest;
-            _debugProcessedPackets++;
+            Interlocked.Increment(ref _debugProcessedPackets);
         }
 
         var refreshDiagnostics = now >= _nextDiagnosticsAtUtc;
@@ -2479,11 +2503,13 @@ public sealed class AppController : IAsyncDisposable
                 false,
                 Settings.OverlayOpacity,
                 hideImmediately: true);
+            PublishDebugHealthContext();
             return false;
         }
 
         if (!force && now < _nextVisibilityCheckAtUtc)
         {
+            PublishDebugHealthContext();
             return _overlayVisibleRequested;
         }
 
@@ -2640,7 +2666,33 @@ public sealed class AppController : IAsyncDisposable
 
         _lastForzaFullscreen = focus.IsFullscreen;
         SetCompositionRenderingEnabled(overlayVisible);
+        PublishDebugHealthContext();
         return overlayVisible;
+    }
+
+    private void PublishDebugHealthContext()
+    {
+        var latest = _receiver.Latest;
+        _debugHealthMonitor.PublishUiContext(new DebugHealthUiContext(
+            Stopwatch.GetTimestamp(),
+            _overlayVisibleRequested,
+            _nativeHudTelemetryActive && Settings.LayoutMode == HudLayoutMode.Native,
+            latest?.IsRaceOn ?? false,
+            latest?.CarOrdinal ?? 0,
+            latest?.GameTimestampMilliseconds ?? 0));
+    }
+
+    private void OnDebugHealthLoggingExpired()
+    {
+        if (_disposed || _debugLog.IsEnabled || !Settings.DebugLoggingEnabled)
+        {
+            return;
+        }
+
+        Settings.DebugLoggingEnabled = false;
+        Settings.DebugLoggingExpiresAtUtc = null;
+        ViewModel.UpdateDebugLogging(false, "Off — 24-hour logging period expired");
+        SaveSettings();
     }
 
     internal static bool ApplyManualOverlaySuppression(bool normalVisibility, bool manuallyHidden) =>

--- a/src/Wisp.App/DebugLogging/DebugDiagnosticReport.cs
+++ b/src/Wisp.App/DebugLogging/DebugDiagnosticReport.cs
@@ -1,0 +1,286 @@
+using System.Globalization;
+using System.Text;
+
+namespace Wisp.App.DebugLogging;
+
+internal static class DebugDiagnosticReport
+{
+    private const int MaximumIncidents = 100;
+    internal const int MaximumSummaryBytes = 64 * 1024;
+    private const int MaximumSessions = 32;
+
+    internal static string Build(IReadOnlyList<DebugHealthSample> samples, long droppedRecords = 0)
+    {
+        var text = new StringBuilder("Wisp diagnostic summary\n");
+        text.AppendLine("Times are UTC. Durations use a monotonic clock within each collection session.");
+        text.AppendLine("Measurements and focus transitions are sampled, normally once per second. Listed times are observation times; brief transitions may be missed and exact onset is uncertain.");
+        text.AppendLine("Findings narrow the affected component; they do not establish a Windows or GPU driver root cause.");
+        text.AppendLine("Game FPS and GPU presentation latency are not measured. Composition callbacks are Wisp callbacks, not displayed game frames.");
+        text.AppendLine($"Health samples retained: {samples.Count}");
+        var validSamples = samples.Where(sample => Nonnegative(sample.ElapsedMilliseconds) &&
+            Nonnegative(sample.CollectionGapMilliseconds)).ToArray();
+        if (validSamples.Length < 2)
+        {
+            var incompleteDropped = Math.Max(droppedRecords, samples.Select(sample => sample.DroppedRecords).DefaultIfEmpty(0).Max());
+            var incompleteFailures = samples.Select(sample => sample.CollectorFailures).DefaultIfEmpty(0).Max();
+            text.AppendLine($"Coverage: {incompleteDropped} dropped records; {incompleteFailures} collector failures.");
+            text.AppendLine("Insufficient evidence: record the issue with local debug logging enabled for several seconds, then export again.");
+            return text.ToString();
+        }
+
+        var incidents = 0;
+        var omitted = 0;
+        var transitions = 0;
+        var collectorGaps = 0;
+        var normalSamples = 0;
+        var allSessions = validSamples.GroupBy(sample => sample.SessionId).ToArray();
+        var sessions = allSessions.TakeLast(MaximumSessions);
+        if (allSessions.Length > MaximumSessions)
+        {
+            text.AppendLine($"Summary limited to the latest {MaximumSessions} retained sessions; older measurements remain in health.ndjson.");
+        }
+        var unknownMeasurements = validSamples.Count(sample => !Nonnegative(sample.PacketAgeMilliseconds) ||
+            !Nonnegative(sample.UiHeartbeatAgeMilliseconds) || !Nonnegative(sample.DispatcherDelayMilliseconds));
+        text.AppendLine($"Incomplete freshness measurements: {unknownMeasurements} samples. Unknown or invalid timing is not evidence of a healthy component.");
+        if (validSamples.Length < samples.Count)
+        {
+            text.AppendLine($"{samples.Count - validSamples.Length} samples had invalid session timing and were excluded from classification.");
+        }
+        foreach (var session in sessions)
+        {
+            var ordered = session.OrderBy(sample => sample.ElapsedMilliseconds).ToArray();
+            text.AppendLine($"\nCollection session: {ordered[0].TimestampUtc:O} to {ordered[^1].TimestampUtc:O}");
+            var rejectedIntervals = new HashSet<DebugHealthSample>();
+            var nativeFailureIntervals = new HashSet<DebugHealthSample>();
+            var arrivalStoppedIntervals = new HashSet<DebugHealthSample>();
+            DebugHealthSample? lastDrivingArrival = null;
+            foreach (var current in ordered)
+            {
+                if (Active(current) && FreshIncoming(current) && current.UiContextFresh && current.Focus == DebugFocus.Game)
+                {
+                    lastDrivingArrival = current;
+                }
+                else if (lastDrivingArrival is { } baseline && current.RaceOn && current.ListenerRunning && !current.ListenerError &&
+                         current.Focus == DebugFocus.Game && current.UiContextFresh && UiResponsive(current) &&
+                         current.IncomingHz == 0 && current.ReceivedDatagrams == baseline.ReceivedDatagrams &&
+                         current.PacketAgeMilliseconds is > 2000 && Nonnegative(current.PacketAgeMilliseconds) &&
+                         current.ElapsedMilliseconds - baseline.ElapsedMilliseconds <= 10_000)
+                {
+                    arrivalStoppedIntervals.Add(current);
+                }
+            }
+            for (var index = 1; index < ordered.Length; index++)
+            {
+                var current = ordered[index];
+                var previous = ordered[index - 1];
+                var rejectedDelta = current.RejectedPackets - previous.RejectedPackets;
+                var acceptedDelta = current.AcceptedPackets - previous.AcceptedPackets;
+                if (Nonnegative(current.IncomingHz) && current.IncomingHz > 0 && rejectedDelta > 0 && acceptedDelta >= 0 && rejectedDelta >= acceptedDelta)
+                {
+                    rejectedIntervals.Add(current);
+                }
+                if (current.NativeReadFailures > previous.NativeReadFailures)
+                {
+                    nativeFailureIntervals.Add(current);
+                }
+            }
+            var rules = Rules(rejectedIntervals, nativeFailureIntervals, arrivalStoppedIntervals);
+            foreach (var rule in rules)
+            {
+                DebugHealthSample? start = null;
+                DebugHealthSample? previous = null;
+                var count = 0;
+                foreach (var sample in ordered)
+                {
+                    // Missing collection intervals cannot demonstrate a continuous fault.
+                    var continuous = previous is null ||
+                        (sample.ElapsedMilliseconds > previous.ElapsedMilliseconds &&
+                         sample.ElapsedMilliseconds - previous.ElapsedMilliseconds <= 2000 &&
+                         sample.CollectionGapMilliseconds <= 2000);
+                    if (!rule.Matches(sample) || !continuous)
+                    {
+                        Finish();
+                        start = null;
+                        count = 0;
+                    }
+                    if (rule.Matches(sample))
+                    {
+                        start ??= sample;
+                        count++;
+                    }
+                    previous = sample;
+                }
+                Finish();
+
+                void Finish()
+                {
+                    if (start is null || previous is null || count < 2 ||
+                        previous.ElapsedMilliseconds - start.ElapsedMilliseconds < 500)
+                    {
+                        return;
+                    }
+                    if (incidents >= MaximumIncidents)
+                    {
+                        omitted++;
+                        return;
+                    }
+                    incidents++;
+                    text.AppendLine($"\n{rule.Name}");
+                    if (rule.ObservationOnly)
+                    {
+                        text.AppendLine("Classification: observed interruption; not a confirmed fault.");
+                    }
+                    text.AppendLine($"When: {start.TimestampUtc:O} to {previous.TimestampUtc:O}; " +
+                        $"elapsed {Number(start.ElapsedMilliseconds)}–{Number(previous.ElapsedMilliseconds)} ms; {count} consecutive samples.");
+                    text.AppendLine($"Evidence (first sample): {Evidence(start)}");
+                    text.AppendLine($"Evidence (last sample): {Evidence(previous)}");
+                    text.AppendLine($"Likely affected component: {rule.Component}");
+                    text.AppendLine($"Uncertainty: {rule.Uncertainty}");
+                    text.AppendLine($"Next useful step: {rule.NextStep}");
+                }
+            }
+
+            DebugHealthSample? last = null;
+            foreach (var sample in ordered)
+            {
+                if (!sample.RaceOn || !sample.GameTimestampAdvancing || !sample.OverlayExpectedVisible)
+                {
+                    normalSamples++;
+                }
+                if (sample.CollectionGapMilliseconds > 2000 ||
+                    (last is not null && sample.ElapsedMilliseconds - last.ElapsedMilliseconds > 2000))
+                {
+                    collectorGaps++;
+                    if (collectorGaps <= 10)
+                    {
+                        text.AppendLine($"\nCollector coverage gap at {sample.TimestampUtc:O}, elapsed {Number(sample.ElapsedMilliseconds)} ms: " +
+                            $"collection interval {Number(sample.CollectionGapMilliseconds)} ms. Events inside this gap cannot be classified reliably. " +
+                            "Next useful step: repeat a short capture and compare process CPU, collection failures, and system sleep/resume timing.");
+                    }
+                }
+                if (last is not null && sample.Focus != last.Focus)
+                {
+                    transitions++;
+                    if (transitions <= 30)
+                    {
+                        text.AppendLine($"Focus transition at {sample.TimestampUtc:O}, elapsed {Number(sample.ElapsedMilliseconds)} ms: {last.Focus} -> {sample.Focus}.");
+                    }
+                }
+                last = sample;
+            }
+        }
+
+        var dropped = Math.Max(droppedRecords, samples.Max(sample => sample.DroppedRecords));
+        var failures = samples.Max(sample => sample.CollectorFailures);
+        text.AppendLine($"\nCoverage: {collectorGaps} collector gaps; {dropped} dropped records; {failures} collector failures; {transitions} focus transitions.");
+        text.AppendLine($"Context (summarized sessions): {normalSamples} samples were outside advancing gameplay or had no expected visible overlay. Hidden overlays, menus, and ordinary telemetry disconnection alone are not rendering faults.");
+        if (dropped > 0 || failures > 0)
+        {
+            text.AppendLine("Evidence is incomplete because collection or storage lost records. Absence of a finding does not rule out a fault. Next useful step: repeat a shorter capture and inspect local storage availability and Wisp resource usage.");
+        }
+        if (incidents == 0)
+        {
+            text.AppendLine("No sustained classified fault detected in the retained samples. This does not prove smooth rendering. Next useful step: capture the symptom while driving, note its UTC time and focus state, then compare it with these measurements.");
+        }
+        if (omitted > 0)
+        {
+            text.AppendLine($"{omitted} additional incident windows omitted from this bounded summary; full retained measurements are in health.ndjson.");
+        }
+        text.AppendLine("Retention is bounded; this export may contain only the recent part of a session. Packet counters can reset between sessions. Drained datagrams are intentional newest-packet coalescing, not packet loss; a lower processed rate alone is not a fault. Raw measurements remain in health.ndjson.");
+        return Bound(text.ToString());
+    }
+
+    private static bool Active(DebugHealthSample sample) => sample.RaceOn && sample.GameTimestampAdvancing;
+    private static bool FreshIncoming(DebugHealthSample sample) => sample.ListenerRunning &&
+        Nonnegative(sample.IncomingHz) && sample.IncomingHz > 0 &&
+        Nonnegative(sample.PacketAgeMilliseconds) && sample.PacketAgeMilliseconds is <= 500;
+    private static bool UiDelayed(DebugHealthSample sample) =>
+        (sample.DispatcherProbePending && Nonnegative(sample.DispatcherDelayMilliseconds) && sample.DispatcherDelayMilliseconds is >= 500) ||
+        (Active(sample) && sample.ProcessedHz == 0 && Nonnegative(sample.UiHeartbeatAgeMilliseconds) && sample.UiHeartbeatAgeMilliseconds is >= 2000);
+    private static bool UiResponsive(DebugHealthSample sample) => sample.UiContextFresh &&
+        Nonnegative(sample.UiHeartbeatAgeMilliseconds) && sample.UiHeartbeatAgeMilliseconds is <= 2000 &&
+        Nonnegative(sample.DispatcherDelayMilliseconds) && sample.DispatcherDelayMilliseconds is < 500 && !UiDelayed(sample);
+    private static bool Nonnegative(double? value) => value is { } number && double.IsFinite(number) && number >= 0;
+
+    private static Rule[] Rules(HashSet<DebugHealthSample> rejectedIntervals, HashSet<DebugHealthSample> nativeFailureIntervals,
+        HashSet<DebugHealthSample> arrivalStoppedIntervals) =>
+    [
+        new("UI processing delay", "Wisp UI dispatcher / telemetry consumption",
+            sample => FreshIncoming(sample) && UiDelayed(sample),
+            "Incoming data stayed fresh while the UI heartbeat or dispatcher probe was delayed. The blocking operation is not identified; this does not establish a GPU fault.",
+            "Reproduce with the same page and focus state. Compare dispatcher delay, incoming versus processed rates, and resource samples during this interval."),
+        new("Telemetry reception interruption", "Telemetry receiver / upstream Data Out connection",
+            sample => sample.ListenerError,
+            "The local listener reported an error. Its exact underlying cause is not captured; remote network and game FPS are not measured.",
+            "Check the listener state and whether Data Out is enabled, then capture an uninterrupted driving interval. Compare received, accepted, and processed counters."),
+        new("Telemetry arrival stopped (cause uncertain)", "Upstream sender or telemetry reception; insufficient evidence to separate them",
+            arrivalStoppedIntervals.Contains,
+            "Fresh driving packets were previously observed, then received counters stopped while the UI remained responsive. Menus, cutscenes, a normal disconnect, and an upstream interruption can produce this pattern. This is not proof of a receiver fault.",
+            "Confirm whether driving continued during this interval. If so, compare the game's Data Out configuration and listener state; repeat an uninterrupted driving capture.", true),
+        new("Telemetry rejected packets", "Telemetry parsing / incoming packet format",
+            rejectedIntervals.Contains,
+            "Rejected packet counters increased at least as fast as accepted counters in consecutive intervals. Unsupported or malformed input is possible; rejected payloads are not retained.",
+            "Verify the Data Out destination and supported packet format. Compare received and rejected counter changes during a fresh capture."),
+        new("Native HUD data unavailable or stale", "Native HUD data provider",
+            sample => Active(sample) && sample.UiContextFresh && sample.NativeExpected && FreshIncoming(sample) &&
+                UiResponsive(sample) && (!sample.NativeAvailable ||
+                    (Nonnegative(sample.NativeAgeMilliseconds) && sample.NativeAgeMilliseconds is > 2000) ||
+                    (Nonnegative(sample.NativeVisibilityAgeMilliseconds) && sample.NativeVisibilityAgeMilliseconds is > 2000) ||
+                    sample.NativeStatus is "ReadFailure" or "InvalidSourceVector" or "InvalidProvider" || nativeFailureIntervals.Contains(sample)),
+            "Telemetry remains fresh but required native data is unavailable or old. A compatibility failure, process access restriction, or provider delay needs further evidence.",
+            "Compare native status and data ages with game focus transitions. Export another capture after checking the compatibility status in Diagnostics."),
+        new("Composition callback gap", "Wisp composition / presentation scheduling",
+            sample => Active(sample) && sample.UiContextFresh && sample.OverlayExpectedVisible && FreshIncoming(sample) &&
+                UiResponsive(sample) && ((Nonnegative(sample.CompositionAgeMilliseconds) && sample.CompositionAgeMilliseconds is >= 250) ||
+                    (Nonnegative(sample.CompositionMaximumGapMilliseconds) && sample.CompositionMaximumGapMilliseconds >= 250)),
+            "Wisp composition callbacks were delayed while the UI heartbeat and incoming telemetry stayed responsive. Callbacks do not measure GPU presentation or prove a driver problem.",
+            "Reproduce while the overlay is visible. Correlate focus transitions and resource pressure; if callbacks alone do not explain the symptom, collect a focused Windows presentation trace."),
+        new("Resource pressure correlation", "Wisp process resource usage",
+            sample => (Nonnegative(sample.WispCpuPercent) && sample.WispCpuPercent is >= 80 and <= 100) || sample.WorkingSetBytes >= 2L * 1024 * 1024 * 1024,
+            "High Wisp CPU or working set is a correlation, not proof of system-wide resource pressure or the cause of another incident. Other processes and GPU utilization are not collected.",
+            "Compare this interval with UI and composition findings. If repeatable, capture a short Wisp CPU or allocation profile; avoid changing drivers based on this report alone.")
+    ];
+
+    private static string Evidence(DebugHealthSample sample) =>
+        $"incoming {Number(sample.IncomingHz)} Hz; processed {Number(sample.ProcessedHz)} Hz; packet age {Number(sample.PacketAgeMilliseconds)} ms; " +
+        $"received/drained/accepted/rejected/processed {sample.ReceivedDatagrams}/{sample.DrainedDatagrams}/{sample.AcceptedPackets}/{sample.RejectedPackets}/{sample.ProcessedPackets}; " +
+        $"UI heartbeat age {Number(sample.UiHeartbeatAgeMilliseconds)} ms; dispatcher delay {Number(sample.DispatcherDelayMilliseconds)} ms; " +
+        $"composition age/max gap {Number(sample.CompositionAgeMilliseconds)}/{Number(sample.CompositionMaximumGapMilliseconds)} ms; " +
+        $"native available {sample.NativeAvailable}, read failures {sample.NativeReadFailures}, age {Number(sample.NativeAgeMilliseconds)} ms, visibility age {Number(sample.NativeVisibilityAgeMilliseconds)} ms; " +
+        $"Wisp CPU {Number(sample.WispCpuPercent)}%, working set {sample.WorkingSetBytes / (1024 * 1024)} MiB, managed heap {sample.ManagedHeapBytes / (1024 * 1024)} MiB, Gen2 collections {sample.Gen2Collections}; focus {sample.Focus}.";
+
+    private static string Number(double? value) => value is { } number && double.IsFinite(number)
+        ? number.ToString("0.0", CultureInfo.InvariantCulture) : "unknown";
+
+    private static string Bound(string value)
+    {
+        if (Encoding.UTF8.GetByteCount(value) <= MaximumSummaryBytes)
+        {
+            return value;
+        }
+        const string suffix = "\nSummary output limit reached. Measurements remain in health.ndjson; use a shorter capture for complete incident details.\n";
+        var budget = MaximumSummaryBytes - Encoding.UTF8.GetByteCount(suffix);
+        var low = 0;
+        var high = value.Length;
+        while (low < high)
+        {
+            var midpoint = (low + high + 1) / 2;
+            if (Encoding.UTF8.GetByteCount(value.AsSpan(0, midpoint)) <= budget)
+            {
+                low = midpoint;
+            }
+            else
+            {
+                high = midpoint - 1;
+            }
+        }
+        if (low > 0 && char.IsHighSurrogate(value[low - 1]))
+        {
+            low--;
+        }
+        return value[..low] + suffix;
+    }
+
+    private sealed record Rule(string Name, string Component, Func<DebugHealthSample, bool> Matches,
+        string Uncertainty, string NextStep, bool ObservationOnly = false);
+}

--- a/src/Wisp.App/DebugLogging/DebugHealthMonitor.cs
+++ b/src/Wisp.App/DebugLogging/DebugHealthMonitor.cs
@@ -1,0 +1,424 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Wisp.Core;
+using Wisp.Telemetry;
+
+namespace Wisp.App.DebugLogging;
+
+internal sealed record DebugHealthUiContext(
+    long HeartbeatTimestamp,
+    bool OverlayExpectedVisible,
+    bool NativeExpected,
+    bool RaceOn,
+    int CarOrdinal,
+    uint GameTimestampMilliseconds);
+
+internal sealed class DebugHealthMonitor : IAsyncDisposable
+{
+    private static readonly TimeSpan DefaultSampleInterval = TimeSpan.FromSeconds(1);
+    private static readonly long UiFreshnessTicks = Stopwatch.Frequency * 2;
+
+    private readonly TelemetryUdpReceiver _receiver;
+    private readonly NativeHudProcessService _nativeHud;
+    private readonly DebugLogService _log;
+    private readonly Func<long> _processedPackets;
+    private readonly Action<Action> _postDispatcher;
+    private readonly Action _loggingExpired;
+    private readonly Func<DateTimeOffset> _utcNow;
+    private readonly Func<long> _timestamp;
+    private readonly TimeSpan _sampleInterval;
+    private readonly Func<DebugFocus> _focus;
+    private readonly object _lifecycleGate = new();
+    private DebugHealthUiContext? _uiContext;
+    private CancellationTokenSource? _cancellation;
+    private Task? _runTask;
+    private int _generation;
+    private int _probePending;
+    private long _probePostedTimestamp;
+    private long _dispatcherDelayBits;
+    private int _hasDispatcherDelay;
+    private long _compositionTimestamp;
+    private long _previousCompositionTimestamp;
+    private long _compositionFrames;
+    private long _compositionMaximumGapBits;
+    private long _collectorFailures;
+    private long _expiresAtUtcTicks;
+    private int _expirationNotificationPending;
+    private bool _restartRequested;
+    private int _disposed;
+    private readonly ForzaFocusService _focusService = new();
+
+    internal DebugHealthMonitor(
+        TelemetryUdpReceiver receiver,
+        NativeHudProcessService nativeHud,
+        DebugLogService log,
+        Func<long> processedPackets,
+        Action<Action> postDispatcher,
+        Action loggingExpired,
+        Func<DateTimeOffset>? utcNow = null,
+        Func<long>? timestamp = null,
+        TimeSpan? sampleInterval = null,
+        Func<DebugFocus>? focus = null)
+    {
+        _receiver = receiver;
+        _nativeHud = nativeHud;
+        _log = log;
+        _processedPackets = processedPackets;
+        _postDispatcher = postDispatcher;
+        _loggingExpired = loggingExpired;
+        _utcNow = utcNow ?? (() => DateTimeOffset.UtcNow);
+        _timestamp = timestamp ?? Stopwatch.GetTimestamp;
+        _sampleInterval = sampleInterval ?? DefaultSampleInterval;
+        _focus = focus ?? GetFocus;
+        if (_sampleInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sampleInterval));
+        }
+    }
+
+    internal void PublishUiContext(DebugHealthUiContext context) =>
+        Volatile.Write(ref _uiContext, context);
+
+    internal void RecordCompositionFrame(long timestamp, double _)
+    {
+        Interlocked.Exchange(ref _compositionTimestamp, timestamp);
+        Interlocked.Increment(ref _compositionFrames);
+        var previous = Interlocked.Exchange(ref _previousCompositionTimestamp, timestamp);
+        if (previous > 0 && timestamp >= previous)
+        {
+            UpdateMaximum(ref _compositionMaximumGapBits, ToMilliseconds(timestamp - previous));
+        }
+    }
+
+    internal void Start(DateTimeOffset expiresAtUtc)
+    {
+        Interlocked.Exchange(ref _expiresAtUtcTicks, expiresAtUtc.UtcDateTime.Ticks);
+        CancellationTokenSource? completedCancellation = null;
+        lock (_lifecycleGate)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+            if (_runTask is { IsCompleted: false })
+            {
+                _restartRequested |= _cancellation?.IsCancellationRequested == true;
+                return;
+            }
+
+            completedCancellation = _cancellation;
+            var cancellation = new CancellationTokenSource();
+            Interlocked.Exchange(ref _hasDispatcherDelay, 0);
+            Interlocked.Exchange(ref _previousCompositionTimestamp, 0);
+            Interlocked.Exchange(ref _compositionMaximumGapBits, 0);
+            _cancellation = cancellation;
+            var generation = ++_generation;
+            var runTask = Task.Run(() => RunAsync(generation, cancellation.Token));
+            _runTask = runTask;
+            _ = runTask.ContinueWith(
+                _ => CompleteRun(runTask, cancellation),
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+        }
+        completedCancellation?.Dispose();
+    }
+
+    internal async Task StopAsync()
+    {
+        Task? runTask;
+        CancellationTokenSource? cancellation;
+        lock (_lifecycleGate)
+        {
+            ++_generation;
+            cancellation = _cancellation;
+            runTask = _runTask;
+            cancellation?.Cancel();
+        }
+
+        if (runTask is not null)
+        {
+            try
+            {
+                await runTask.WaitAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (TimeoutException)
+            {
+                return;
+            }
+            catch
+            {
+                Interlocked.Increment(ref _collectorFailures);
+            }
+        }
+        CompleteRun(runTask, cancellation);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            await StopAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunAsync(int generation, CancellationToken cancellationToken)
+    {
+        var sessionId = Guid.NewGuid().ToString("N");
+        var startedAt = _timestamp();
+        var previousCollection = startedAt;
+        var previousRateAt = startedAt;
+        var previousReceived = _receiver.ReceivedDatagrams;
+        var previousProcessed = _processedPackets();
+        var previousCompositionFrames = Interlocked.Read(ref _compositionFrames);
+        var previousGameTimestamp = _receiver.Latest?.GameTimestampMilliseconds;
+        long? compositionExpectedSince = null;
+        TimeSpan? previousCpu = null;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var nowUtc = _utcNow();
+            if (nowUtc.UtcDateTime.Ticks >= Interlocked.Read(ref _expiresAtUtcTicks) || !_log.IsEnabled)
+            {
+                if (_log.ExpireIfNeeded(nowUtc))
+                {
+                    TryPostExpiration();
+                }
+                return;
+            }
+
+            var now = _timestamp();
+            try
+            {
+                var context = Volatile.Read(ref _uiContext);
+                var received = _receiver.ReceivedDatagrams;
+                var processed = _processedPackets();
+                var rateSeconds = Math.Max(ToMilliseconds(now - previousRateAt) / 1000d, 0.001);
+                var statistics = _receiver.GetStatistics(nowUtc);
+                var latest = _receiver.Latest;
+                var native = _nativeHud.SnapshotFor(latest?.CarOrdinal ?? context?.CarOrdinal ?? 0);
+                using var process = Process.GetCurrentProcess();
+                var cpu = process.TotalProcessorTime;
+                double? cpuPercent = previousCpu is { } oldCpu
+                    ? Math.Clamp((cpu - oldCpu).TotalMilliseconds / (rateSeconds * 1000d * Environment.ProcessorCount) * 100d, 0d, 100d)
+                    : null;
+                var heartbeatAge = AgeMilliseconds(now, context?.HeartbeatTimestamp ?? 0);
+                var uiContextFresh = heartbeatAge is { } age &&
+                                     age <= UiFreshnessTicks * 1000d / Stopwatch.Frequency;
+                compositionExpectedSince = context?.OverlayExpectedVisible == true && uiContextFresh
+                    ? compositionExpectedSince ?? now
+                    : null;
+                var gameTimestampAdvancing = latest is { IsRaceOn: true } &&
+                                             previousGameTimestamp is { } oldGameTimestamp &&
+                                             latest.GameTimestampMilliseconds != oldGameTimestamp;
+                var compositionTimestamp = Interlocked.Read(ref _compositionTimestamp);
+                var compositionFrames = Interlocked.Read(ref _compositionFrames);
+                var compositionAge = compositionExpectedSince is { } expectedSince &&
+                                     compositionTimestamp < expectedSince
+                    ? AgeMilliseconds(now, expectedSince)
+                    : AgeMilliseconds(now, compositionTimestamp);
+                var probePending = Volatile.Read(ref _probePending) != 0;
+                var dispatcherDelay = probePending
+                    ? AgeMilliseconds(now, Interlocked.Read(ref _probePostedTimestamp))
+                    : Volatile.Read(ref _hasDispatcherDelay) != 0
+                        ? BitConverter.Int64BitsToDouble(Interlocked.Read(ref _dispatcherDelayBits))
+                        : null;
+
+                _log.TryLogHealthSample(new DebugHealthSample
+                {
+                    TimestampUtc = nowUtc,
+                    SessionId = sessionId,
+                    ElapsedMilliseconds = ToMilliseconds(now - startedAt),
+                    CollectionGapMilliseconds = ToMilliseconds(now - previousCollection),
+                    ReceivedDatagrams = received,
+                    DrainedDatagrams = _receiver.DrainedDatagrams,
+                    AcceptedPackets = statistics.AcceptedPackets,
+                    RejectedPackets = statistics.RejectedPackets,
+                    ProcessedPackets = processed,
+                    IncomingHz = Math.Max(0, received - previousReceived) / rateSeconds,
+                    ProcessedHz = Math.Max(0, processed - previousProcessed) / rateSeconds,
+                    PacketAgeMilliseconds = AgeMilliseconds(now, latest?.ReceivedTimestamp ?? 0),
+                    ListenerRunning = _receiver.IsRunning,
+                    ListenerError = statistics.ListenerError is not null,
+                    RaceOn = latest?.IsRaceOn ?? false,
+                    GameTimestampAdvancing = gameTimestampAdvancing,
+                    Focus = _focus(),
+                    UiContextFresh = uiContextFresh,
+                    OverlayExpectedVisible = context?.OverlayExpectedVisible ?? false,
+                    NativeExpected = context?.NativeExpected ?? false,
+                    UiHeartbeatAgeMilliseconds = heartbeatAge,
+                    DispatcherDelayMilliseconds = dispatcherDelay,
+                    DispatcherProbePending = probePending,
+                    CompositionHz = Math.Max(0, compositionFrames - previousCompositionFrames) / rateSeconds,
+                    CompositionAgeMilliseconds = compositionAge,
+                    CompositionMaximumGapMilliseconds = BitConverter.Int64BitsToDouble(
+                        Interlocked.Exchange(ref _compositionMaximumGapBits, 0)),
+                    NativeAvailable = native.NativeGaugeObservedTimestamp > 0,
+                    NativeReadAttempts = _nativeHud.DiagnosticReadAttempts,
+                    NativeReadFailures = _nativeHud.DiagnosticReadFailures,
+                    NativeStatus = native.Status.ToString(),
+                    NativeAgeMilliseconds = AgeMilliseconds(now, native.NativeGaugeObservedTimestamp),
+                    NativeVisibilityAgeMilliseconds = AgeMilliseconds(now, native.VisibilityObservedTimestamp),
+                    GameplayVisibility = native.GameplayVisibility.ToString(),
+                    WispCpuPercent = cpuPercent,
+                    WorkingSetBytes = process.WorkingSet64,
+                    ManagedHeapBytes = GC.GetTotalMemory(false),
+                    Gen2Collections = GC.CollectionCount(2),
+                    DroppedRecords = _log.DroppedRecords,
+                    CollectorFailures = Interlocked.Read(ref _collectorFailures)
+                });
+
+                previousCollection = now;
+                previousRateAt = now;
+                previousReceived = received;
+                previousProcessed = processed;
+                previousCompositionFrames = compositionFrames;
+                previousGameTimestamp = latest?.GameTimestampMilliseconds;
+                previousCpu = cpu;
+            }
+            catch
+            {
+                Interlocked.Increment(ref _collectorFailures);
+            }
+
+            QueueDispatcherProbe(_timestamp(), generation);
+
+            await Task.Delay(_sampleInterval, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void QueueDispatcherProbe(long postedAt, int generation)
+    {
+        if (Interlocked.CompareExchange(ref _probePending, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            Interlocked.Exchange(ref _probePostedTimestamp, postedAt);
+            _postDispatcher(() =>
+            {
+                if (Volatile.Read(ref _generation) == generation)
+                {
+                    var delay = ToMilliseconds(_timestamp() - postedAt);
+                    Interlocked.Exchange(ref _dispatcherDelayBits, BitConverter.DoubleToInt64Bits(delay));
+                    Volatile.Write(ref _hasDispatcherDelay, 1);
+                }
+
+                Interlocked.Exchange(ref _probePostedTimestamp, 0);
+                Interlocked.Exchange(ref _probePending, 0);
+            });
+        }
+        catch
+        {
+            Interlocked.Exchange(ref _probePending, 0);
+            Interlocked.Increment(ref _collectorFailures);
+        }
+    }
+
+    private void TryPostExpiration()
+    {
+        if (Interlocked.CompareExchange(ref _expirationNotificationPending, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _postDispatcher(() =>
+            {
+                try
+                {
+                    _loggingExpired();
+                }
+                finally
+                {
+                    Interlocked.Exchange(ref _expirationNotificationPending, 0);
+                }
+            });
+        }
+        catch
+        {
+            Interlocked.Exchange(ref _expirationNotificationPending, 0);
+            Interlocked.Increment(ref _collectorFailures);
+        }
+    }
+
+    private void CompleteRun(Task? runTask, CancellationTokenSource? cancellation)
+    {
+        var disposeCancellation = false;
+        var restart = false;
+        lock (_lifecycleGate)
+        {
+            if (ReferenceEquals(_runTask, runTask))
+            {
+                _runTask = null;
+                _cancellation = null;
+                disposeCancellation = true;
+                restart = _restartRequested &&
+                          Volatile.Read(ref _disposed) == 0 &&
+                          _log.IsEnabled;
+                _restartRequested = false;
+            }
+        }
+        _ = runTask?.Exception;
+        if (disposeCancellation)
+        {
+            cancellation?.Dispose();
+        }
+        if (restart)
+        {
+            Start(new DateTimeOffset(Interlocked.Read(ref _expiresAtUtcTicks), TimeSpan.Zero));
+        }
+    }
+
+    private DebugFocus GetFocus()
+    {
+        var foreground = GetForegroundWindow();
+        if (foreground == IntPtr.Zero)
+        {
+            return DebugFocus.None;
+        }
+
+        _ = GetWindowThreadProcessId(foreground, out var processId);
+        if (processId == Environment.ProcessId)
+        {
+            return DebugFocus.Wisp;
+        }
+
+        return _focusService.GetState(_utcNow()).IsForzaForeground
+            ? DebugFocus.Game
+            : DebugFocus.Other;
+    }
+
+    private static double? AgeMilliseconds(long now, long observed) =>
+        observed > 0 && now >= observed ? ToMilliseconds(now - observed) : null;
+
+    private static double ToMilliseconds(long ticks) => ticks * 1000d / Stopwatch.Frequency;
+
+    private static void UpdateMaximum(ref long targetBits, double value)
+    {
+        while (true)
+        {
+            var currentBits = Interlocked.Read(ref targetBits);
+            if (BitConverter.Int64BitsToDouble(currentBits) >= value)
+            {
+                return;
+            }
+            if (Interlocked.CompareExchange(ref targetBits, BitConverter.DoubleToInt64Bits(value), currentBits) == currentBits)
+            {
+                return;
+            }
+        }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr windowHandle, out int processId);
+}

--- a/src/Wisp.App/DebugLogging/DebugHealthSample.cs
+++ b/src/Wisp.App/DebugLogging/DebugHealthSample.cs
@@ -1,0 +1,46 @@
+namespace Wisp.App.DebugLogging;
+
+internal enum DebugFocus { Unknown, Game, Wisp, Other, None }
+
+internal sealed record DebugHealthSample
+{
+    public DateTimeOffset TimestampUtc { get; init; }
+    public string SessionId { get; init; } = string.Empty;
+    public double ElapsedMilliseconds { get; init; }
+    public double CollectionGapMilliseconds { get; init; }
+    public long ReceivedDatagrams { get; init; }
+    public long DrainedDatagrams { get; init; }
+    public long AcceptedPackets { get; init; }
+    public long RejectedPackets { get; init; }
+    public long ProcessedPackets { get; init; }
+    public double IncomingHz { get; init; }
+    public double ProcessedHz { get; init; }
+    public double? PacketAgeMilliseconds { get; init; }
+    public bool ListenerRunning { get; init; }
+    public bool ListenerError { get; init; }
+    public bool RaceOn { get; init; }
+    public bool GameTimestampAdvancing { get; init; }
+    public DebugFocus Focus { get; init; }
+    public bool UiContextFresh { get; init; }
+    public bool OverlayExpectedVisible { get; init; }
+    public bool NativeExpected { get; init; }
+    public double? UiHeartbeatAgeMilliseconds { get; init; }
+    public double? DispatcherDelayMilliseconds { get; init; }
+    public bool DispatcherProbePending { get; init; }
+    public double CompositionHz { get; init; }
+    public double? CompositionAgeMilliseconds { get; init; }
+    public double CompositionMaximumGapMilliseconds { get; init; }
+    public bool NativeAvailable { get; init; }
+    public long NativeReadAttempts { get; init; }
+    public long NativeReadFailures { get; init; }
+    public string NativeStatus { get; init; } = "Unknown";
+    public double? NativeAgeMilliseconds { get; init; }
+    public double? NativeVisibilityAgeMilliseconds { get; init; }
+    public string GameplayVisibility { get; init; } = "Unknown";
+    public double? WispCpuPercent { get; init; }
+    public long WorkingSetBytes { get; init; }
+    public long ManagedHeapBytes { get; init; }
+    public int Gen2Collections { get; init; }
+    public long DroppedRecords { get; init; }
+    public long CollectorFailures { get; init; }
+}

--- a/src/Wisp.App/DebugLogging/DebugLogService.cs
+++ b/src/Wisp.App/DebugLogging/DebugLogService.cs
@@ -134,6 +134,7 @@ internal sealed class DebugLogService : IAsyncDisposable
     private readonly SemaphoreSlim _pendingDrained = new(0);
     private readonly CancellationTokenSource _lifetime = new();
     private readonly Task _writerTask;
+    private readonly object _stateGate = new();
     private DateTimeOffset? _expiresAtUtc;
     private int _enabled;
     private long _droppedRecords;
@@ -176,7 +177,10 @@ internal sealed class DebugLogService : IAsyncDisposable
     }
 
     public bool IsEnabled => Volatile.Read(ref _enabled) != 0;
-    public DateTimeOffset? ExpiresAtUtc => _expiresAtUtc;
+    public DateTimeOffset? ExpiresAtUtc
+    {
+        get { lock (_stateGate) { return _expiresAtUtc; } }
+    }
     public long DroppedRecords => Interlocked.Read(ref _droppedRecords);
     public bool HasLocalLogs => SafeSegmentFiles().Length > 0;
 
@@ -194,129 +198,162 @@ internal sealed class DebugLogService : IAsyncDisposable
         {
             Directory.CreateDirectory(_rootDirectory);
             PruneSegments(_utcNow());
-            _expiresAtUtc = expiresAtUtc;
-            Volatile.Write(ref _enabled, 1);
-            TryQueue("event", new DebugEvent(
-                _utcNow(),
-                DebugEventCode.LoggingEnabled,
-                DebugEventCategory.Lifecycle));
+            lock (_stateGate)
+            {
+                if (Volatile.Read(ref _disposed) != 0 || expiresAtUtc <= _utcNow())
+                {
+                    return false;
+                }
+                _expiresAtUtc = expiresAtUtc;
+                Volatile.Write(ref _enabled, 1);
+                TryQueue("event", new DebugEvent(
+                    _utcNow(),
+                    DebugEventCode.LoggingEnabled,
+                    DebugEventCategory.Lifecycle));
+            }
             return true;
         }
         catch (Exception exception) when (IsLocalStorageFailure(exception))
         {
-            _expiresAtUtc = null;
-            Volatile.Write(ref _enabled, 0);
+            lock (_stateGate)
+            {
+                _expiresAtUtc = null;
+                Volatile.Write(ref _enabled, 0);
+            }
             return false;
         }
     }
 
     public bool ExpireIfNeeded(DateTimeOffset nowUtc)
     {
-        if (!IsEnabled || _expiresAtUtc is not { } expiresAtUtc || nowUtc < expiresAtUtc)
+        lock (_stateGate)
         {
-            return false;
-        }
+            if (!IsEnabled || _expiresAtUtc is not { } expiresAtUtc || nowUtc < expiresAtUtc)
+            {
+                return false;
+            }
 
-        TryQueue("event", new DebugEvent(
-            nowUtc,
-            DebugEventCode.LoggingExpired,
-            DebugEventCategory.Lifecycle));
-        _expiresAtUtc = null;
-        Volatile.Write(ref _enabled, 0);
-        return true;
+            TryQueue("event", new DebugEvent(
+                nowUtc,
+                DebugEventCode.LoggingExpired,
+                DebugEventCategory.Lifecycle));
+            _expiresAtUtc = null;
+            Volatile.Write(ref _enabled, 0);
+            return true;
+        }
     }
 
     public async Task DisableAsync()
     {
-        if (!IsEnabled)
+        lock (_stateGate)
         {
-            _expiresAtUtc = null;
-            return;
-        }
+            if (!IsEnabled)
+            {
+                _expiresAtUtc = null;
+                return;
+            }
 
-        TryQueue("event", new DebugEvent(
-            _utcNow(),
-            DebugEventCode.LoggingDisabled,
-            DebugEventCategory.Lifecycle));
-        _expiresAtUtc = null;
-        Volatile.Write(ref _enabled, 0);
+            TryQueue("event", new DebugEvent(
+                _utcNow(),
+                DebugEventCode.LoggingDisabled,
+                DebugEventCategory.Lifecycle));
+            _expiresAtUtc = null;
+            Volatile.Write(ref _enabled, 0);
+        }
         await FlushAsync().ConfigureAwait(false);
     }
 
     public void TryLogSample(DebugTelemetrySample sample)
     {
-        if (IsEnabled && !ExpireIfNeeded(sample.TimestampUtc))
+        lock (_stateGate)
         {
-            TryQueue("sample", new
+            if (IsEnabled && !ExpireIfNeeded(sample.TimestampUtc))
             {
-                sample.TimestampUtc,
-                sample.TelemetryState,
-                sample.RaceOn,
-                sample.TelemetryProcessedHz,
-                sample.WispCompositionHz,
-                game_fps = (double?)null,
-                game_fps_status = "not_available_in_fh6_data_out",
-                sample.WispCpuPercent,
-                sample.WispWorkingSetBytes,
-                sample.ManagedHeapBytes,
-                sample.Gen0Collections,
-                sample.Gen1Collections,
-                sample.Gen2Collections,
-                sample.PacketAgeMilliseconds,
-                sample.AcceptedPackets,
-                sample.RejectedPackets,
-                sample.ListenerState,
-                sample.GameTimestampMilliseconds,
-                sample.GameTimestampAdvanced,
-                sample.GameTimestampStalled,
-                sample.CarOrdinal,
-                sample.Drivetrain,
-                sample.GroundSpeedMetersPerSecond,
-                sample.IndicatedSpeedAvailable,
-                sample.IndicatedSpeedMetersPerSecond,
-                sample.IndicatedSpeedDisplayValue,
-                sample.SpeedUnit,
-                sample.SpeedSource,
-                sample.WheelRotationRadiansPerSecond,
-                sample.TireSlipRatio,
-                sample.TrustedFrontRadiusMeters,
-                sample.TrustedRearRadiusMeters,
-                sample.ProvisionalFrontRadiusMeters,
-                sample.ProvisionalRearRadiusMeters,
-                sample.CalibrationConfidence,
-                sample.CalibrationAcceptedSamples,
-                sample.CalibrationTrusted,
-                sample.CalibrationState,
-                sample.EngineRpm,
-                sample.EngineMaximumRpm,
-                sample.Gear,
-                sample.PowerWatts,
-                sample.TorqueNm,
-                sample.BoostPressurePsi,
-                sample.TireTemperatureFahrenheit,
-                sample.LateralAccelerationMetersPerSecondSquared,
-                sample.LongitudinalAccelerationMetersPerSecondSquared,
-                sample.Steering,
-                sample.Accelerator,
-                sample.Brake,
-                sample.NativeProviderStatus,
-                sample.ExactRedlineStatus,
-                sample.NativeCapabilitiesAvailable,
-                sample.GameplayHudVisibility,
-                sample.GameplayHudVisibilityFresh,
-                sample.OverlayLayout,
-                sample.OverlayRequestedVisible,
-                sample.OverlayManuallyHidden,
-                sample.OverlayLocked
-            });
+                TryQueue("sample", new
+                {
+                    sample.TimestampUtc,
+                    sample.TelemetryState,
+                    sample.RaceOn,
+                    sample.TelemetryProcessedHz,
+                    sample.WispCompositionHz,
+                    game_fps = (double?)null,
+                    game_fps_status = "not_available_in_fh6_data_out",
+                    sample.WispCpuPercent,
+                    sample.WispWorkingSetBytes,
+                    sample.ManagedHeapBytes,
+                    sample.Gen0Collections,
+                    sample.Gen1Collections,
+                    sample.Gen2Collections,
+                    sample.PacketAgeMilliseconds,
+                    sample.AcceptedPackets,
+                    sample.RejectedPackets,
+                    sample.ListenerState,
+                    sample.GameTimestampMilliseconds,
+                    sample.GameTimestampAdvanced,
+                    sample.GameTimestampStalled,
+                    sample.CarOrdinal,
+                    sample.Drivetrain,
+                    sample.GroundSpeedMetersPerSecond,
+                    sample.IndicatedSpeedAvailable,
+                    sample.IndicatedSpeedMetersPerSecond,
+                    sample.IndicatedSpeedDisplayValue,
+                    sample.SpeedUnit,
+                    sample.SpeedSource,
+                    sample.WheelRotationRadiansPerSecond,
+                    sample.TireSlipRatio,
+                    sample.TrustedFrontRadiusMeters,
+                    sample.TrustedRearRadiusMeters,
+                    sample.ProvisionalFrontRadiusMeters,
+                    sample.ProvisionalRearRadiusMeters,
+                    sample.CalibrationConfidence,
+                    sample.CalibrationAcceptedSamples,
+                    sample.CalibrationTrusted,
+                    sample.CalibrationState,
+                    sample.EngineRpm,
+                    sample.EngineMaximumRpm,
+                    sample.Gear,
+                    sample.PowerWatts,
+                    sample.TorqueNm,
+                    sample.BoostPressurePsi,
+                    sample.TireTemperatureFahrenheit,
+                    sample.LateralAccelerationMetersPerSecondSquared,
+                    sample.LongitudinalAccelerationMetersPerSecondSquared,
+                    sample.Steering,
+                    sample.Accelerator,
+                    sample.Brake,
+                    sample.NativeProviderStatus,
+                    sample.ExactRedlineStatus,
+                    sample.NativeCapabilitiesAvailable,
+                    sample.GameplayHudVisibility,
+                    sample.GameplayHudVisibilityFresh,
+                    sample.OverlayLayout,
+                    sample.OverlayRequestedVisible,
+                    sample.OverlayManuallyHidden,
+                    sample.OverlayLocked
+                });
+            }
         }
     }
 
     public void TryLogEvent(DebugEvent debugEvent)
     {
-        if (IsEnabled && !ExpireIfNeeded(debugEvent.TimestampUtc))
+        lock (_stateGate)
         {
-            TryQueue("event", debugEvent);
+            if (IsEnabled && !ExpireIfNeeded(debugEvent.TimestampUtc))
+            {
+                TryQueue("event", debugEvent);
+            }
+        }
+    }
+
+    public void TryLogHealthSample(DebugHealthSample sample)
+    {
+        lock (_stateGate)
+        {
+            if (IsEnabled && !ExpireIfNeeded(sample.TimestampUtc))
+            {
+                TryQueue("health", sample);
+            }
         }
     }
 
@@ -343,11 +380,16 @@ internal sealed class DebugLogService : IAsyncDisposable
                 {
                     var samples = new List<string>();
                     var events = new List<string>();
+                    var health = new List<DebugHealthSample>();
+                    var omittedRecords = 0L;
                     foreach (var segment in SafeSegmentFiles())
                     {
                         foreach (var line in File.ReadLines(segment))
                         {
-                            TryCollectExportLine(line, samples, events);
+                            if (!TryCollectExportLine(line, samples, events, health))
+                            {
+                                omittedRecords++;
+                            }
                         }
                     }
 
@@ -355,13 +397,16 @@ internal sealed class DebugLogService : IAsyncDisposable
                     {
                         WriteEntry(archive, "samples.ndjson", samples);
                         WriteEntry(archive, "events.ndjson", events);
+                        WriteEntry(archive, "health.ndjson", health.Select(sample => JsonSerializer.Serialize(sample, JsonOptions)));
                         var manifest = new
                         {
-                            schema_version = 1,
+                            schema_version = 2,
                             created_at_utc = _utcNow(),
                             wisp_version = applicationVersion,
                             samples = samples.Count,
                             events = events.Count,
+                            health_samples = health.Count,
+                            omitted_records = omittedRecords,
                             dropped_records = DroppedRecords,
                             game_fps = (double?)null,
                             game_fps_status = "not_available_in_fh6_data_out",
@@ -373,7 +418,9 @@ internal sealed class DebugLogService : IAsyncDisposable
                             "summary.txt",
                             $"Wisp local debug export\nSamples: {samples.Count}\nEvents: {events.Count}\n" +
                             "Game FPS: not available in FH6 Data Out\n" +
-                            "This export contains only Wisp telemetry health metrics selected by the debug logging whitelist.\n");
+                            $"Unreadable or unsupported records omitted: {omittedRecords}. Missing records limit diagnostic coverage.\n" +
+                            "This export contains only Wisp telemetry health metrics selected by the debug logging whitelist.\n\n" +
+                            DebugDiagnosticReport.Build(health, DroppedRecords));
                     }
 
                     File.Move(temporaryPath, destination, overwrite: true);
@@ -430,7 +477,11 @@ internal sealed class DebugLogService : IAsyncDisposable
             return;
         }
 
-        Volatile.Write(ref _enabled, 0);
+        lock (_stateGate)
+        {
+            _expiresAtUtc = null;
+            Volatile.Write(ref _enabled, 0);
+        }
         _records.Writer.TryComplete();
         try
         {
@@ -590,7 +641,7 @@ internal sealed class DebugLogService : IAsyncDisposable
         }
     }
 
-    private static void TryCollectExportLine(string line, List<string> samples, List<string> events)
+    private static bool TryCollectExportLine(string line, List<string> samples, List<string> events, List<DebugHealthSample> health)
     {
         try
         {
@@ -601,16 +652,28 @@ internal sealed class DebugLogService : IAsyncDisposable
             if (kind == "sample")
             {
                 samples.Add(payload);
+                return true;
             }
             else if (kind == "event")
             {
                 events.Add(payload);
+                return true;
+            }
+            else if (kind == "health")
+            {
+                var sample = JsonSerializer.Deserialize<DebugHealthSample>(payload, JsonOptions);
+                if (sample is not null)
+                {
+                    health.Add(sample);
+                    return true;
+                }
             }
         }
         catch (Exception exception) when (exception is JsonException or InvalidOperationException or KeyNotFoundException)
         {
-            // A partial record is omitted from the user-created export.
+            // Partial records are counted without copying their contents into the export.
         }
+        return false;
     }
 
     private static void WriteEntry(ZipArchive archive, string name, IEnumerable<string> lines) =>

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1841,7 +1841,7 @@
                                         <StackPanel>
                                             <TextBlock Text="VERSION HISTORY" Style="{StaticResource EyebrowTextStyle}" />
                                             <TextBlock Text="What changed in Wisp" Style="{StaticResource SectionTitleStyle}" Margin="0,4,0,0" />
-                                            <TextBlock Text="Feature updates, hotfixes, and important refinements from every documented public release. The current 1.0.11 entry summarizes this release."
+                                            <TextBlock Text="Feature updates, hotfixes, and important refinements from every documented public release. The current 1.0.12 entry summarizes this release."
                                                        Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap"
                                                        LineHeight="19" Margin="0,7,0,0" />
                                         </StackPanel>
@@ -1977,8 +1977,7 @@
                   KeyDown="ApplicationUpdateConfirmation_KeyDown"
                   AutomationProperties.Name="Confirm Wisp update">
                 <Border Width="480" HorizontalAlignment="Center" VerticalAlignment="Center"
-                        Style="{StaticResource CardStyle}" BorderBrush="{DynamicResource AccentBrush}"
-                        BorderThickness="1.5" Padding="30">
+                        Style="{StaticResource CardStyle}" BorderThickness="0" Padding="30">
                     <StackPanel>
                         <Border Width="46" Height="46" CornerRadius="23"
                                 HorizontalAlignment="Left" Background="{DynamicResource RaisedBrush}"
@@ -2028,7 +2027,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.11" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.12" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/NativeHudMemoryResolver.cs
+++ b/src/Wisp.App/NativeHudMemoryResolver.cs
@@ -113,7 +113,21 @@ public sealed class NativeHudMemoryResolver
 
         if (localPlayerCandidates.Count == 0)
         {
-            return Unavailable(NativeAssistProviderStatus.PlayerNotUnique, generation, carOrdinal);
+            // Race providers can clear the secondary local-provider flag after
+            // menu navigation. Keep the verified contract and primary flag,
+            // then require a unique match to the live Data Out identity below.
+            foreach (var source in sources)
+            {
+                if (TryGetLocalPlayerProvider(memory, moduleBase, source, out var provider,
+                        allowUnmarkedProvider: true))
+                {
+                    localPlayerCandidates.Add((source, provider));
+                }
+            }
+            if (localPlayerCandidates.Count == 0)
+            {
+                return Unavailable(NativeAssistProviderStatus.PlayerNotUnique, generation, carOrdinal);
+            }
         }
 
         // FH6 can briefly retain more than one local-player HUD source across
@@ -338,7 +352,8 @@ public sealed class NativeHudMemoryResolver
         IReadOnlyProcessMemory memory,
         ulong moduleBase,
         ulong source,
-        out ulong provider)
+        out ulong provider,
+        bool allowUnmarkedProvider = false)
     {
         provider = 0;
         return IsPointer(source) && IsAddressRange(source, NativeHudCompatibilityPack.MaximumFieldBytes) &&
@@ -347,7 +362,7 @@ public sealed class NativeHudMemoryResolver
                HasExactProviderContract(memory, moduleBase, provider) &&
                memory.TryReadByte(provider + LocalPlayerFlagOffset, out var localPlayer) &&
                memory.TryReadByte(provider + LocalPlayerProviderFlagOffset, out var localProvider) &&
-               localPlayer == 1 && localProvider == 1;
+               localPlayer == 1 && (localProvider == 1 || allowUnmarkedProvider && localProvider == 0);
     }
 
     private bool TryMatchTelemetryIdentity(

--- a/src/Wisp.App/NativeHudProcessService.cs
+++ b/src/Wisp.App/NativeHudProcessService.cs
@@ -27,6 +27,8 @@ public sealed class NativeHudProcessService : IAsyncDisposable
     private long _snapshotCompatibilityGeneration = -1;
     private long _sessionEpoch;
     private long _generation;
+    private long _diagnosticReadAttempts;
+    private long _diagnosticReadFailures;
     private bool _fullResolvePending;
     private bool _disposed;
     private Task? _disposeTask;
@@ -59,6 +61,9 @@ public sealed class NativeHudProcessService : IAsyncDisposable
     }
 
     public string CompatibilityStatus => _memoryFactory.CompatibilityStatus;
+
+    internal long DiagnosticReadAttempts => Interlocked.Read(ref _diagnosticReadAttempts);
+    internal long DiagnosticReadFailures => Interlocked.Read(ref _diagnosticReadFailures);
 
     public NativeHudSnapshot SnapshotFor(int carOrdinal)
     {
@@ -254,6 +259,7 @@ public sealed class NativeHudProcessService : IAsyncDisposable
             }
 
             var memory = _memory;
+            Interlocked.Increment(ref _diagnosticReadAttempts);
             var generation = (ulong)Interlocked.Increment(ref _generation);
             var nowTimestamp = Stopwatch.GetTimestamp();
             var performFullResolve = fullResolveRequested ||
@@ -320,6 +326,12 @@ public sealed class NativeHudProcessService : IAsyncDisposable
             if (!TryPublish(epoch, compatibilityGeneration, result))
             {
                 continue;
+            }
+
+            if (result.Status is NativeAssistProviderStatus.ReadFailure or
+                NativeAssistProviderStatus.InvalidSourceVector or NativeAssistProviderStatus.InvalidProvider)
+            {
+                Interlocked.Increment(ref _diagnosticReadFailures);
             }
 
             if (!result.HasAvailableCapabilities &&

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,26 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.0.12",
+            "September 4, 2026",
+            "RELIABILITY",
+            "More useful local diagnostic reports and improved Native HUD recovery after race settings.",
+            true,
+            [
+                Group("Diagnostics",
+                    "Collects telemetry reception, UI processing, native-data freshness, composition callbacks, focus transitions, and Wisp CPU and memory usage on a background sampler.",
+                    "Exported reports show sustained findings with timestamps, supporting measurements, the likely affected component, remaining uncertainty, and a useful next step.",
+                    "Logging stays local, opt-in, time-limited, and size-limited. Game FPS and GPU presentation latency are not measured; the report does not claim an exact driver diagnosis."),
+                Group("Fixed",
+                    "Allows Native HUD data to recover when a race provider clears its secondary local-provider flag. Recovery still requires a validated provider and a unique live car, RPM, and maximum-RPM match.",
+                    "Removed the outer outline from the update confirmation dialog.")
+            ]),
+        new(
             "1.0.11",
             "September 4, 2026",
             "MAINTENANCE",
             "Corrects the repository's build-author alias. Application behavior is unchanged from 1.0.10.",
-            true,
+            false,
             [
                 Group("Maintenance",
                     "Maps the temporary build-author identity to Views2k in repository tools that support author aliases.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.11</Version>
-    <FileVersion>1.0.11.0</FileVersion>
-    <AssemblyVersion>1.0.11.0</AssemblyVersion>
+    <Version>1.0.12</Version>
+    <FileVersion>1.0.12.0</FileVersion>
+    <AssemblyVersion>1.0.12.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.11.0" name="Wisp.App" />
+  <assemblyIdentity version="1.0.12.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Telemetry/TelemetryUdpReceiver.cs
+++ b/src/Wisp.Telemetry/TelemetryUdpReceiver.cs
@@ -23,6 +23,9 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
     private VehicleState? _latest;
     private long _acceptedPackets;
     private long _rejectedPackets;
+    private long _receivedDatagrams;
+    private long _drainedDatagrams;
+    private long _lastDatagramTimestamp;
     private long _previousAcceptedPackets;
     private DateTimeOffset _previousRateAtUtc = DateTimeOffset.UtcNow;
     private double _cachedPacketRate;
@@ -38,6 +41,10 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
     public event EventHandler? PacketAvailable;
 
     public VehicleState? Latest => Volatile.Read(ref _latest);
+
+    public long ReceivedDatagrams => Interlocked.Read(ref _receivedDatagrams);
+    public long DrainedDatagrams => Interlocked.Read(ref _drainedDatagrams);
+    public long LastDatagramTimestamp => Interlocked.Read(ref _lastDatagramTimestamp);
 
     public bool IsRunning => Volatile.Read(ref _session)?.ReceiveTask is { IsCompleted: false };
 
@@ -261,6 +268,8 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
                     remoteEndpoint,
                     cancellationToken).ConfigureAwait(false);
 
+                RecordDatagram(drained: false);
+
                 var receivedBytes = DrainToNewestDatagram(
                     socket,
                     buffer,
@@ -301,7 +310,7 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
         }
     }
 
-    private static int DrainToNewestDatagram(
+    private int DrainToNewestDatagram(
         Socket socket,
         byte[] buffer,
         int receivedBytes,
@@ -315,9 +324,20 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
                 buffer.Length,
                 SocketFlags.None,
                 ref remoteEndpoint);
+            RecordDatagram(drained: true);
         }
 
         return receivedBytes;
+    }
+
+    private void RecordDatagram(bool drained)
+    {
+        Interlocked.Increment(ref _receivedDatagrams);
+        if (drained)
+        {
+            Interlocked.Increment(ref _drainedDatagrams);
+        }
+        Interlocked.Exchange(ref _lastDatagramTimestamp, Stopwatch.GetTimestamp());
     }
 
     private void NotifyPacketAvailable()
@@ -345,6 +365,9 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
         {
             Interlocked.Exchange(ref _acceptedPackets, 0);
             Interlocked.Exchange(ref _rejectedPackets, 0);
+            Interlocked.Exchange(ref _receivedDatagrams, 0);
+            Interlocked.Exchange(ref _drainedDatagrams, 0);
+            Interlocked.Exchange(ref _lastDatagramTimestamp, 0);
             Volatile.Write(ref _lastParseError, (int)PacketParseError.None);
             Volatile.Write(ref _listenerError, null);
             _previousAcceptedPackets = 0;

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.11</Version>
-    <FileVersion>1.0.11.0</FileVersion>
-    <AssemblyVersion>1.0.11.0</AssemblyVersion>
+    <Version>1.0.12</Version>
+    <FileVersion>1.0.12.0</FileVersion>
+    <AssemblyVersion>1.0.12.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/DebugDiagnosticReportTests.cs
+++ b/tests/Wisp.App.Tests/DebugDiagnosticReportTests.cs
@@ -1,0 +1,413 @@
+using Wisp.App.DebugLogging;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class DebugDiagnosticReportTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 9, 4, 20, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void SustainedDispatcherDelayWithFreshUdpIsClassifiedAsUiProcessingDelay()
+    {
+        var report = Build(
+            Healthy(1) with
+            {
+                UiHeartbeatAgeMilliseconds = 820,
+                DispatcherDelayMilliseconds = 760,
+                DispatcherProbePending = true,
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = 810,
+                CompositionMaximumGapMilliseconds = 790
+            },
+            Healthy(2) with
+            {
+                UiHeartbeatAgeMilliseconds = 1_820,
+                DispatcherDelayMilliseconds = 1_760,
+                DispatcherProbePending = true,
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = 1_810,
+                CompositionMaximumGapMilliseconds = 0
+            },
+            Healthy(3));
+
+        AssertUsefulFinding(report, "UI processing delay");
+        Assert.DoesNotContain("Telemetry reception interruption", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("Composition callback gap", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActualStoppedArrivalsAfterDrivingNarrowThePathWithoutCallingNormalDisconnectAFault()
+    {
+        var samples = new List<DebugHealthSample> { Healthy(1) };
+        for (var second = 2; second <= 4; second++)
+        {
+            samples.Add(Healthy(second) with
+            {
+                IncomingHz = 0,
+                ProcessedHz = 0,
+                ReceivedDatagrams = 60,
+                AcceptedPackets = 60,
+                ProcessedPackets = 60,
+                PacketAgeMilliseconds = (second - 1) * 1_000 + 5,
+                GameTimestampAdvancing = false
+            });
+        }
+        var report = DebugDiagnosticReport.Build(samples);
+
+        AssertUsefulFinding(report, "Telemetry arrival stopped (cause uncertain)");
+        Assert.Contains("not a confirmed fault", report, StringComparison.Ordinal);
+        Assert.Contains("normal disconnect", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("Telemetry reception interruption", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("UI processing delay", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActualListenerErrorsAreSeparatedFromMissingUpstreamData()
+    {
+        var report = Build(Healthy(1) with { ListenerError = true }, Healthy(2) with { ListenerError = true });
+        AssertUsefulFinding(report, "Telemetry reception interruption");
+        Assert.Contains("local listener reported an error", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RejectedPacketGrowthIsReportedWithEvidence()
+    {
+        var report = Build(
+            Healthy(0),
+            Healthy(1) with { AcceptedPackets = 0, RejectedPackets = 3 },
+            Healthy(2) with { AcceptedPackets = 0, RejectedPackets = 7 },
+            Healthy(3));
+
+        AssertUsefulFinding(report, "Telemetry rejected packets");
+    }
+
+    [Fact]
+    public void HealthyUiWithSustainedCompositionGapIsClassifiedSeparately()
+    {
+        var report = Build(
+            Healthy(1) with
+            {
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = 720,
+                CompositionMaximumGapMilliseconds = 710
+            },
+            Healthy(2) with
+            {
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = 1_690,
+                CompositionMaximumGapMilliseconds = 980
+            },
+            Healthy(3));
+
+        AssertUsefulFinding(report, "Composition callback gap");
+        Assert.DoesNotContain("UI processing delay", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpectedNativeHudFailureAndStalenessAreReportedWithoutGuessingACause()
+    {
+        var report = Build(
+            Healthy(0),
+            Healthy(1) with
+            {
+                NativeAvailable = false,
+                NativeStatus = "Failed",
+                NativeAgeMilliseconds = 2_820,
+                NativeVisibilityAgeMilliseconds = 2_810
+            },
+            Healthy(2) with
+            {
+                NativeAvailable = false,
+                NativeStatus = "Failed",
+                NativeAgeMilliseconds = 3_810,
+                NativeVisibilityAgeMilliseconds = 3_790
+            },
+            Healthy(3));
+
+        AssertUsefulFinding(report, "Native HUD data unavailable or stale");
+        Assert.DoesNotContain("driver caused", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ResourcePressureIsReportedAsCorrelationNotDriverBlame()
+    {
+        var report = Build(
+            Healthy(0),
+            Healthy(1) with
+            {
+                UiHeartbeatAgeMilliseconds = 850,
+                DispatcherDelayMilliseconds = 800,
+                DispatcherProbePending = true,
+                WispCpuPercent = 96,
+                WorkingSetBytes = 1_500_000_000,
+                ManagedHeapBytes = 900_000_000,
+                Gen2Collections = 5
+            },
+            Healthy(2) with
+            {
+                UiHeartbeatAgeMilliseconds = 920,
+                DispatcherDelayMilliseconds = 870,
+                DispatcherProbePending = true,
+                WispCpuPercent = 98,
+                WorkingSetBytes = 1_650_000_000,
+                ManagedHeapBytes = 1_000_000_000,
+                Gen2Collections = 8
+            },
+            Healthy(3));
+
+        AssertUsefulFinding(report, "Resource pressure correlation");
+        Assert.Contains("correlation", report, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("driver caused", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DroppedRecordsAndCollectorFailuresCreateACoverageWarning()
+    {
+        var report = DebugDiagnosticReport.Build(
+            [Healthy(0), Healthy(1) with { CollectionGapMilliseconds = 3_000, CollectorFailures = 2 }, Healthy(2)],
+            droppedRecords: 4);
+
+        Assert.Contains("Collector coverage gap", report, StringComparison.Ordinal);
+        Assert.Contains("cannot be classified reliably", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Next useful step", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("menu")]
+    [InlineData("hidden")]
+    [InlineData("disconnected")]
+    [InlineData("background")]
+    [InlineData("stale_context")]
+    public void SustainedExpectedInactiveStatesDoNotProduceFaultFindings(string context)
+    {
+        var samples = Enumerable.Range(1, 3).Select(second =>
+        {
+            var sample = Healthy(second) with
+            {
+                OverlayExpectedVisible = false,
+                NativeExpected = false,
+                UiHeartbeatAgeMilliseconds = 700,
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = second * 1000,
+                NativeAvailable = false,
+                NativeAgeMilliseconds = second * 1000 + 3000
+            };
+            return context switch
+            {
+                "menu" => sample with { RaceOn = false, GameTimestampAdvancing = false },
+                "hidden" => sample,
+                "background" => sample with { Focus = DebugFocus.Other },
+                "stale_context" => sample with { UiContextFresh = false, OverlayExpectedVisible = true, NativeExpected = true },
+                "disconnected" => sample with
+                {
+                    RaceOn = false,
+                    GameTimestampAdvancing = false,
+                    IncomingHz = 0,
+                    ProcessedHz = 0,
+                    ReceivedDatagrams = 0,
+                    AcceptedPackets = 0,
+                    ProcessedPackets = 0,
+                    PacketAgeMilliseconds = null
+                },
+                _ => throw new InvalidOperationException()
+            };
+        }).ToArray();
+
+        var report = Build(samples);
+        AssertNoFaultHeadings(report);
+    }
+
+    [Fact]
+    public void NormalIdleHeartbeatCadenceIsNotMistakenForUiDelay()
+    {
+        var report = Build(Enumerable.Range(1, 3).Select(second => Healthy(second) with
+        {
+            RaceOn = false,
+            GameTimestampAdvancing = false,
+            UiHeartbeatAgeMilliseconds = 780,
+            DispatcherProbePending = false,
+            DispatcherDelayMilliseconds = 6,
+            OverlayExpectedVisible = false,
+            ProcessedHz = 0
+        }).ToArray());
+        AssertNoFaultHeadings(report);
+    }
+
+    [Fact]
+    public void RateDifferenceFromNewestPacketCoalescingDoesNotImplyLossOrUiFailure()
+    {
+        var report = Build(Enumerable.Range(1, 3).Select(second => Healthy(second) with
+        {
+            ReceivedDatagrams = second * 600,
+            AcceptedPackets = second * 60,
+            DrainedDatagrams = second * 540,
+            ProcessedPackets = second * 30,
+            IncomingHz = 600,
+            ProcessedHz = 30
+        }).ToArray());
+        AssertNoFaultHeadings(report);
+        Assert.Contains("intentional newest-packet coalescing", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnknownUiTimingCannotSupportACompositionOrNativeAttribution()
+    {
+        var report = Build(Enumerable.Range(1, 3).Select(second => Healthy(second) with
+        {
+            UiHeartbeatAgeMilliseconds = null,
+            DispatcherDelayMilliseconds = double.NaN,
+            CompositionAgeMilliseconds = second * 1000,
+            NativeAvailable = false,
+            NativeAgeMilliseconds = second * 1000 + 3000
+        }).ToArray());
+        AssertNoFaultHeadings(report);
+        Assert.Contains("Unknown or invalid timing", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InvalidIncomingTimingCannotEstablishFreshTelemetryDuringAUiStall()
+    {
+        var report = Build(Enumerable.Range(1, 3).Select(second => Healthy(second) with
+        {
+            IncomingHz = double.PositiveInfinity,
+            PacketAgeMilliseconds = double.NaN,
+            DispatcherProbePending = true,
+            DispatcherDelayMilliseconds = second * 1000,
+            UiHeartbeatAgeMilliseconds = second * 1000
+        }).ToArray());
+        AssertNoFaultHeadings(report);
+    }
+
+    [Fact]
+    public void SustainedMissingUiContextCanStillBeDetectedByThePendingProbe()
+    {
+        var report = Build(Enumerable.Range(1, 3).Select(second => Healthy(second) with
+        {
+            UiContextFresh = false,
+            UiHeartbeatAgeMilliseconds = null,
+            DispatcherProbePending = true,
+            DispatcherDelayMilliseconds = second * 1000,
+            ProcessedPackets = 0,
+            ProcessedHz = 0
+        }).ToArray());
+        AssertUsefulFinding(report, "UI processing delay");
+    }
+
+    [Fact]
+    public void UnknownSessionTimingIsInsufficientEvidence()
+    {
+        var report = Build(Healthy(1) with { ElapsedMilliseconds = double.NaN },
+            Healthy(2) with { ElapsedMilliseconds = double.PositiveInfinity });
+        AssertNoFaultHeadings(report);
+        Assert.Contains("Insufficient evidence", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SummarySizeAndSessionCountStayBounded()
+    {
+        var samples = Enumerable.Range(1, 200).SelectMany(session => Enumerable.Range(1, 3).Select(second =>
+            Healthy(second) with
+            {
+                SessionId = $"session-{session}",
+                DispatcherProbePending = true,
+                DispatcherDelayMilliseconds = second * 1000,
+                UiHeartbeatAgeMilliseconds = second * 1000,
+                WispCpuPercent = 95
+            })).ToArray();
+        var report = DebugDiagnosticReport.Build(samples);
+        Assert.True(System.Text.Encoding.UTF8.GetByteCount(report) <= DebugDiagnosticReport.MaximumSummaryBytes);
+        Assert.Contains("latest 32 retained sessions", report, StringComparison.Ordinal);
+        Assert.Contains("sampled, normally once per second", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OneIsolatedBadSampleIsInsufficientEvidence()
+    {
+        var report = Build(
+            Healthy(1) with
+            {
+                UiHeartbeatAgeMilliseconds = 900,
+                DispatcherDelayMilliseconds = 850,
+                DispatcherProbePending = true,
+                CompositionHz = 0,
+                CompositionAgeMilliseconds = 850,
+                CompositionMaximumGapMilliseconds = 820,
+                NativeAvailable = false,
+                NativeStatus = "Failed",
+                NativeAgeMilliseconds = 850
+            });
+
+        AssertNoFaultHeadings(report);
+        Assert.Contains("insufficient", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Build(params DebugHealthSample[] samples) =>
+        DebugDiagnosticReport.Build(samples);
+
+    private static DebugHealthSample Healthy(int second) => new()
+    {
+        TimestampUtc = Start.AddSeconds(second),
+        SessionId = "test-session",
+        ElapsedMilliseconds = second * 1_000,
+        CollectionGapMilliseconds = second == 0 ? 0 : 1_000,
+        ReceivedDatagrams = 60L * second,
+        DrainedDatagrams = 0,
+        AcceptedPackets = 60L * second,
+        RejectedPackets = 0,
+        ProcessedPackets = 60L * second,
+        IncomingHz = 60,
+        ProcessedHz = 60,
+        PacketAgeMilliseconds = 5,
+        ListenerRunning = true,
+        ListenerError = false,
+        RaceOn = true,
+        GameTimestampAdvancing = true,
+        Focus = DebugFocus.Game,
+        UiContextFresh = true,
+        OverlayExpectedVisible = true,
+        NativeExpected = true,
+        UiHeartbeatAgeMilliseconds = 8,
+        DispatcherDelayMilliseconds = 4,
+        DispatcherProbePending = false,
+        CompositionHz = 60,
+        CompositionAgeMilliseconds = 8,
+        CompositionMaximumGapMilliseconds = 18,
+        NativeAvailable = true,
+        NativeStatus = "Ready",
+        NativeAgeMilliseconds = 8,
+        NativeVisibilityAgeMilliseconds = 8,
+        GameplayVisibility = "Visible",
+        WispCpuPercent = 4,
+        WorkingSetBytes = 180_000_000,
+        ManagedHeapBytes = 45_000_000,
+        Gen2Collections = 0,
+        DroppedRecords = 0,
+        CollectorFailures = 0
+    };
+
+    private static void AssertUsefulFinding(string report, string heading)
+    {
+        Assert.Contains(heading, report, StringComparison.Ordinal);
+        Assert.Contains("Evidence", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("When:", report, StringComparison.Ordinal);
+        Assert.Contains("Uncertainty", report, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Next useful step", report, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void AssertNoFaultHeadings(string report)
+    {
+        foreach (var heading in new[]
+                 {
+                     "UI processing delay",
+                     "Telemetry reception interruption",
+                     "Telemetry rejected packets",
+                     "Native HUD data unavailable or stale",
+                     "Composition callback gap",
+                     "Resource pressure correlation"
+                 })
+        {
+            Assert.DoesNotContain(heading, report, StringComparison.Ordinal);
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/DebugHealthMonitorTests.cs
+++ b/tests/Wisp.App.Tests/DebugHealthMonitorTests.cs
@@ -1,0 +1,252 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
+using Wisp.App;
+using Wisp.App.DebugLogging;
+using Wisp.Core;
+using Wisp.Telemetry;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class DebugHealthMonitorTests
+{
+    [Fact(Timeout = 6000)]
+    public async Task HeldDispatcherStillCollectsFreshUdpAndReportsUiDelay()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"wisp-health-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var port = AvailableUdpPort();
+            await using var receiver = new TelemetryUdpReceiver();
+            await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+            await using var nativeHud = new NativeHudProcessService(new RejectingNativeFactory());
+            await using var log = new DebugLogService(Path.Combine(root, "logs"));
+            Assert.True(log.TryEnable(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5)));
+
+            var postedCallbacks = 0;
+            await using var monitor = new DebugHealthMonitor(
+                receiver,
+                nativeHud,
+                log,
+                () => 0,
+                _ => Interlocked.Increment(ref postedCallbacks),
+                () => { },
+                sampleInterval: TimeSpan.FromMilliseconds(100),
+                focus: () => DebugFocus.Game);
+
+            using var sendCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            var sender = SendAdvancingPacketsAsync(port, sendCancellation.Token);
+            try
+            {
+                await WaitUntilAsync(
+                    () => receiver.ReceivedDatagrams >= 2,
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+                monitor.PublishUiContext(new DebugHealthUiContext(
+                    Stopwatch.GetTimestamp(),
+                    OverlayExpectedVisible: true,
+                    NativeExpected: false,
+                    RaceOn: true,
+                    CarOrdinal: 42,
+                    GameTimestampMilliseconds: receiver.Latest!.GameTimestampMilliseconds));
+                monitor.Start(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5));
+
+                await Task.Delay(1350, TestContext.Current.CancellationToken);
+            }
+            finally
+            {
+                await monitor.StopAsync();
+                sendCancellation.Cancel();
+                await sender;
+            }
+
+            Assert.Equal(1, Volatile.Read(ref postedCallbacks));
+            var exportPath = Path.Combine(root, "debug.zip");
+            Assert.True(await log.ExportAsync(exportPath, "1.0.12"));
+
+            using var archive = ZipFile.OpenRead(exportPath);
+            var health = ReadEntry(archive, "health.ndjson")
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            Assert.True(health.Length >= 10, $"Expected continuous background samples, got {health.Length}.");
+            Assert.True(health.Count(line => line.Contains(
+                "\"dispatcher_probe_pending\":true", StringComparison.Ordinal)) >= 8);
+
+            var summary = ReadEntry(archive, "summary.txt");
+            Assert.Contains("UI processing delay", summary, StringComparison.Ordinal);
+            Assert.Contains("Incoming data stayed fresh", summary, StringComparison.Ordinal);
+            Assert.DoesNotContain("Composition callback gap", summary, StringComparison.Ordinal);
+            Assert.Contains("does not establish a GPU fault", summary, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Theory(Timeout = 15000)]
+    [InlineData("native", "Native HUD data unavailable or stale")]
+    [InlineData("composition", "Composition callback gap")]
+    [InlineData("malformed", "Telemetry rejected packets")]
+    [InlineData("healthy", null)]
+    [InlineData("menu", null)]
+    [InlineData("hidden", null)]
+    [InlineData("disconnected", null)]
+    public async Task ControlledPipelineScenariosProduceSpecificReports(string scenario, string? expectedFinding)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"wisp-health-scenario-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var port = AvailableUdpPort();
+            await using var receiver = new TelemetryUdpReceiver();
+            await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+            var factory = new RejectingNativeFactory();
+            await using var nativeHud = new NativeHudProcessService(factory);
+            await using var log = new DebugLogService(Path.Combine(root, "logs"));
+            Assert.True(log.TryEnable(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5)));
+            long processed = 0;
+            await using var monitor = new DebugHealthMonitor(
+                receiver, nativeHud, log, () => Interlocked.Read(ref processed),
+                callback => callback(), () => { },
+                sampleInterval: TimeSpan.FromMilliseconds(100), focus: () => DebugFocus.Game);
+            monitor.Start(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5));
+            using var sender = new UdpClient(AddressFamily.InterNetwork);
+            var destination = new IPEndPoint(IPAddress.Loopback, port);
+            var elapsed = Stopwatch.StartNew();
+            uint gameTimestamp = 1000;
+            while (elapsed.Elapsed < TimeSpan.FromSeconds(2))
+            {
+                var packet = scenario == "malformed" ? new byte[3] : ValidPacket(gameTimestamp += 20);
+                if (scenario == "menu")
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(packet.AsSpan(Fh6PacketLayout.IsRaceOn), 0);
+                }
+                if (scenario != "disconnected")
+                {
+                    await sender.SendAsync(packet, destination, TestContext.Current.CancellationToken);
+                }
+                var latest = receiver.Latest;
+                if (latest is not null)
+                {
+                    Interlocked.Increment(ref processed);
+                    nativeHud.UpdateTelemetry(latest, scenario == "native");
+                }
+                monitor.PublishUiContext(new DebugHealthUiContext(
+                    Stopwatch.GetTimestamp(),
+                    OverlayExpectedVisible: scenario is "healthy" or "native" or "composition",
+                    NativeExpected: scenario == "native", RaceOn: latest?.IsRaceOn ?? false,
+                    CarOrdinal: 42, GameTimestampMilliseconds: latest?.GameTimestampMilliseconds ?? 0));
+                if (scenario is "healthy" or "native")
+                {
+                    monitor.RecordCompositionFrame(Stopwatch.GetTimestamp(), 50);
+                }
+                await Task.Delay(20, TestContext.Current.CancellationToken);
+            }
+            await monitor.StopAsync();
+            var exportPath = Path.Combine(root, "debug.zip");
+            Assert.True(await log.ExportAsync(exportPath, "1.0.12"));
+            using var archive = ZipFile.OpenRead(exportPath);
+            var summary = ReadEntry(archive, "summary.txt");
+            foreach (var heading in new[]
+            {
+                "UI processing delay", "Native HUD data unavailable or stale", "Composition callback gap",
+                "Telemetry rejected packets", "Telemetry reception interruption"
+            })
+            {
+                if (heading == expectedFinding)
+                {
+                    Assert.Contains(heading, summary, StringComparison.Ordinal);
+                    Assert.Contains("When:", summary, StringComparison.Ordinal);
+                    Assert.Contains("Evidence (last sample):", summary, StringComparison.Ordinal);
+                    Assert.Contains("Likely affected component:", summary, StringComparison.Ordinal);
+                    Assert.Contains("Uncertainty:", summary, StringComparison.Ordinal);
+                    Assert.Contains("Next useful step:", summary, StringComparison.Ordinal);
+                }
+                else
+                {
+                    Assert.DoesNotContain(heading, summary, StringComparison.Ordinal);
+                }
+            }
+            if (scenario == "native") Assert.True(factory.OpenAttempts > 0);
+            if (scenario == "malformed") Assert.True(receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets > 0);
+            if (scenario == "disconnected") Assert.Equal(0, receiver.ReceivedDatagrams);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static async Task SendAdvancingPacketsAsync(int port, CancellationToken cancellationToken)
+    {
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        var destination = new IPEndPoint(IPAddress.Loopback, port);
+        uint gameTimestamp = 1000;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var packet = ValidPacket(gameTimestamp += 20);
+                await sender.SendAsync(packet, destination, cancellationToken);
+                await Task.Delay(20, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private static byte[] ValidPacket(uint gameTimestamp)
+    {
+        var packet = new byte[Fh6PacketLayout.PacketLength];
+        BinaryPrimitives.WriteInt32LittleEndian(packet.AsSpan(Fh6PacketLayout.IsRaceOn), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(packet.AsSpan(Fh6PacketLayout.TimestampMilliseconds), gameTimestamp);
+        BinaryPrimitives.WriteInt32LittleEndian(packet.AsSpan(Fh6PacketLayout.CarOrdinal), 42);
+        BinaryPrimitives.WriteInt32LittleEndian(packet.AsSpan(Fh6PacketLayout.DrivetrainType), 0);
+        return packet;
+    }
+
+    private static int AvailableUdpPort()
+    {
+        using var socket = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.Client.LocalEndPoint!).Port;
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> condition,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency);
+        while (!condition())
+        {
+            Assert.True(Stopwatch.GetTimestamp() < deadline, "Timed out waiting for local UDP telemetry.");
+            await Task.Delay(10, cancellationToken);
+        }
+    }
+
+    private static string ReadEntry(ZipArchive archive, string name)
+    {
+        using var reader = new StreamReader(archive.GetEntry(name)!.Open());
+        return reader.ReadToEnd();
+    }
+
+    private sealed class RejectingNativeFactory : INativeHudProcessMemoryFactory
+    {
+        public int OpenAttempts;
+
+        public bool TryOpen(out INativeHudProcessMemory? memory, out NativeAssistProviderStatus status)
+        {
+            Interlocked.Increment(ref OpenAttempts);
+            memory = null;
+            status = NativeAssistProviderStatus.UnsupportedBuild;
+            return false;
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/DebugLogServiceTests.cs
+++ b/tests/Wisp.App.Tests/DebugLogServiceTests.cs
@@ -18,6 +18,7 @@ public sealed class DebugLogServiceTests
             await using (var service = new DebugLogService(logDirectory))
             {
                 service.TryLogSample(Sample(DateTimeOffset.UtcNow));
+                service.TryLogHealthSample(new DebugHealthSample { TimestampUtc = DateTimeOffset.UtcNow });
             }
 
             Assert.False(Directory.Exists(logDirectory));
@@ -48,7 +49,7 @@ public sealed class DebugLogServiceTests
 
             using var archive = ZipFile.OpenRead(exportPath);
             Assert.Equal(
-                ["events.ndjson", "manifest.json", "samples.ndjson", "summary.txt"],
+                ["events.ndjson", "health.ndjson", "manifest.json", "samples.ndjson", "summary.txt"],
                 archive.Entries.Select(entry => entry.FullName).OrderBy(name => name).ToArray());
             var samples = ReadEntry(archive, "samples.ndjson");
             Assert.Contains("\"telemetry_processed_hz\":60", samples, StringComparison.Ordinal);
@@ -212,6 +213,32 @@ public sealed class DebugLogServiceTests
 
             Assert.True(await service.DeleteLocalLogsAsync());
             Assert.Empty(Directory.GetFiles(logs, "segment-*.ndjson"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CorruptRecordsAreCountedWithoutIncludingTheirContentsInTheReport()
+    {
+        var root = TemporaryDirectory();
+        try
+        {
+            var logs = Path.Combine(root, "logs");
+            Directory.CreateDirectory(logs);
+            File.WriteAllText(Path.Combine(logs, "segment-partial.ndjson"), "not-json-private-sentinel\n");
+            await using var service = new DebugLogService(logs);
+            var export = Path.Combine(root, "debug.zip");
+            Assert.True(await service.ExportAsync(export, "1.0.12"));
+            using var archive = ZipFile.OpenRead(export);
+            using var manifest = JsonDocument.Parse(ReadEntry(archive, "manifest.json"));
+            Assert.Equal(1, manifest.RootElement.GetProperty("omitted_records").GetInt64());
+            var summary = ReadEntry(archive, "summary.txt");
+            Assert.Contains("Unreadable or unsupported records omitted: 1", summary);
+            Assert.DoesNotContain("private-sentinel", summary);
+            Assert.Empty(ReadEntry(archive, "health.ndjson"));
         }
         finally
         {

--- a/tests/Wisp.App.Tests/NativeGameplayVisibilityServiceTests.cs
+++ b/tests/Wisp.App.Tests/NativeGameplayVisibilityServiceTests.cs
@@ -156,18 +156,30 @@ public sealed class NativeGameplayVisibilityServiceTests
     [Fact]
     public async Task FailedVisibilityReadClearsThePreviousKnownState()
     {
+        using var failedRead = new ReadGate();
         var resolver = new ScriptedResolver(
             new ReadStep(NativeGameplayVisibility.Visible),
-            new ReadStep(NativeGameplayVisibility.Unknown));
+            new ReadStep(NativeGameplayVisibility.Unknown, failedRead));
         await using var service = new NativeHudProcessService(new FakeFactory(new NoGaugeMemory()), _ => resolver);
+        try
+        {
+            service.UpdateTelemetry(State(CarA), nativeLayoutActive: true);
+            await failedRead.WaitUntilEnteredAsync();
+            var visible = service.SnapshotFor(CarA);
+            Assert.Equal(NativeGameplayVisibility.Visible, visible.GameplayVisibility);
+            Assert.True(visible.VisibilityObservedTimestamp > 0);
 
-        service.UpdateTelemetry(State(CarA), nativeLayoutActive: true);
-        var visible = await WaitForSnapshotAsync(service, CarA, value => value.GameplayVisibility == NativeGameplayVisibility.Visible);
-        service.UpdateTelemetry(State(CarA, 2), nativeLayoutActive: true);
-        var unknown = await WaitForSnapshotAsync(service, CarA, value => value.Generation > visible.Generation);
+            service.UpdateTelemetry(State(CarA, 2), nativeLayoutActive: true);
+            failedRead.Release();
+            var unknown = await WaitForSnapshotAsync(service, CarA, value => value.Generation > visible.Generation);
 
-        AssertUnknown(unknown);
-        Assert.False(unknown.HasAvailableCapabilities);
+            AssertUnknown(unknown);
+            Assert.False(unknown.HasAvailableCapabilities);
+        }
+        finally
+        {
+            failedRead.Release();
+        }
     }
 
     [Theory]

--- a/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
@@ -226,6 +226,35 @@ public sealed class NativeHudMemoryResolverTests
     }
 
     [Fact]
+    public void RaceMenuReturnRecoversWhenSecondaryProviderFlagClears()
+    {
+        var memory = ValidMemory();
+        var resolver = new NativeHudMemoryResolver();
+        Assert.True(resolver.Resolve(memory, Module, 314, 4_000, 8_000, 1).Available);
+
+        resolver.Reset(); // The menu ends native demand; returning must resolve again.
+        memory.SetByte(Provider + NativeHudBuildContract.BuiltIn.Fields.LocalPlayerProviderFlag, 0);
+        const ulong source2 = 0x0000000310000000;
+        const ulong provider2 = 0x0000000420000000;
+        memory.SetUInt64(Module + NativeHudBuildContract.SourceVectorRva + 8, SourceList + 16);
+        memory.SetUInt64(Module + NativeHudBuildContract.SourceVectorRva + 16, SourceList + 16);
+        memory.SetUInt64(SourceList + 8, source2);
+        ConfigureSource(memory, source2, provider2, 999);
+        ConfigureProvider(memory, provider2, absOn: true, tcrOn: true, stmOn: true, lcOn: true);
+        memory.SetByte(provider2 + NativeHudBuildContract.BuiltIn.Fields.LocalPlayerProviderFlag, 0);
+
+        var recovered = resolver.Resolve(memory, Module, 314, 4_000, 8_000, 2, forceSourceAudit: true);
+        Assert.True(recovered.Available);
+        Assert.True(recovered.ExactRedline.IsExact);
+        Assert.Equal(8_000, recovered.TachometerMaximumRpm, 2);
+
+        ConfigureSource(memory, source2, provider2, 314);
+        var ambiguous = resolver.Resolve(memory, Module, 314, 4_000, 8_000, 3, forceSourceAudit: true);
+        Assert.False(ambiguous.Available);
+        Assert.Equal(NativeAssistProviderStatus.PlayerNotUnique, ambiguous.Status);
+    }
+
+    [Fact]
     public void ZeroLocalPlayerAndTelemetryMismatchFailClosed()
     {
         var noPlayer = ValidMemory();

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -220,7 +220,7 @@ public sealed class XamlContractTests
         var footer = document.Descendants(Presentation + "TextBlock")
             .Single(element => element.Attribute("Text")?.Value?.StartsWith(
                 "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.11", footer.Attribute("Text")?.Value);
+        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.12", footer.Attribute("Text")?.Value);
     }
 
     [Fact]
@@ -1270,6 +1270,9 @@ public sealed class XamlContractTests
     public void UpdateConfirmationShowsReleaseDetailsAsPlainWrappedText()
     {
         var document = LoadXaml(Path.Combine(AppSourceDirectory(), "MainWindow.xaml"));
+        var confirmation = document.Descendants(Presentation + "Grid")
+            .Single(element => element.Attribute(Xaml + "Name")?.Value == "ApplicationUpdateConfirmation");
+        Assert.Equal("0", confirmation.Elements(Presentation + "Border").Single().Attribute("BorderThickness")?.Value);
         var details = document.Descendants(Presentation + "Border")
             .Single(element => element.Attribute(Xaml + "Name")?.Value == "ApplicationUpdateConfirmationDetails");
         var summary = details.Descendants(Presentation + "TextBlock")

--- a/tests/Wisp.Telemetry.Tests/TelemetryUdpReceiverTests.cs
+++ b/tests/Wisp.Telemetry.Tests/TelemetryUdpReceiverTests.cs
@@ -36,7 +36,12 @@ public sealed class TelemetryUdpReceiverTests
 
         Assert.NotNull(receiver.Latest);
         Assert.Equal(2468, receiver.Latest!.CarOrdinal);
+        Assert.Equal(1, receiver.ReceivedDatagrams);
+        Assert.Equal(0, receiver.DrainedDatagrams);
+        Assert.True(receiver.LastDatagramTimestamp > 0);
         await receiver.StopAsync();
+        Assert.Equal(0, receiver.ReceivedDatagrams);
+        Assert.Equal(0, receiver.LastDatagramTimestamp);
     }
 
     [Fact]
@@ -167,6 +172,31 @@ public sealed class TelemetryUdpReceiverTests
 
         await WaitForCarAsync(receiver, 4015);
         Assert.Equal(4015, receiver.Latest?.CarOrdinal);
+        Assert.Equal(16, receiver.ReceivedDatagrams);
+        var statistics = receiver.GetStatistics(DateTimeOffset.UtcNow);
+        Assert.Equal(receiver.ReceivedDatagrams,
+            receiver.DrainedDatagrams + statistics.AcceptedPackets + statistics.RejectedPackets);
+    }
+
+    [Fact]
+    public async Task MalformedTrafficIsCountedWithoutPretendingValidTelemetryIsFresh()
+    {
+        var port = GetAvailablePort();
+        await using var receiver = new TelemetryUdpReceiver();
+        await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        await sender.SendAsync(new byte[8], new IPEndPoint(IPAddress.Loopback, port),
+            TestContext.Current.CancellationToken);
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5, TestContext.Current.CancellationToken);
+        }
+
+        Assert.Equal(1, receiver.ReceivedDatagrams);
+        Assert.Equal(1, receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets);
+        Assert.True(receiver.LastDatagramTimestamp > 0);
+        Assert.Null(receiver.Latest);
     }
 
     [Fact]

--- a/tools/Wisp.UiReview/NativeLifetimeReview.cs
+++ b/tools/Wisp.UiReview/NativeLifetimeReview.cs
@@ -56,7 +56,7 @@ internal static class NativeLifetimeReview
         var surface = new UniformGrid { Rows = 2, Columns = 2, IsHitTestVisible = false };
         foreach (var probe in controls)
         {
-            probe.Feed(0, false, SpeedUnit.MilesPerHour, firstHiddenFrame: false);
+            probe.Feed(0, false, SpeedUnit.MilesPerHour);
             surface.Children.Add(new Viewbox { Child = probe.Control, Margin = new Thickness(8) });
         }
         var host = new Window
@@ -148,14 +148,14 @@ internal static class NativeLifetimeReview
                                               probe.RenderingAttached is not false)) return;
                     Check(controls.All(probe => probe.LatestRetained && probe.ResumedVisualsMatch && probe.BlurIsReset),
                         "resume-latest-visuals-or-blur");
-                    Check(controls.Where(probe => probe.Electric).All(probe => probe.GearHistoryRetained(phase == 2)),
-                        "resume-ev-gear-history");
+                    Check(controls.Where(probe => probe.Electric).All(probe => probe.ResumedGearMatches),
+                        "resume-ev-latest-gear");
                     run.VerifiedResumes++;
                     awaitingResume = false;
                     ResetObservations();
                 }
                 var unit = phase is 1 or 2 ? SpeedUnit.KilometersPerHour : SpeedUnit.MilesPerHour;
-                foreach (var probe in controls) probe.Feed(++sequence, !active, unit, supplied == 0);
+                foreach (var probe in controls) probe.Feed(++sequence, !active, unit);
                 supplied++;
                 if (elapsed.Elapsed.TotalMilliseconds - phaseStarted < 600) return;
 
@@ -226,6 +226,7 @@ internal static class NativeLifetimeReview
         private readonly Image _ones;
         private readonly Image _unit;
         private readonly Image _gear;
+        private readonly ImageSource? _reverseGearSource;
         private readonly NativeAnalogNeedleVisual? _needle;
         private NativeGaugeFrame _latest;
         private ImageSource? _lastSource, _frozenSource, _frozenUnit, _frozenGear;
@@ -248,12 +249,14 @@ internal static class NativeLifetimeReview
             _unit = control.FindName("UnitImage") as Image ?? throw new InvalidOperationException("Missing native unit.");
             _gear = control.FindName("GearImage") as Image ?? throw new InvalidOperationException("Missing native gear.");
             _needle = control.FindName("NeedleMaterial") as NativeAnalogNeedleVisual;
+            Feed(0, true, SpeedUnit.MilesPerHour);
+            _reverseGearSource = _gear.Source;
         }
-        internal void Feed(int sequence, bool hidden, SpeedUnit unit, bool firstHiddenFrame)
+        internal void Feed(int sequence, bool hidden, SpeedUnit unit)
         {
             _latest = new NativeGaugeFrame(true, hidden ? 127 : 121 + sequence % 5,
                 2_000 + sequence, 9_000,
-                hidden && firstHiddenFrame ? TransmissionGear.Second : TransmissionGear.First, unit,
+                hidden ? TransmissionGear.Reverse : TransmissionGear.First, unit,
                 ExactRedlineResult.Exact(7_500 * 2 * Math.PI / 60), Assists,
                 IsElectric: Electric, CarOrdinal: 314, GameTimestampMilliseconds: (uint)sequence,
                 ReceivedTimestamp: Stopwatch.GetTimestamp());
@@ -275,8 +278,14 @@ internal static class NativeLifetimeReview
             _lastRendering = _compositor ? Read<TimeSpan>("_lastRenderingTime") : TimeSpan.MinValue;
         }
         internal void FreezeDisplayedState() => (_frozenSource, _frozenUnit, _frozenGear) = (_ones.Source, _unit.Source, _gear.Source);
-        internal bool GearHistoryRetained(bool firstResume) => Read<string>("_gearToken") == "1" &&
-            (!firstResume || !ReferenceEquals(_frozenGear, _gear.Source));
+        internal bool ResumedGearMatches
+        {
+            get
+            {
+                return _reverseGearSource is not null && _gear.Visibility == Visibility.Visible &&
+                       ReferenceEquals(_reverseGearSource, _gear.Source) && !ReferenceEquals(_frozenGear, _gear.Source);
+            }
+        }
         internal NativeLifetimeConsumer Snapshot() => new(Control.GetType().Name, Control.IsLoaded, Control.IsVisible,
             RenderingAttached, LatestRetained, FramePending, _frames, _digitChanges, _renderingAdvances, _needle?.BlurAmount);
         private T Read<T>(string field) => (T)(Control.GetType().GetField(field, BindingFlags.Instance | BindingFlags.NonPublic)


### PR DESCRIPTION
Adds background diagnostic sampling, evidence-based report summaries, race-provider recovery, and a borderless update confirmation. Version metadata is 1.0.12. Validation: 37 diagnostic/confirmation tests, 53 XAML/catalog tests, and 30 native resolver tests passed; two live native reader settings/race recoveries passed. Updated the synthetic lifetime harness to verify the rendered EV gear image: six stages and two resumes pass, zero binding diagnostics. Full race/settings overlay visual confirmation remains pending. No website changes.