### PR TITLE
Wisp 1.1: maintenance and wheel-speed smoothing fixes

### DIFF
--- a/.github/rulesets/protect-release-tags.json
+++ b/.github/rulesets/protect-release-tags.json
@@ -6,7 +6,8 @@
   "conditions": {
     "ref_name": {
       "include": [
-        "refs/tags/v*"
+        "refs/tags/v*",
+        "refs/tags/V*"
       ],
       "exclude": []
     }

--- a/.github/scripts/Test-ReleaseTag.ps1
+++ b/.github/scripts/Test-ReleaseTag.ps1
@@ -8,10 +8,38 @@ param(
 $ErrorActionPreference = 'Stop'
 $repository = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
 
-if ($Tag -notmatch '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$') {
-    throw 'Release tags must use canonical vX.Y.Z syntax.'
+function ConvertTo-CanonicalReleaseVersion {
+    param([Parameter(Mandatory)][string]$Value)
+
+    if ($Value.Length -gt 128) {
+        throw 'The numeric release tag is too long.'
+    }
+    $match = [regex]::Match(
+        $Value,
+        '\A[vV]?(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?(?:\.(0|[1-9][0-9]*))?(?:-stable)?\z',
+        [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor
+        [System.Text.RegularExpressions.RegexOptions]::CultureInvariant)
+    if (-not $match.Success) {
+        throw 'Release tags must contain one to three numeric components, optionally prefixed with v and suffixed with -stable.'
+    }
+    $parts = @('0', '0', '0')
+    for ($index = 0; $index -lt 3; $index++) {
+        if ($match.Groups[$index + 1].Success) {
+            [System.UInt16]$part = 0
+            if (-not [System.UInt16]::TryParse(
+                    $match.Groups[$index + 1].Value,
+                    [System.Globalization.NumberStyles]::None,
+                    [System.Globalization.CultureInfo]::InvariantCulture,
+                    [ref]$part)) {
+                throw 'Release-version components must fit the Windows PE version resource range.'
+            }
+            $parts[$index] = $part.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+        }
+    }
+    return $parts -join '.'
 }
-$version = $Tag.Substring(1)
+
+$version = ConvertTo-CanonicalReleaseVersion $Tag
 
 function Read-RequiredMatch {
     param(
@@ -49,7 +77,14 @@ if (-not (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf)) {
     throw "The release notes for $Tag are missing."
 }
 $releaseNotesHeading = [System.IO.File]::ReadLines($releaseNotesPath) | Select-Object -First 1
-if ($releaseNotesHeading -cne "# Wisp $version") {
+$displayVersion = if ($version.EndsWith('.0', [StringComparison]::Ordinal)) {
+    $version.Substring(0, $version.Length - 2)
+}
+else {
+    $version
+}
+if ($releaseNotesHeading -cne "# Wisp $version" -and
+    $releaseNotesHeading -cne "# Wisp $displayVersion") {
     throw "The release-notes heading does not match $Tag."
 }
 

--- a/.github/scripts/Test-RepositoryPolicy.ps1
+++ b/.github/scripts/Test-RepositoryPolicy.ps1
@@ -57,8 +57,8 @@ Assert-Policy (
     $innoScript -match ('(?m)^\s*#define\s+MyAppVersion\s+"' + [regex]::Escape($applicationVersion) + '"\s*$')
 ) 'The Inno Setup version must match Wisp.App.csproj.'
 Assert-Policy (
-    $mainWindow -match ('Text="WHEEL-INDICATED SPEED PANEL ' + [regex]::Escape($applicationVersion) + '"')
-) 'The control-center footer version must match Wisp.App.csproj.'
+    $mainWindow -match 'Text="\{x:Static local:ApplicationVersionInfo\.FooterText\}"'
+) 'The control-center footer must use the assembly-derived application version.'
 
 foreach ($ruleset in $branchRuleset, $tagRuleset) {
     $bypassActors = @($ruleset.bypass_actors)
@@ -130,6 +130,7 @@ foreach ($currentWorkflowPath in $workflowPaths) {
 Assert-Policy ($tagRuleset.target -eq 'tag') 'Protect release tags must target tags.'
 Assert-Policy ($tagRuleset.enforcement -eq 'active') 'Protect release tags must be defined as active.'
 Assert-Policy ($tagRuleset.conditions.ref_name.include -contains 'refs/tags/v*') 'Protect release tags must target v* tags.'
+Assert-Policy ($tagRuleset.conditions.ref_name.include -contains 'refs/tags/V*') 'Protect release tags must also target V* tags.'
 
 $tagRuleTypes = @($tagRuleset.rules.type)
 foreach ($requiredRule in 'update', 'deletion', 'non_fast_forward') {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    tags: ["v*"]
+    tags: ["v*", "V*"]
   pull_request:
     branches: [main]
 
@@ -94,7 +94,8 @@ jobs:
     if: >-
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch' ||
-      startsWith(github.ref, 'refs/tags/v')
+      startsWith(github.ref, 'refs/tags/v') ||
+      startsWith(github.ref, 'refs/tags/V')
     needs: test
     runs-on: windows-latest
     timeout-minutes: 45
@@ -109,7 +110,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate release tag provenance
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')
         shell: pwsh
         run: ./.github/scripts/Test-ReleaseTag.ps1 -Tag $env:GITHUB_REF_NAME
 
@@ -196,7 +197,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')
     needs: package-review
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -223,7 +224,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
+          version="$(python3 -c 'import xml.etree.ElementTree as ET; versions = [node.text.strip() for node in ET.parse("src/Wisp.App/Wisp.App.csproj").findall("./PropertyGroup/Version")]; assert len(versions) == 1; print(versions[0])')"
+          [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          display_version="${version%.0}"
           installer="outputs/Wisp-Setup-${version}.exe"
           archive="outputs/Wisp-Setup-${version}.zip"
           notes="docs/releases/Wisp-${version}-release-notes.md"
@@ -238,7 +241,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --draft \
             --verify-tag \
-            --title "Wisp ${version}" \
+            --title "Wisp ${display_version}" \
             --notes-file "$notes" \
             "$installer" \
             "$archive"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,24 @@
 
 Notable changes to Wisp are recorded here.
 
-## Unreleased
+## 1.1.0 - 2026-09-06
+
+Wisp 1.1 maintenance release.
 
 ### Fixed
 
 - Remove expired local debug-log segments before export, including after logging has stopped. Existing exported ZIPs are not deleted.
+- Confirm profile saves only after successful persistence, retaining retry support on failure.
+- Include drivetrain and calibration revision when deciding whether calibration needs saving.
+- Use monotonic elapsed time for telemetry freshness and retain release details on update retries.
+- Honor speed smoothing during large wheel-speed changes, and prevent release-history version labels from clipping.
 
 ### Maintenance
 
 - Bring update, retention, boost, and developer documentation into line with the application; clarify older screenshots and link current downloads.
 - Organize detailed release notes and document shader regeneration.
+- Match setup's particle material and depth styling to the website without low-opacity gradient banding.
+- Accept shortened stable release versions while preserving numeric installer identity and verification.
 
 ## 1.0.12 - 2026-09-04
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
+## New in Wisp 1.1
+
+[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.1 release notes](docs/releases/Wisp-1.1.0-release-notes.md)
+
+- **More readable wheel speed while drifting.** Speed smoothing now follows the
+  selected amount during rapid wheel-speed changes. Zero smoothing remains immediate.
+- **Reliable saves.** Profile-save confirmation waits for a successful write and
+  offers a retry on failure. Calibration saves also track drivetrain and revision
+  changes without altering tire-learning rules.
+- **Connection and update fixes.** Windows clock changes no longer affect telemetry
+  freshness, and release details stay available when retrying a downloaded update.
+- **Setup and release-history polish.** Setup uses the website's particle material
+  and depth styling with smoother faint gradients. Version labels no longer clip.
+- **Flexible release labels.** New clients accept shortened versions while keeping
+  installer size, SHA-256, embedded-version, and downgrade checks intact. This
+  release retains the `v1.1.0` tag so older installations can discover it.
+
+Includes expired-log cleanup before debug export. Existing exported ZIPs are
+untouched. HUD layouts, saved colors, and tire calibration behavior are preserved.
+
 ## New in 1.0.12
 
 [Download 1.0.12](https://github.com/Views2k/Wisp/releases/tag/v1.0.12) ·
@@ -183,8 +204,8 @@ You can also select **Check for updates** there to check immediately. Automatic
 checks discover releases; they never download or install an update without your
 confirmation.
 
-An accepted release must be public, stable, and immutable. Its tag and
-versioned installer name must match, and GitHub must provide the installer's
+An accepted release must be public, stable, and immutable. Numeric tags must
+match the installer's normalized version, and GitHub must provide the installer's
 exact byte length and SHA-256 digest. Downloads are limited to the canonical
 GitHub release URL and GitHub's HTTPS release-asset hosts. Wisp shows the release
 summary and asks you to confirm the download, installation, and restart. After

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,9 +36,11 @@ Wisp checks for application updates at startup, at most once every 24 hours.
 These checks are enabled by default and can be disabled in **Extras**. The
 **Check for updates** action also allows a manual check. The client makes an
 anonymous HTTPS request to the latest-release API and accepts only a non-draft,
-non-prerelease, immutable release with a strict version tag. The release must
-contain exactly one canonical versioned installer asset with an uploaded state,
-byte length, and GitHub SHA-256 digest.
+non-prerelease, immutable release. Exactly one versioned installer supplies its
+numeric version, uploaded state, byte length, and GitHub SHA-256 digest.
+Short numeric versions are normalized; numeric release tags must agree with the
+installer. Other safe stable labels are not used to infer a version. The initial
+download URL must match the exact validated release tag and installer filename.
 
 Wisp shows the release summary and asks for confirmation before downloading and
 installing an update. After confirmation, redirects are handled explicitly and

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -98,9 +98,15 @@ The application updater is separate from compatibility contracts. Availability
 checks run at startup, at most once every 24 hours. They are enabled by default
 and can be disabled in **Extras**. **Check for updates** also allows a manual
 check. The client uses GitHub's anonymous latest-release endpoint and requires a
-non-draft, non-prerelease, immutable release with a strict `vX.Y.Z` tag. Exactly
-one uploaded `Wisp-Setup-<version>.exe` asset must match the tag and provide its
-byte length and GitHub SHA-256 digest.
+non-draft, non-prerelease, immutable release. Exactly one uploaded
+`Wisp-Setup-<version>.exe` asset provides the numeric version, byte length, and
+GitHub SHA-256 digest. One-, two-, and three-part numeric versions normalize to
+`X.Y.Z`; numeric tags must agree with the installer. Stable release titles are
+display text, never version-ordering evidence.
+
+Use canonical tags such as `v1.1.0` and filenames such as `Wisp-Setup-1.1.0.exe`
+when publishing for clients older than Wisp 1.1. Those clients cannot discover
+short-tag releases, even if they skipped the release that added support.
 
 Wisp shows the release summary and asks for confirmation before downloading and
 installing the update. The initial download URL and every redirect must remain

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -122,10 +122,14 @@ ZIP, and outer checksum retain verified recovery copies if any destination
 cannot be replaced.
 GitHub's source ZIP and TAR.GZ are generated from the same release tag.
 
-For the in-application updater, the published release must use a strict `vX.Y.Z`
-tag, be neither a draft nor a prerelease, and be immutable. It must contain
+For the in-application updater, the published release must be neither a draft
+nor a prerelease and must be immutable. It must contain
 exactly one uploaded `Wisp-Setup-<version>.exe` asset whose GitHub metadata
-includes the byte length and SHA-256 digest. This anonymous update path requires
+includes the byte length and SHA-256 digest. Numeric tags must match the
+normalized installer version; the exact tag and asset filename define the
+allowed initial download URL. Publication retains canonical `vX.Y.Z` tags and
+three-part filenames for older-client compatibility, independently of the
+display label (for example, Wisp 1.1). This anonymous update path requires
 a public repository and public release assets. The local packaging script does
 not publish GitHub releases.
 

--- a/docs/WHEEL-SPEED-MODEL.md
+++ b/docs/WHEEL-SPEED-MODEL.md
@@ -97,8 +97,10 @@ generic tire radius. A brief impossible wheel sample can retain the last valid
 same-car value instead of presenting a believable but fabricated replacement.
 
 The default smoothing value is zero. Optional smoothing is applied after the
-physical calculation and is deliberately bounded so it cannot move more than
-1.5 mph away from the current raw result.
+physical calculation using an exponential filter. The slider sets its time
+constant from zero (immediate) to 250 milliseconds. At maximum smoothing, a
+steady speed change reaches about 63% of its new value after 250 milliseconds
+and 95% after 750 milliseconds. Ground-speed mode is not filtered.
 
 ## Stored profiles
 

--- a/docs/releases/Wisp-1.1.0-release-notes.md
+++ b/docs/releases/Wisp-1.1.0-release-notes.md
@@ -1,0 +1,26 @@
+# Wisp 1.1
+
+Wisp 1.1 improves wheel-speed readability and settings reliability, with a refreshed
+setup background and more flexible release-version support.
+
+- Profile changes are confirmed only after the settings write succeeds. If a
+  write fails, the existing dialog offers a retry without adding another profile.
+- Calibration save detection now includes drivetrain and calibration revision,
+  even when tire radii remain unchanged.
+- Windows clock changes no longer affect the telemetry connection timeout.
+- Release details remain available when retrying a downloaded update.
+- Setup uses the website's particle material and depth styling, with smoother
+  faint gradients and a new particle distribution.
+- Wheel-indicated speed smoothing now honors the selected amount during large
+  wheel-speed changes, instead of staying within 1.5 mph of the raw reading.
+- Includes the previously merged expired-log cleanup before debug export.
+- Release-history version labels have room to display without clipping.
+- Update checks recognize shortened version numbers and stable release labels.
+  Installer hashes, sizes, embedded versions, and downgrade protection are still checked.
+
+Wisp 1.1 uses the numeric Windows version 1.1.0. The release tag and installer
+filename remain `v1.1.0` and `Wisp-Setup-1.1.0.exe` so existing installations
+can discover this update. Newer clients also understand shortened release tags.
+
+HUD layouts, colors, tire-learning rules, and the settings
+format are unchanged. These changes do not address intermittent tachometer lag.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,6 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.0.12"
+#define MyAppVersion "1.1.0"
+#define MyAppDisplayVersion "1.1"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 
@@ -7,6 +8,7 @@
 AppId={{A8FC0D58-11E3-4B25-B78D-3B98E9855473}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppDisplayVersion}
 AppPublisher={#MyAppPublisher}
 DefaultDirName={localappdata}\Programs\Wisp
 DefaultGroupName={#MyAppName}

--- a/src/Wisp.App/AmbientBackdrop.cs
+++ b/src/Wisp.App/AmbientBackdrop.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 
 namespace Wisp.App;
@@ -15,15 +16,11 @@ public sealed class AmbientBackdrop : FrameworkElement
 
     public static readonly DependencyProperty IntensityProperty = DependencyProperty.Register(
         nameof(Intensity), typeof(double), typeof(AmbientBackdrop),
-        new FrameworkPropertyMetadata(0.78, OnIntensityChanged, CoerceIntensity));
+        new FrameworkPropertyMetadata(1d, OnIntensityChanged, CoerceIntensity));
 
-    private static readonly Brush[] FarParticleBrushes = CreateParticlePalette(AmbientParticleLayer.Far);
-    private static readonly Brush[] MiddleParticleBrushes = CreateParticlePalette(AmbientParticleLayer.Middle);
-    private static readonly Brush[] NearParticleBrushes = CreateParticlePalette(AmbientParticleLayer.Near);
-    private static readonly Brush BackgroundBrush = CreateBackground();
-
-    private readonly DrawingVisual _background = new();
-    private readonly DrawingVisual _foreground = new();
+    private readonly DrawingVisual _frame = new();
+    private AmbientBackdropRasterizer? _rasterizer;
+    private WriteableBitmap? _bitmap;
     private readonly AmbientBackdropScene _scene = new();
     private readonly AmbientBackdropClock _clock = new();
     private readonly AmbientBackdropPointer _pointer = new();
@@ -47,8 +44,7 @@ public sealed class AmbientBackdrop : FrameworkElement
         {
             Interval = TimeSpan.FromSeconds(1d / AmbientBackdropClock.FramesPerSecond)
         };
-        AddVisualChild(_background);
-        AddVisualChild(_foreground);
+        AddVisualChild(_frame);
         Loaded += OnLoaded;
         Unloaded += OnUnloaded;
         IsVisibleChanged += OnVisibilityChanged;
@@ -75,12 +71,11 @@ public sealed class AmbientBackdrop : FrameworkElement
     internal bool HasHostWindow => _host is not null;
     internal double SceneTimeSeconds => _clock.Seconds;
 
-    protected override int VisualChildrenCount => 2;
+    protected override int VisualChildrenCount => 1;
 
     protected override Visual GetVisualChild(int index) => index switch
     {
-        0 => _background,
-        1 => _foreground,
+        0 => _frame,
         _ => throw new ArgumentOutOfRangeException(nameof(index))
     };
 
@@ -88,7 +83,6 @@ public sealed class AmbientBackdrop : FrameworkElement
     {
         _viewport = finalSize;
         UpdateAnimationState();
-        DrawBackground();
         DrawScene(_clock.Seconds);
         return finalSize;
     }
@@ -254,40 +248,36 @@ public sealed class AmbientBackdrop : FrameworkElement
         }
     }
 
-    private void DrawBackground()
-    {
-        using var drawing = _background.RenderOpen();
-        if (_viewport.Width <= 0 || _viewport.Height <= 0)
-            return;
-        drawing.DrawRectangle(BackgroundBrush, null, new Rect(_viewport));
-    }
-
     private void DrawScene(double seconds)
     {
+        if (_viewport.Width <= 0 || _viewport.Height <= 0)
+            return;
+        var dpi = VisualTreeHelper.GetDpi(this);
+        var width = Math.Ceiling(_viewport.Width * dpi.DpiScaleX);
+        var height = Math.Ceiling(_viewport.Height * dpi.DpiScaleY);
+        var scale = Math.Min(1, Math.Sqrt(AmbientBackdropRasterizer.MaximumPixels / (width * height)));
+        var pixelWidth = Math.Max(1, (int)Math.Floor(width * scale));
+        var pixelHeight = Math.Max(1, (int)Math.Floor(height * scale));
+        if (_rasterizer is null || _rasterizer.Width != pixelWidth || _rasterizer.Height != pixelHeight)
+        {
+            _rasterizer = new AmbientBackdropRasterizer(pixelWidth, pixelHeight);
+            _bitmap = new WriteableBitmap(pixelWidth, pixelHeight, 96, 96, PixelFormats.Pbgra32, null);
+        }
         _scene.Update(
-            _viewport.Width,
-            _viewport.Height,
+            pixelWidth,
+            pixelHeight,
             seconds,
             _pointer.Position,
             _pointer.Activity);
-        using var drawing = _foreground.RenderOpen();
-        foreach (var particle in _scene.Particles)
-        {
-            var palette = particle.Layer switch
-            {
-                AmbientParticleLayer.Far => FarParticleBrushes,
-                AmbientParticleLayer.Middle => MiddleParticleBrushes,
-                _ => NearParticleBrushes
-            };
-            drawing.DrawEllipse(palette[particle.Shade], null, Point(particle.Position),
-                particle.Radius, particle.Radius);
-        }
+        _rasterizer.Render(_scene.Particles, Intensity);
+        _bitmap!.WritePixels(new Int32Rect(0, 0, pixelWidth, pixelHeight), _rasterizer.Pixels, pixelWidth * 4, 0);
+        using var drawing = _frame.RenderOpen();
+        drawing.DrawImage(_bitmap, new Rect(_viewport));
     }
 
     private void ApplyIntensity()
     {
-        _background.Opacity = 1;
-        _foreground.Opacity = Intensity;
+        DrawScene(_clock.Seconds);
     }
 
     private static void OnAnimationChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e) =>
@@ -303,63 +293,5 @@ public sealed class AmbientBackdrop : FrameworkElement
     private static object CoerceIntensity(DependencyObject sender, object value) =>
         double.IsFinite((double)value) ? Math.Clamp((double)value, 0, 1) : 0d;
 
-    private static Point Point(AmbientPoint point) => new(point.X, point.Y);
     private static double Timestamp() => Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency;
-
-    private static Brush CreateBackground() => Freeze(new RadialGradientBrush
-    {
-        MappingMode = BrushMappingMode.RelativeToBoundingBox,
-        Center = new Point(1.20, 0.42),
-        GradientOrigin = new Point(1.20, 0.42),
-        RadiusX = 1.55,
-        RadiusY = 1.35,
-        ColorInterpolationMode = ColorInterpolationMode.ScRgbLinearInterpolation,
-        GradientStops = new GradientStopCollection
-        {
-            new(Color.FromRgb(12, 23, 26), 0),
-            new(Color.FromRgb(11, 20, 24), 0.35),
-            new(Color.FromRgb(10, 16, 21), 0.70),
-            new(Color.FromRgb(9, 13, 18), 1)
-        }
-    });
-
-    private static Brush[] CreateParticlePalette(AmbientParticleLayer layer)
-    {
-        var brushes = new Brush[AmbientBackdropScene.PaletteSize];
-        for (var index = 0; index < brushes.Length; index++)
-        {
-            var light = index / (double)(brushes.Length - 1);
-            var color = layer switch
-            {
-                AmbientParticleLayer.Far => Color.FromArgb(
-                    (byte)(8 + light * 26), 64, 102, 99),
-                AmbientParticleLayer.Middle => Color.FromArgb(
-                    (byte)(12 + light * 48), 105, 130, 129),
-                _ => Color.FromArgb(
-                    (byte)(20 + light * 74), 138, 153, 153)
-            };
-            brushes[index] = layer == AmbientParticleLayer.Near
-                ? Freeze(new SolidColorBrush(color))
-                : Freeze(new RadialGradientBrush
-                {
-                    Center = new Point(0.5, 0.5),
-                    GradientOrigin = new Point(0.5, 0.5),
-                    RadiusX = 0.5,
-                    RadiusY = 0.5,
-                    GradientStops = new GradientStopCollection
-                    {
-                        new(color, 0),
-                        new(Color.FromArgb((byte)(color.A * 0.58), color.R, color.G, color.B), 0.52),
-                        new(Color.FromArgb(0, color.R, color.G, color.B), 1)
-                    }
-                });
-        }
-        return brushes;
-    }
-
-    private static T Freeze<T>(T value) where T : Freezable
-    {
-        value.Freeze();
-        return value;
-    }
 }

--- a/src/Wisp.App/AmbientBackdropRasterizer.cs
+++ b/src/Wisp.App/AmbientBackdropRasterizer.cs
@@ -1,0 +1,133 @@
+namespace Wisp.App;
+
+// The website's dark background and point-sprite material, composited before
+// conversion to 8-bit output so faint overlapping particles do not form bands.
+internal sealed class AmbientBackdropRasterizer
+{
+    internal const int MaximumPixels = 1_600_000;
+    private readonly float[] _background;
+    private readonly float[] _composite;
+    private readonly byte[] _roundingNoise;
+
+    internal AmbientBackdropRasterizer(int width, int height)
+    {
+        if (width <= 0 || height <= 0 || (long)width * height > MaximumPixels)
+            throw new ArgumentOutOfRangeException(nameof(width));
+        Width = width;
+        Height = height;
+        var count = width * height;
+        _background = new float[count * 3];
+        _composite = new float[count * 3];
+        _roundingNoise = new byte[count];
+        Pixels = new byte[count * 4];
+        var aspect = width / (double)height;
+        for (var y = 0; y < height; y++)
+        {
+            var dy = (1 - (y + 0.5) / height - 0.42) * 0.8;
+            for (var x = 0; x < width; x++)
+            {
+                var dx = ((x + 0.5) / width - 1.2) * aspect * 0.58;
+                var light = (float)(Math.Exp(-(dx * dx + dy * dy) * 1.24) * 0.135);
+                var index = y * width + x;
+                _background[index * 3] = 9 + 10 * light;
+                _background[index * 3 + 1] = 13 + 30 * light;
+                _background[index * 3 + 2] = 18 + 26 * light;
+                _roundingNoise[index] = Noise(x, y);
+                Pixels[index * 4 + 3] = 255;
+            }
+        }
+    }
+
+    internal int Width { get; }
+    internal int Height { get; }
+    internal byte[] Pixels { get; }
+
+    internal void Render(ReadOnlySpan<AmbientParticle> particles, double intensity)
+    {
+        Array.Copy(_background, _composite, _background.Length);
+        intensity = double.IsFinite(intensity) ? Math.Clamp(intensity, 0, 1) : 0;
+        if (intensity > 0)
+            foreach (var particle in particles)
+                Composite(particle, intensity);
+
+        for (var index = 0; index < _roundingNoise.Length; index++)
+        {
+            // Stable stochastic rounding removes contour steps without adding
+            // a visible animated grain layer or biasing the average color.
+            var rounding = (_roundingNoise[index] + 0.5f) / 256;
+            var source = index * 3;
+            var target = index * 4;
+            Pixels[target] = Quantize(_composite[source + 2], rounding);
+            Pixels[target + 1] = Quantize(_composite[source + 1], rounding);
+            Pixels[target + 2] = Quantize(_composite[source], rounding);
+        }
+    }
+
+    private void Composite(AmbientParticle particle, double intensity)
+    {
+        if (!double.IsFinite(particle.Position.X) || !double.IsFinite(particle.Position.Y) ||
+            !double.IsFinite(particle.Radius) || particle.Radius <= 0 || particle.Radius > 21 ||
+            !double.IsFinite(particle.Opacity) || !double.IsFinite(particle.Softness) ||
+            !double.IsFinite(particle.Red) || !double.IsFinite(particle.Green) || !double.IsFinite(particle.Blue))
+            return;
+
+        var peakAlpha = Math.Clamp(particle.Opacity, 0, 1) * intensity;
+        if (peakAlpha < 0.001)
+            return;
+        var left = Math.Max(0, Math.Ceiling(particle.Position.X - particle.Radius - 0.5));
+        var right = Math.Min(Width - 1, Math.Floor(particle.Position.X + particle.Radius - 0.5));
+        var top = Math.Max(0, Math.Ceiling(particle.Position.Y - particle.Radius - 0.5));
+        var bottom = Math.Min(Height - 1, Math.Floor(particle.Position.Y + particle.Radius - 0.5));
+        if (left > right || top > bottom)
+            return;
+        var exponent = 0.72 + (2.6 - 0.72) * Math.Clamp(particle.Softness, 0, 1);
+        var red = (float)(Math.Clamp(particle.Red, 0, 1) * 255);
+        var green = (float)(Math.Clamp(particle.Green, 0, 1) * 255);
+        var blue = (float)(Math.Clamp(particle.Blue, 0, 1) * 255);
+        for (var y = (int)top; y <= (int)bottom; y++)
+        {
+            var py = (y + 0.5 - particle.Position.Y) / particle.Radius;
+            for (var x = (int)left; x <= (int)right; x++)
+            {
+                var px = (x + 0.5 - particle.Position.X) / particle.Radius;
+                var radius = Math.Sqrt(px * px + py * py);
+                if (radius >= 1)
+                    continue;
+                var derivative = radius > 0.000001
+                    ? (Math.Abs(px) + Math.Abs(py)) / (radius * particle.Radius)
+                    : 1 / particle.Radius;
+                var antialias = Math.Max(derivative * 1.35, 0.006);
+                var mask = 1 - SmoothStep(1 - antialias, 1 + antialias, radius);
+                var alpha = (float)(mask * Math.Pow(1 - radius, exponent) * peakAlpha);
+                if (alpha < 0.001f)
+                    continue;
+                var index = (y * Width + x) * 3;
+                _composite[index] += (red - _composite[index]) * alpha;
+                _composite[index + 1] += (green - _composite[index + 1]) * alpha;
+                _composite[index + 2] += (blue - _composite[index + 2]) * alpha;
+            }
+        }
+    }
+
+    private static double SmoothStep(double lower, double upper, double value)
+    {
+        var amount = Math.Clamp((value - lower) / (upper - lower), 0, 1);
+        return amount * amount * (3 - 2 * amount);
+    }
+
+    private static byte Quantize(float value, float rounding) => (byte)Math.Clamp((int)(value + rounding), 0, 255);
+
+    private static byte Noise(int x, int y)
+    {
+        unchecked
+        {
+            var value = (uint)x * 0x1f123bb5u ^ (uint)y * 0x5f356495u ^ 0x57495350u;
+            value ^= value >> 16;
+            value *= 0x7feb352du;
+            value ^= value >> 15;
+            value *= 0x846ca68bu;
+            value ^= value >> 16;
+            return (byte)(value >> 24);
+        }
+    }
+}

--- a/src/Wisp.App/AmbientBackdropScene.cs
+++ b/src/Wisp.App/AmbientBackdropScene.cs
@@ -1,79 +1,67 @@
 namespace Wisp.App;
 
-internal enum AmbientParticleLayer : byte
-{
-    Far,
-    Middle,
-    Near
-}
-
 internal readonly record struct AmbientPoint(double X, double Y);
 internal readonly record struct AmbientParticle(
     AmbientPoint Position,
     double Radius,
-    int Shade,
-    AmbientParticleLayer Layer);
+    double Opacity,
+    double Softness,
+    double Red,
+    double Green,
+    double Blue);
 
 internal sealed class AmbientBackdropScene
 {
-    internal const int FarParticleCount = 40;
-    internal const int MiddleParticleCount = 72;
-    internal const int NearParticleCount = 128;
-    internal const int ParticleCount = FarParticleCount + MiddleParticleCount + NearParticleCount;
-    internal const int PaletteSize = 32;
-
-    private const double RibbonBaseY = 0.69;
-    private const double RibbonSlope = -0.30;
-    private const double PrimaryAmplitude = 0.085;
-    private const double PrimarySpatialFrequency = 0.83;
-    private const double PrimaryPhase = 0.08;
-    private const double PrimaryPeriodSeconds = 72;
-    private const double SecondaryAmplitude = 0.028;
-    private const double SecondarySpatialFrequency = 2.15;
-    private const double SecondaryPhase = 0.31;
-    private const double SecondaryPeriodSeconds = 53;
+    internal const int ParticleCount = 2048;
+    private const double BoundX = 4.35;
+    private const double BoundY = 4.05;
+    private const double BoundZ = 1.65;
+    private const double HorizontalExtent = BoundX * 0.93;
+    private const double VerticalExtent = BoundY * 0.86;
+    private const double DepthExtent = BoundZ * 0.84;
     private const double PointerRadius = 0.22;
+    private static readonly double[] StreamCenters = [-0.72, -0.48, -0.2, 0.08, 0.35, 0.6, 0.79];
 
-    private static readonly double[] GroupCenters = [0.08, 0.27, 0.49, 0.72, 0.93];
-    private static readonly double[] GroupHalfWidths = [0.085, 0.065, 0.085, 0.070, 0.080];
-
+    private readonly StreamSeed[] _streams = new StreamSeed[StreamCenters.Length];
     private readonly ParticleSeed[] _seeds = new ParticleSeed[ParticleCount];
     private readonly AmbientParticle[] _particles = new AmbientParticle[ParticleCount];
     private int _particleCount;
 
     internal AmbientBackdropScene(uint seed = 0x57495350)
     {
-        var state = seed;
+        var streamState = seed ^ 0xd1b54a35;
+        var commonPhase = Next(ref streamState) * Math.Tau;
+        for (var index = 0; index < _streams.Length; index++)
+        {
+            _streams[index] = new StreamSeed(
+                StreamCenters[index] + (Next(ref streamState) - 0.5) * 0.13,
+                0.1 + Next(ref streamState) * 0.13,
+                0.72 + Next(ref streamState) * 0.48,
+                commonPhase + Next(ref streamState) * 1.7 + index * 0.61,
+                0.085 + Next(ref streamState) * 0.055,
+                0.12 + Next(ref streamState) * 0.08,
+                0.61 + Next(ref streamState) * 0.52,
+                commonPhase * 0.73 + Next(ref streamState) * 2.1 + index * 0.47);
+        }
+
+        var shaderState = seed;
+        var shaderX = Next(ref shaderState) * 97;
+        var shaderY = Next(ref shaderState) * 97;
+        var particleState = seed ^ 0xa53c9e17;
         for (var index = 0; index < ParticleCount; index++)
         {
-            var layer = Layer(index);
-            var layerIndex = LayerIndex(index, layer);
-            var connector = (layerIndex + (int)layer * 2) % 7 == 0;
-            var group = (layerIndex * 3 + (int)layer * 2) % GroupCenters.Length;
-            var along = connector
-                ? 0.03 + Fraction((layerIndex + 0.5) * 0.61803398875 + Next(ref state) * 0.07) * 0.94
-                : GroupCenters[group] + Bell3(ref state) * GroupHalfWidths[group];
-            var across = Bell3(ref state) * RibbonHalfWidth(layer) * (connector ? 0.72 : 1.0);
-            var radius = layer switch
-            {
-                AmbientParticleLayer.Far => 3.0 + Next(ref state) * 7.5,
-                AmbientParticleLayer.Middle => 1.4 + Next(ref state) * 2.8,
-                _ => 0.55 + Next(ref state) * 1.65
-            };
-            var light = layer switch
-            {
-                AmbientParticleLayer.Far => 0.12 + Next(ref state) * 0.33,
-                AmbientParticleLayer.Middle => 0.25 + Next(ref state) * 0.45,
-                _ => 0.42 + Next(ref state) * 0.58
-            };
+            var progress = Math.Pow(Next(ref particleState), 1.78);
+            var streamIndex = (int)(Next(ref particleState) * _streams.Length);
+            var verticalNoise = Centered(ref particleState) * _streams[streamIndex].Spread;
+            var depthNoise = Centered(ref particleState) * 1.02;
+            var velocityVariation = Next(ref particleState);
+            var life = Math.Clamp(1 - progress * (0.93 + Next(ref particleState) * 0.2), 0.025, 0.995);
             _seeds[index] = new ParticleSeed(
-                Math.Clamp(along, 0.015, 0.985),
-                across,
-                radius,
-                light,
-                layer,
-                Next(ref state) * Math.Tau,
-                CreateMotion(ref state));
+                streamIndex, progress, verticalNoise, depthNoise, life,
+                Mix(0.012, 0.026, velocityVariation),
+                Hash21(index % 64 + shaderX, index / 64 + shaderY));
+            _ = Next(ref particleState);
+            _ = Next(ref particleState);
         }
     }
 
@@ -82,212 +70,130 @@ internal sealed class AmbientBackdropScene
     internal void Update(double width, double height, double seconds) =>
         Update(width, height, seconds, default, 0);
 
-    internal void Update(
-        double width,
-        double height,
-        double seconds,
-        AmbientPoint pointer,
-        double pointerActivity)
+    internal void Update(double width, double height, double seconds, AmbientPoint pointer, double pointerActivity)
     {
         _particleCount = 0;
         if (!double.IsFinite(width) || !double.IsFinite(height) || width <= 0 || height <= 0)
-        {
             return;
-        }
 
         seconds = NormalizeTime(seconds);
-        var minimumDimension = Math.Min(width, height);
-        var scale = Math.Clamp(minimumDimension / 720, 0.72, 1.35);
-        pointerActivity = ValidPointer(pointer)
-            ? Math.Clamp(double.IsFinite(pointerActivity) ? pointerActivity : 0, 0, 1)
+        pointerActivity = ValidPointer(pointer) && double.IsFinite(pointerActivity)
+            ? Math.Clamp(pointerActivity, 0, 1)
             : 0;
 
         for (var index = 0; index < ParticleCount; index++)
         {
             var seed = _seeds[index];
-            var parallax = LayerCoupling(seed.Layer);
-            var alongNoise = Noise(
-                seconds / seed.Motion.XSeconds + seed.Motion.Offset,
-                seed.Motion.Key);
-            var alongOscillation = Math.Sin(
-                seconds / seed.Motion.WaveSeconds * Math.Tau + seed.Phase);
-            var along = Math.Clamp(
-                seed.Along + parallax * (alongNoise * 0.014 + alongOscillation * 0.006),
-                0.012,
-                0.988);
-            var center = RibbonCenter(along, seconds);
-            var derivative = RibbonDerivative(along, seconds);
-            var tangentX = width;
-            var tangentY = derivative * height;
-            var tangentLength = Math.Sqrt(tangentX * tangentX + tangentY * tangentY);
-            var normalX = -tangentY / tangentLength;
-            var normalY = tangentX / tangentLength;
-            var acrossNoise = Noise(
-                seconds / seed.Motion.YSeconds + seed.Motion.Offset,
-                seed.Motion.Key ^ 0x9E3779B9);
-            var acrossWave = Math.Sin(
-                seconds / (seed.Motion.WaveSeconds * 1.23) * Math.Tau + seed.Phase * 0.63);
-            var across = seed.Across + parallax * (acrossNoise * 0.012 + acrossWave * 0.0045);
-            var offset = across * minimumDimension;
-            var x = width * along + normalX * offset;
-            var y = height * center + normalY * offset;
-            ApplyPointer(ref x, ref y, width, height, pointer, pointerActivity, seed.Layer);
-            var shimmer = 0.88 + 0.12 * Noise(
-                seconds / 29 + seed.Motion.Offset,
-                seed.Motion.Key ^ 0x68E31DA4);
-            _particles[index] = new AmbientParticle(
-                new AmbientPoint(x, y),
-                seed.Radius * scale,
-                Shade(seed.Light * shimmer),
-                seed.Layer);
+            var stream = _streams[seed.StreamIndex];
+            var lifetimeProgress = 1 - seed.Life + seconds * seed.LifeRate;
+            var age = Fraction(lifetimeProgress);
+            var life = 1 - age;
+            // The website's mature stream distribution is present immediately.
+            // Analytic paths keep CPU work bounded; respawns occur only at the faded life boundary.
+            var progress = lifetimeProgress < 1
+                ? seed.Progress + seconds * seed.LifeRate
+                : age;
+            var streamAngle = progress * Math.Tau * stream.Frequency + stream.Phase;
+            var depthAngle = progress * Math.Tau * stream.DepthFrequency + stream.DepthPhase;
+            var x = -HorizontalExtent + progress * HorizontalExtent * 2;
+            var y = Math.Clamp(stream.Center + Math.Sin(streamAngle) * stream.Amplitude + seed.VerticalNoise,
+                -0.98, 0.98) * VerticalExtent;
+            var z = Math.Clamp(-0.02 + Math.Sin(depthAngle) * stream.DepthAmplitude + seed.DepthNoise,
+                -0.98, 0.98) * DepthExtent;
+            var particle = Project(x, y, z, life, seed.Variation, width, height);
+            var position = particle.Position;
+            ApplyPointer(ref position, width, height, pointer, pointerActivity, SmoothStep(-BoundZ, BoundZ, z));
+            _particles[index] = particle with { Position = position };
         }
         _particleCount = ParticleCount;
     }
 
-    internal static double RibbonCenter(double along, double seconds)
+    // Depth, perspective, point size, life envelope, and material match the production website shader.
+    internal static AmbientParticle Project(
+        double x, double y, double z, double life, double variation, double width, double height)
     {
-        along = Math.Clamp(double.IsFinite(along) ? along : 0.5, 0, 1);
-        seconds = NormalizeTime(seconds);
-        var primary = Math.Tau *
-            (along * PrimarySpatialFrequency + PrimaryPhase + seconds / PrimaryPeriodSeconds);
-        var secondary = Math.Tau *
-            (along * SecondarySpatialFrequency + SecondaryPhase - seconds / SecondaryPeriodSeconds);
-        return RibbonBaseY + RibbonSlope * along +
-            PrimaryAmplitude * Math.Sin(primary) +
-            SecondaryAmplitude * Math.Sin(secondary);
+        var viewDepth = Math.Max(1, 5 - z);
+        var depth = SmoothStep(-BoundZ, BoundZ, z);
+        var focusDistance = Math.Abs(depth - 0.56);
+        var pointSize = (Mix(1.15, 4.4, depth) + Math.Pow(focusDistance, 1.38) * 31) * height / 900;
+        var lifeEnvelope = SmoothStep(0, 0.016, 1 - life) * SmoothStep(0, 0.024, life);
+        var focusOpacity = Mix(0.115, 0.34, 1 - SmoothStep(0.08, 0.48, focusDistance));
+        var areaCompensation = 1 / Math.Sqrt(Math.Max(1, pointSize * 0.20));
+        var opacity = lifeEnvelope * focusOpacity * areaCompensation * Mix(0.78, 1.15, variation);
+        var softness = Mix(0.82, 0.18, 1 - SmoothStep(0.04, 0.46, focusDistance));
+        var colorFocus = 1 - focusDistance;
+        return new AmbientParticle(
+            new AmbientPoint((x * 1.7320508 / viewDepth + 1) * width / 2,
+                (1 - y * 1.7320508 / viewDepth) * height / 2),
+            Math.Clamp(pointSize, 1, 42) / 2,
+            opacity, softness,
+            Mix(0.25, 0.54, colorFocus),
+            Mix(0.40, 0.60, colorFocus),
+            Mix(0.39, 0.60, colorFocus));
     }
 
-    // Independent long-period paths avoid a short synchronized scene reset.
     internal static double NormalizeTime(double seconds) =>
         double.IsFinite(seconds) && seconds >= 0 ? seconds : 0;
 
-    private static double RibbonDerivative(double along, double seconds)
-    {
-        var primary = Math.Tau *
-            (along * PrimarySpatialFrequency + PrimaryPhase + seconds / PrimaryPeriodSeconds);
-        var secondary = Math.Tau *
-            (along * SecondarySpatialFrequency + SecondaryPhase - seconds / SecondaryPeriodSeconds);
-        return RibbonSlope +
-            PrimaryAmplitude * Math.Tau * PrimarySpatialFrequency * Math.Cos(primary) +
-            SecondaryAmplitude * Math.Tau * SecondarySpatialFrequency * Math.Cos(secondary);
-    }
-
     private static void ApplyPointer(
-        ref double x,
-        ref double y,
-        double width,
-        double height,
-        AmbientPoint pointer,
-        double activity,
-        AmbientParticleLayer layer)
+        ref AmbientPoint position, double width, double height,
+        AmbientPoint pointer, double activity, double depth)
     {
         if (activity <= 0)
             return;
         var minimumDimension = Math.Min(width, height);
-        var deltaX = x - pointer.X * width;
-        var deltaY = y - pointer.Y * height;
+        var deltaX = position.X - pointer.X * width;
+        var deltaY = position.Y - pointer.Y * height;
         var radius = minimumDimension * PointerRadius;
         var distanceSquared = deltaX * deltaX + deltaY * deltaY;
         if (distanceSquared <= 0.0001 || distanceSquared >= radius * radius)
             return;
         var distance = Math.Sqrt(distanceSquared);
-        var influence = 1 - distance / radius;
-        influence = influence * influence * (3 - 2 * influence) * activity * LayerCoupling(layer);
+        var influence = SmoothStep(0, 1, 1 - distance / radius) * activity * Mix(0.38, 1, depth);
         var directionX = deltaX / distance;
         var directionY = deltaY / distance;
-        var tangentX = -directionY;
-        var tangentY = directionX;
-        x += (directionX * 0.88 + tangentX * 0.12) * minimumDimension * 0.010 * influence;
-        y += (directionY * 0.88 + tangentY * 0.12) * minimumDimension * 0.007 * influence;
+        position = new AmbientPoint(
+            position.X + (directionX * 0.88 - directionY * 0.12) * minimumDimension * 0.010 * influence,
+            position.Y + (directionY * 0.88 + directionX * 0.12) * minimumDimension * 0.007 * influence);
     }
 
     private static bool ValidPointer(AmbientPoint pointer) =>
         double.IsFinite(pointer.X) && double.IsFinite(pointer.Y) &&
         pointer.X >= 0 && pointer.X <= 1 && pointer.Y >= 0 && pointer.Y <= 1;
 
-    private static double LayerCoupling(AmbientParticleLayer layer) => layer switch
+    private static double SmoothStep(double edge0, double edge1, double value)
     {
-        AmbientParticleLayer.Far => 0.35,
-        AmbientParticleLayer.Middle => 0.65,
-        _ => 1.0
-    };
-
-    private static double RibbonHalfWidth(AmbientParticleLayer layer) => layer switch
-    {
-        AmbientParticleLayer.Far => 0.18,
-        AmbientParticleLayer.Middle => 0.105,
-        _ => 0.055
-    };
-
-    private static AmbientParticleLayer Layer(int index) => index switch
-    {
-        < FarParticleCount => AmbientParticleLayer.Far,
-        < FarParticleCount + MiddleParticleCount => AmbientParticleLayer.Middle,
-        _ => AmbientParticleLayer.Near
-    };
-
-    private static int LayerIndex(int index, AmbientParticleLayer layer) => layer switch
-    {
-        AmbientParticleLayer.Far => index,
-        AmbientParticleLayer.Middle => index - FarParticleCount,
-        _ => index - FarParticleCount - MiddleParticleCount
-    };
-
-    private static MotionSeed CreateMotion(ref uint state) => new(
-        Hash(state),
-        18 + Next(ref state) * 26,
-        24 + Next(ref state) * 34,
-        28 + Next(ref state) * 42,
-        Next(ref state) * 80);
-
-    private static double Noise(double coordinate, uint key)
-    {
-        var cell = Math.Floor(coordinate);
-        var blend = coordinate - cell;
-        blend = blend * blend * blend * (blend * (blend * 6 - 15) + 10);
-        var a = NoiseSample(cell, key);
-        return a + (NoiseSample(cell + 1, key) - a) * blend;
+        var t = Math.Clamp((value - edge0) / (edge1 - edge0), 0, 1);
+        return t * t * (3 - 2 * t);
     }
 
-    private static double NoiseSample(double cell, uint key)
-    {
-        var bits = unchecked((ulong)BitConverter.DoubleToInt64Bits(cell));
-        return Hash(key ^ (uint)bits ^ (uint)(bits >> 32)) / (double)uint.MaxValue * 2 - 1;
-    }
-
-    private static uint Hash(uint value)
-    {
-        value = unchecked((value ^ (value >> 16)) * 0x7FEB352D);
-        value = unchecked((value ^ (value >> 15)) * 0x846CA68B);
-        return value ^ (value >> 16);
-    }
+    private static double Mix(double a, double b, double weight) => a + (b - a) * weight;
+    private static double Fraction(double value) => value - Math.Floor(value);
 
     private static double Next(ref uint state)
     {
-        state = unchecked(state * 1664525 + 1013904223);
-        return state / (double)uint.MaxValue;
+        state = unchecked(state + 0x6d2b79f5);
+        var value = unchecked((state ^ (state >> 15)) * (state | 1));
+        value ^= unchecked(value + ((value ^ (value >> 7)) * (value | 61)));
+        return (value ^ (value >> 14)) / 4294967296.0;
     }
 
-    private static double Bell3(ref uint state) =>
-        ((Next(ref state) + Next(ref state) + Next(ref state)) / 3 - 0.5) * 2;
+    private static double Centered(ref uint state) =>
+        Next(ref state) + Next(ref state) + Next(ref state) + Next(ref state) - 2;
 
-    private static double Fraction(double value) => value - Math.Floor(value);
-    private static int Shade(double light) =>
-        (int)Math.Round(Math.Clamp(light, 0, 1) * (PaletteSize - 1));
+    private static double Hash21(double x, double y)
+    {
+        x = Fraction(x * 123.34);
+        y = Fraction(y * 456.21);
+        var dot = x * (x + 45.32) + y * (y + 45.32);
+        return Fraction((x + dot) * (y + dot));
+    }
 
-    private readonly record struct MotionSeed(
-        uint Key,
-        double XSeconds,
-        double YSeconds,
-        double WaveSeconds,
-        double Offset);
+    private readonly record struct StreamSeed(
+        double Center, double Amplitude, double Frequency, double Phase, double Spread,
+        double DepthAmplitude, double DepthFrequency, double DepthPhase);
 
     private readonly record struct ParticleSeed(
-        double Along,
-        double Across,
-        double Radius,
-        double Light,
-        AmbientParticleLayer Layer,
-        double Phase,
-        MotionSeed Motion);
+        int StreamIndex, double Progress, double VerticalNoise, double DepthNoise,
+        double Life, double LifeRate, double Variation);
 }

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -39,7 +39,7 @@ public sealed class AppController : IAsyncDisposable
     private readonly CancellationTokenSource _compatibilityLifetime = new();
     private readonly WispUpdateClient _applicationUpdates = WispUpdateClient.CreateDefault();
     private readonly CancellationTokenSource _applicationUpdateLifetime = new();
-    private readonly Dictionary<int, RollingRadii> _savedCalibrationRadii;
+    private readonly Dictionary<int, CalibrationPersistenceIdentity> _capturedCalibrationProfiles;
     private readonly Dispatcher _dispatcher;
     private readonly DispatcherTimer _uiTimer;
     private readonly DispatcherTimer _settingsSaveTimer;
@@ -86,6 +86,7 @@ public sealed class AppController : IAsyncDisposable
     private int _applicationUpdateOperation;
     private UpdateRelease? _availableApplicationRelease;
     private VerifiedInstaller? _pendingInstaller;
+    private ApplicationUpdateDetails? _pendingApplicationUpdateDetails;
     private string? _compatibilityImportStatus;
     private DateTimeOffset _tractionCueUntilUtc = DateTimeOffset.MinValue;
     private ReceiverStatistics _cachedStatistics;
@@ -116,22 +117,7 @@ public sealed class AppController : IAsyncDisposable
         _startupRegistrationService = startupRegistrationService;
         SetupTelemetry = new SetupTelemetryTest(new SetupTelemetrySource(_receiver));
         _calibration.ImportSnapshots(settings.Calibrations);
-        _savedCalibrationRadii = settings.Calibrations
-            .Where(snapshot =>
-                snapshot.Drivetrain is { } drivetrain &&
-                RollingRadiusEstimator.TrySnapshotRadii(snapshot, drivetrain, out _))
-            .GroupBy(snapshot => snapshot.CarOrdinal)
-            .ToDictionary(
-                group => group.Key,
-                group =>
-                {
-                    var snapshot = group.Last();
-                    _ = RollingRadiusEstimator.TrySnapshotRadii(
-                        snapshot,
-                        snapshot.Drivetrain!.Value,
-                        out var radii);
-                    return radii;
-                });
+        _capturedCalibrationProfiles = CalibrationPersistenceIdentity.Capture(_calibration);
         var debugLoggingNowUtc = DateTimeOffset.UtcNow;
         if (settings.DebugLoggingEnabled && settings.DebugLoggingExpiresAtUtc is { } debugLoggingExpiry &&
             debugLoggingExpiry > debugLoggingNowUtc)
@@ -457,7 +443,9 @@ public sealed class AppController : IAsyncDisposable
     {
         if (_pendingInstaller is { } pending && File.Exists(pending.StagedPath))
         {
-            return new ApplicationUpdateDetails(pending.Version.ToString(), string.Empty);
+            return _pendingApplicationUpdateDetails is { } details && details.Version == pending.Version.ToString()
+                ? details
+                : new ApplicationUpdateDetails(pending.Version.ToString(), string.Empty);
         }
 
         if (_availableApplicationRelease is { } available)
@@ -497,8 +485,8 @@ public sealed class AppController : IAsyncDisposable
                 _availableApplicationRelease = null;
                 ViewModel.UpdateApplicationUpdateStatus(
                     Settings.AutomaticApplicationUpdateChecks
-                        ? $"Wisp {installedVersion.Major}.{installedVersion.Minor}.{installedVersion.Build} is current. Automatic checks run once daily."
-                        : $"Wisp {installedVersion.Major}.{installedVersion.Minor}.{installedVersion.Build} is current.",
+                        ? $"Wisp {ApplicationVersionInfo.Format(installedVersion)} is current. Automatic checks run once daily."
+                        : $"Wisp {ApplicationVersionInfo.Format(installedVersion)} is current.",
                     "Check again",
                     canCheck: true);
                 return null;
@@ -506,7 +494,7 @@ public sealed class AppController : IAsyncDisposable
 
             _availableApplicationRelease = release;
             ViewModel.UpdateApplicationUpdateStatus(
-                $"Wisp {release.Version} is available. The installer will download only after you confirm.",
+                $"Wisp {ApplicationVersionInfo.Format(release.Version)} is available. The installer will download only after you confirm.",
                 "Update",
                 canCheck: true,
                 isUpdateAvailable: true);
@@ -598,6 +586,7 @@ public sealed class AppController : IAsyncDisposable
             }
 
             _pendingInstaller = null;
+            _pendingApplicationUpdateDetails = null;
             if (_availableApplicationRelease is not { } release)
             {
                 ViewModel.UpdateApplicationUpdateStatus(
@@ -611,7 +600,7 @@ public sealed class AppController : IAsyncDisposable
             var progress = new Progress<UpdateDownloadProgress>(value =>
             {
                 ViewModel.UpdateApplicationUpdateStatus(
-                    $"Downloading Wisp {release.Version} — {Math.Clamp(value.Percentage, 0, 100):0}%",
+                    $"Downloading Wisp {ApplicationVersionInfo.Format(release.Version)} — {Math.Clamp(value.Percentage, 0, 100):0}%",
                     "Downloading…",
                     canCheck: false);
             });
@@ -620,9 +609,10 @@ public sealed class AppController : IAsyncDisposable
                 createdAttemptDirectory,
                 progress,
                 _applicationUpdateLifetime.Token);
+            _pendingApplicationUpdateDetails = ApplicationUpdateDetailsFrom(release);
             _availableApplicationRelease = null;
             ViewModel.UpdateApplicationUpdateStatus(
-                $"Wisp {_pendingInstaller.Version} is verified and ready to install.",
+                $"Wisp {ApplicationVersionInfo.Format(_pendingInstaller.Version)} is verified and ready to install.",
                 "Install update",
                 canCheck: true,
                 isUpdateAvailable: true);
@@ -1639,7 +1629,7 @@ public sealed class AppController : IAsyncDisposable
         }
 
         _calibration.ResetProfile(carOrdinal);
-        _savedCalibrationRadii.Remove(carOrdinal);
+        _capturedCalibrationProfiles.Remove(carOrdinal);
         Settings.Calibrations = _calibration.ExportSnapshots().ToList();
         _speedModel.Reset();
         _tractionHookDetector.Reset();
@@ -1930,8 +1920,9 @@ public sealed class AppController : IAsyncDisposable
             _nextDiagnosticsAtUtc = now + TimeSpan.FromMilliseconds(250);
         }
 
-        var connectionState = _freshness.GetState(now);
-        var age = _freshness.GetAge(now);
+        var nowTimestamp = Stopwatch.GetTimestamp();
+        var connectionState = _freshness.GetState(nowTimestamp);
+        var age = _freshness.GetAge(nowTimestamp);
         CaptureDebugSample(now, latest, connectionState, age);
         var hasFreshTelemetry = latest is not null &&
                                 connectionState == TelemetryConnectionState.Connected &&
@@ -2129,12 +2120,16 @@ public sealed class AppController : IAsyncDisposable
             // transitions, so persist every real transition. A coarse save
             // tolerance can otherwise discard a small but meaningful parity
             // correction and resurrect the old radius after restart.
-            var profileChanged = !_savedCalibrationRadii.TryGetValue(current.CarOrdinal, out var savedRadii) ||
-                                 RadiiDiffer(radii, savedRadii, 1e-9);
+            var identity = new CalibrationPersistenceIdentity(
+                current.Drivetrain,
+                RollingRadiusEstimator.CurrentCalibrationRevision,
+                radii);
+            var profileChanged = !_capturedCalibrationProfiles.TryGetValue(current.CarOrdinal, out var captured) ||
+                                 !captured.Matches(identity);
             if (profileChanged)
             {
                 Settings.Calibrations = _calibration.ExportSnapshots().ToList();
-                _savedCalibrationRadii[current.CarOrdinal] = radii;
+                _capturedCalibrationProfiles[current.CarOrdinal] = identity;
                 _settingsSaveTimer.Stop();
                 SaveSettings();
             }
@@ -2392,10 +2387,6 @@ public sealed class AppController : IAsyncDisposable
                 : $"On — expires in {hours} h · local only");
     }
 
-    private static bool RadiiDiffer(RollingRadii first, RollingRadii second, double tolerance) =>
-        Math.Abs(first.FrontMeters - second.FrontMeters) / first.FrontMeters > tolerance ||
-        Math.Abs(first.RearMeters - second.RearMeters) / first.RearMeters > tolerance;
-
     internal static bool ShouldPreserveHudVisuals(
         bool nativeHudTelemetryActive,
         TelemetryConnectionState connectionState,
@@ -2545,7 +2536,7 @@ public sealed class AppController : IAsyncDisposable
             ? focus.ForegroundWindow
             : _lastConfirmedForzaWindow;
         var forzaWindowKnown = WindowZOrder.IsWindowAvailable(confirmedForzaWindow);
-        var telemetryFresh = _freshness.GetState(now) == TelemetryConnectionState.Connected;
+        var telemetryFresh = _freshness.GetState(Stopwatch.GetTimestamp()) == TelemetryConnectionState.Connected;
         var nativeVisibility = EvaluateNativeGameplayVisibility(
             _nativeHudProcessService.SnapshotFor(_receiver.Latest?.CarOrdinal ?? 0),
             Stopwatch.GetTimestamp());
@@ -2742,7 +2733,7 @@ public sealed class AppController : IAsyncDisposable
         _lastFreshnessState = latest;
         if (ShouldRecordTelemetryActivity(previous, latest))
         {
-            _freshness.RecordPacket(latest.ReceivedAtUtc);
+            _freshness.RecordPacket(latest.ReceivedTimestamp);
         }
     }
 
@@ -2797,16 +2788,27 @@ public sealed class AppController : IAsyncDisposable
         ViewModel.ClearHudVisuals();
     }
 
-    private void SaveSettings()
+    internal bool TrySavePendingSettings()
+    {
+        if (_disposed)
+        {
+            return false;
+        }
+        _settingsSaveTimer.Stop();
+        return SaveSettings();
+    }
+
+    private bool SaveSettings()
     {
         if (Settings.RequiresSetup)
         {
-            return;
+            return false;
         }
 
         try
         {
             _saveSettings(Settings);
+            return true;
         }
         catch (IOException)
         {
@@ -2820,6 +2822,7 @@ public sealed class AppController : IAsyncDisposable
         {
             // Local policy can temporarily block the settings directory.
         }
+        return false;
     }
 
     private void ScheduleSettingsSave()

--- a/src/Wisp.App/ApplicationVersionInfo.cs
+++ b/src/Wisp.App/ApplicationVersionInfo.cs
@@ -1,0 +1,21 @@
+using Wisp.Update;
+
+namespace Wisp.App;
+
+public static class ApplicationVersionInfo
+{
+    public static string DisplayVersion => Format(
+        typeof(ApplicationVersionInfo).Assembly.GetName().Version ?? new Version(1, 0, 0));
+
+    public static string FooterText => $"WHEEL-INDICATED SPEED PANEL {DisplayVersion}";
+
+    public static string ReleaseHistoryIntroduction =>
+        $"Feature updates, hotfixes, and important refinements from every documented public release. The current {DisplayVersion} entry covers this release.";
+
+    public static string Format(Version version) => Format(
+        new SemanticVersion(version.Major, version.Minor, Math.Max(0, version.Build)));
+
+    public static string Format(SemanticVersion version) => version.Patch == 0
+        ? $"{version.Major}.{version.Minor}"
+        : version.ToString();
+}

--- a/src/Wisp.App/DiagnosticsViewModel.cs
+++ b/src/Wisp.App/DiagnosticsViewModel.cs
@@ -618,14 +618,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     public bool TractionCueEnabled { get => _tractionCueEnabled; set => Set(ref _tractionCueEnabled, value); }
     public bool IsTractionCueActive { get => _isTractionCueActive; set => Set(ref _isTractionCueActive, value); }
     public bool CanRelearnCurrentTires { get => _canRelearnCurrentTires; private set => Set(ref _canRelearnCurrentTires, value); }
-    public string InstalledApplicationVersion
-    {
-        get
-        {
-            var version = typeof(DiagnosticsViewModel).Assembly.GetName().Version ?? new Version(1, 0, 0);
-            return $"{version.Major}.{version.Minor}.{Math.Max(0, version.Build)}";
-        }
-    }
+    public string InstalledApplicationVersion => ApplicationVersionInfo.DisplayVersion;
     public string ApplicationUpdateStatus
     {
         get => _applicationUpdateStatus;

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1841,7 +1841,7 @@
                                         <StackPanel>
                                             <TextBlock Text="VERSION HISTORY" Style="{StaticResource EyebrowTextStyle}" />
                                             <TextBlock Text="What changed in Wisp" Style="{StaticResource SectionTitleStyle}" Margin="0,4,0,0" />
-                                            <TextBlock Text="Feature updates, hotfixes, and important refinements from every documented public release. The current 1.0.12 entry summarizes this release."
+                                            <TextBlock Text="{x:Static local:ApplicationVersionInfo.ReleaseHistoryIntroduction}"
                                                        Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap"
                                                        LineHeight="19" Margin="0,7,0,0" />
                                         </StackPanel>
@@ -1863,17 +1863,17 @@
                                                     </Border.Style>
                                                     <Grid>
                                                         <Grid.ColumnDefinitions>
-                                                            <ColumnDefinition Width="138" />
+                                                            <ColumnDefinition Width="Auto" MinWidth="160" MaxWidth="240" />
                                                             <ColumnDefinition Width="*" />
                                                         </Grid.ColumnDefinitions>
                                                         <StackPanel Margin="0,0,22,0">
                                                             <Border Background="{DynamicResource RaisedBrush}" CornerRadius="6"
                                                                     Padding="8,4" HorizontalAlignment="Left">
-                                                                <TextBlock Text="{Binding Label}" FontSize="9" FontWeight="Bold"
+                                                                <TextBlock Text="{Binding Label}" FontSize="9" FontWeight="Bold" TextWrapping="Wrap"
                                                                            Foreground="{DynamicResource AccentBrush}" />
                                                             </Border>
-                                                            <TextBlock Text="{Binding Version, StringFormat=Version {0}}"
-                                                                       FontSize="20" FontWeight="SemiBold" Margin="0,12,0,0" />
+                                                            <TextBlock x:Name="ReleaseVersionText" Text="{Binding Version, StringFormat=Version {0}}"
+                                                                       FontSize="20" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,12,0,0" />
                                                             <TextBlock Text="{Binding Date}" Foreground="{DynamicResource FaintBrush}"
                                                                        FontSize="10" TextWrapping="Wrap" Margin="0,5,0,0" />
                                                         </StackPanel>
@@ -2027,7 +2027,7 @@
             <Grid Grid.Row="2" Margin="29,0">
                 <TextBlock Text="LOCAL DATA OUT  ·  READ-ONLY NATIVE HUD  ·  NO INJECTION" VerticalAlignment="Center"
                            FontSize="9" FontWeight="SemiBold" Foreground="{DynamicResource FaintBrush}" />
-                <TextBlock Text="WHEEL-INDICATED SPEED PANEL 1.0.12" HorizontalAlignment="Right" VerticalAlignment="Center"
+                <TextBlock x:Name="ApplicationVersionFooter" Text="{x:Static local:ApplicationVersionInfo.FooterText}" HorizontalAlignment="Right" VerticalAlignment="Center"
                            FontSize="10" Foreground="{DynamicResource FaintBrush}" />
             </Grid>
         </Grid>

--- a/src/Wisp.App/MainWindow.xaml.cs
+++ b/src/Wisp.App/MainWindow.xaml.cs
@@ -30,6 +30,8 @@ public partial class MainWindow : Window
     private IInputElement? _focusBeforeHudProfileDialog;
     private Guid? _activeHudProfileId;
     private HudProfileDialogMode _hudProfileDialogMode;
+    private bool _hudProfileChangePending;
+    private string? _pendingHudProfileName;
     private bool _capturingOverlayHotkey;
     private bool _updatingColorEditors;
 
@@ -345,6 +347,9 @@ public partial class MainWindow : Window
     private void ShowHudProfileDialog(HudProfileDialogMode mode, HudPreset? profile = null)
     {
         _hudProfileDialogMode = mode;
+        _hudProfileChangePending = false;
+        _pendingHudProfileName = null;
+        HudProfileNameInput.IsEnabled = true;
         _activeHudProfileId = profile?.Id;
         _focusBeforeHudProfileDialog = Keyboard.FocusedElement;
         HudProfileDialogError.Text = string.Empty;
@@ -420,8 +425,8 @@ public partial class MainWindow : Window
     private void ConfirmHudProfileDialog_Click(object sender, RoutedEventArgs e)
     {
         HudPreset? savedProfile = null;
-        string error;
-        var succeeded = _hudProfileDialogMode switch
+        string error = string.Empty;
+        var succeeded = _hudProfileChangePending || (_hudProfileDialogMode switch
         {
             HudProfileDialogMode.Create => _controller.TryCreateHudPreset(
                 HudProfileNameInput.Text,
@@ -434,7 +439,7 @@ public partial class MainWindow : Window
             HudProfileDialogMode.Delete when _activeHudProfileId is { } id =>
                 DeleteHudProfile(id, out error),
             _ => FailHudProfileAction(out error)
-        };
+        });
 
         if (!succeeded)
         {
@@ -443,9 +448,25 @@ public partial class MainWindow : Window
             return;
         }
 
+        if (!_hudProfileChangePending)
+        {
+            _pendingHudProfileName = savedProfile?.Name ?? _controller.Settings.HudPresets
+                .FirstOrDefault(profile => profile.Id == _activeHudProfileId)?.Name;
+            _hudProfileChangePending = true;
+            HudProfileNameInput.IsEnabled = false;
+        }
+        if (!_controller.TrySavePendingSettings())
+        {
+            HudProfileDialogError.Text = "Wisp could not write these changes to disk. Retry to confirm they are saved before closing Wisp.";
+            HudProfileDialogError.Visibility = Visibility.Visible;
+            ConfirmHudProfileButton.Content = "Try again";
+            HudProfileStatusText.Text = "The last profile save attempt failed.";
+            RefreshHudProfileList();
+            return;
+        }
+
         var mode = _hudProfileDialogMode;
-        var profileName = savedProfile?.Name ?? _controller.Settings.HudPresets
-            .FirstOrDefault(profile => profile.Id == _activeHudProfileId)?.Name;
+        var profileName = _pendingHudProfileName;
         HideHudProfileDialog();
         RefreshHudProfileList();
         RootTabs.SelectedItem = ProfilesTab;
@@ -484,6 +505,9 @@ public partial class MainWindow : Window
         HudProfileDialogError.Text = string.Empty;
         HudProfileNameInput.Text = string.Empty;
         _activeHudProfileId = null;
+        _hudProfileChangePending = false;
+        _pendingHudProfileName = null;
+        HudProfileNameInput.IsEnabled = true;
         if (_focusBeforeHudProfileDialog is { } previousFocus)
         {
             Keyboard.Focus(previousFocus);
@@ -632,7 +656,7 @@ public partial class MainWindow : Window
     {
         _applicationUpdateVersion = details.Version;
         _focusBeforeApplicationUpdateConfirmation = Keyboard.FocusedElement;
-        ApplicationUpdateConfirmationVersion.Text = $"Wisp {details.Version}";
+        ApplicationUpdateConfirmationVersion.Text = $"Wisp {ApplicationVersionInfo.Format(Version.Parse(details.Version))}";
         ApplicationUpdateConfirmationSummary.Text = details.ReleaseSummary;
         ApplicationUpdateConfirmationDetails.Visibility = string.IsNullOrWhiteSpace(details.ReleaseSummary)
             ? Visibility.Collapsed

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,28 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.1",
+            "September 6, 2026",
+            "MAINTENANCE",
+            "Focused corrections to settings saves, calibration persistence, and connection timing.",
+            true,
+            [
+                Group("Fixed",
+                    "Profile changes are confirmed only after the settings write succeeds. Failed writes can be retried without creating duplicate profiles.",
+                    "Saved calibration changes now include drivetrain and calibration revision, even when tire radii are unchanged.",
+                    "Windows clock changes no longer affect telemetry expiry.",
+                    "Release details remain available when retrying a downloaded update.",
+                    "Setup uses the website's particle material and depth styling, with smoother faint gradients and a new particle distribution.",
+                    "Wheel-indicated speed smoothing now honors the selected amount during large wheel-speed changes, instead of staying within 1.5 mph of the raw reading.",
+                    "Release version labels no longer clip in the release history.",
+                    "Update checks support shortened release versions and stable release labels while retaining installer verification.")
+            ]),
+        new(
             "1.0.12",
             "September 4, 2026",
             "RELIABILITY",
             "More useful local diagnostic reports and improved Native HUD recovery after race settings.",
-            true,
+            false,
             [
                 Group("Diagnostics",
                     "Collects telemetry reception, UI processing, native-data freshness, composition callbacks, focus transitions, and Wisp CPU and memory usage on a background sampler.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.0.12</Version>
-    <FileVersion>1.0.12.0</FileVersion>
-    <AssemblyVersion>1.0.12.0</AssemblyVersion>
+    <Version>1.1.0</Version>
+    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.12.0" name="Wisp.App" />
+  <assemblyIdentity version="1.1.0.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Core/CalibrationPersistenceIdentity.cs
+++ b/src/Wisp.Core/CalibrationPersistenceIdentity.cs
@@ -1,0 +1,27 @@
+namespace Wisp.Core;
+
+public readonly record struct CalibrationPersistenceIdentity(
+    DrivetrainType Drivetrain,
+    int CalibrationRevision,
+    RollingRadii Radii)
+{
+    private const double RelativeRadiusTolerance = 1e-9;
+
+    public static Dictionary<int, CalibrationPersistenceIdentity> Capture(RollingRadiusEstimator estimator) =>
+        estimator.ExportSnapshots().ToDictionary(
+            snapshot => snapshot.CarOrdinal,
+            snapshot => new CalibrationPersistenceIdentity(
+                snapshot.Drivetrain!.Value,
+                snapshot.CalibrationRevision,
+                new RollingRadii(snapshot.FrontRadiusMeters!.Value, snapshot.RearRadiusMeters!.Value)));
+
+    // Sample-count growth does not change the accepted calibration. Keep
+    // the same radius tolerance used for the estimator's persisted transitions.
+    public bool Matches(CalibrationPersistenceIdentity current) =>
+        Drivetrain == current.Drivetrain &&
+        CalibrationRevision == current.CalibrationRevision &&
+        Math.Abs(current.Radii.FrontMeters - Radii.FrontMeters) / current.Radii.FrontMeters <=
+            RelativeRadiusTolerance &&
+        Math.Abs(current.Radii.RearMeters - Radii.RearMeters) / current.Radii.RearMeters <=
+            RelativeRadiusTolerance;
+}

--- a/src/Wisp.Core/SpeedModel.cs
+++ b/src/Wisp.Core/SpeedModel.cs
@@ -58,8 +58,6 @@ public sealed class SpeedModel
     public const double MetersPerSecondToMilesPerHour = 2.2369362920544;
     public const double MetersPerSecondToKilometersPerHour = 3.6;
     public const double MaximumIndicatedMetersPerSecond = 250.0;
-    public const double MaximumSmoothingDeviationMetersPerSecond =
-        1.5 / MetersPerSecondToMilesPerHour;
 
     private readonly IDrivenWheelSelector _selector;
     private double? _filteredMetersPerSecond;
@@ -133,10 +131,6 @@ public sealed class SpeedModel
                 ? 1.0
                 : 1.0 - Math.Exp(-Math.Clamp(elapsed.TotalSeconds, 0, 0.5) / timeConstantSeconds);
             _filteredMetersPerSecond += (raw - _filteredMetersPerSecond.Value) * alpha;
-            _filteredMetersPerSecond = Math.Clamp(
-                _filteredMetersPerSecond.Value,
-                Math.Max(0, raw - MaximumSmoothingDeviationMetersPerSecond),
-                raw + MaximumSmoothingDeviationMetersPerSecond);
         }
 
         _lastCarOrdinal = state.CarOrdinal;

--- a/src/Wisp.Core/TelemetryFreshness.cs
+++ b/src/Wisp.Core/TelemetryFreshness.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Wisp.Core;
 
 public enum TelemetryConnectionState
@@ -10,30 +12,36 @@ public enum TelemetryConnectionState
 public sealed class TelemetryFreshness
 {
     private readonly TimeSpan _timeout;
-    private DateTimeOffset? _lastPacketAtUtc;
+    private long? _lastPacketTimestamp;
 
     public TelemetryFreshness(TimeSpan? timeout = null)
     {
         _timeout = timeout ?? TimeSpan.FromMilliseconds(750);
     }
 
-    public void RecordPacket(DateTimeOffset receivedAtUtc)
+    public void RecordPacket(long? receivedTimestamp)
     {
-        _lastPacketAtUtc = receivedAtUtc;
+        // Missing arrival evidence cannot establish or extend freshness.
+        if (receivedTimestamp is > 0)
+        {
+            _lastPacketTimestamp = receivedTimestamp;
+        }
     }
 
-    public TelemetryConnectionState GetState(DateTimeOffset nowUtc)
+    public TelemetryConnectionState GetState(long nowTimestamp)
     {
-        if (_lastPacketAtUtc is null)
+        if (_lastPacketTimestamp is null)
         {
             return TelemetryConnectionState.Waiting;
         }
 
-        return nowUtc - _lastPacketAtUtc.Value <= _timeout
+        return GetAge(nowTimestamp) is { } age && age <= _timeout
             ? TelemetryConnectionState.Connected
             : TelemetryConnectionState.Lost;
     }
 
-    public TimeSpan? GetAge(DateTimeOffset nowUtc) =>
-        _lastPacketAtUtc is null ? null : nowUtc - _lastPacketAtUtc.Value;
+    public TimeSpan? GetAge(long nowTimestamp) =>
+        _lastPacketTimestamp is not { } receivedTimestamp || nowTimestamp < receivedTimestamp
+            ? null
+            : Stopwatch.GetElapsedTime(receivedTimestamp, nowTimestamp);
 }

--- a/src/Wisp.Update/GitHubReleaseParser.cs
+++ b/src/Wisp.Update/GitHubReleaseParser.cs
@@ -39,15 +39,8 @@ internal static class GitHubReleaseParser
             throw new UpdateSecurityException("The latest GitHub release is not immutable.");
         }
 
-        if (!SemanticVersion.TryParseTag(release.TagName, out var version))
-        {
-            throw new UpdateSecurityException("The latest GitHub release tag is not strict vX.Y.Z semantic versioning.");
-        }
-
-        var expectedName = ReleaseUriPolicy.InstallerFileName(version);
         var matchingAssets = release.Assets?
-            .Where(asset => asset is not null &&
-                            string.Equals(asset.Name, expectedName, StringComparison.Ordinal))
+            .Where(asset => asset is not null && ReleaseIdentity.IsInstallerAsset(asset.Name))
             .Take(2)
             .ToArray() ?? [];
         if (matchingAssets.Length != 1)
@@ -56,6 +49,13 @@ internal static class GitHubReleaseParser
         }
 
         var asset = matchingAssets[0]!;
+        if (!ReleaseIdentity.TryParseInstallerVersion(asset.Name, out var version))
+        {
+            throw new UpdateSecurityException("The Wisp installer asset must contain an unambiguous stable version.");
+        }
+
+        ReleaseIdentity.RequireMatchingTag(release.TagName, version);
+        ReleaseIdentity.RequireStableTitle(release.Name);
         if (!string.Equals(asset.State, "uploaded", StringComparison.Ordinal))
         {
             throw new UpdateSecurityException("The Wisp installer asset is not in the uploaded state.");
@@ -76,9 +76,9 @@ internal static class GitHubReleaseParser
             throw new UpdateSecurityException("The Wisp installer asset URL is invalid.");
         }
 
-        ReleaseUriPolicy.RequireInitialDownloadUri(downloadUri, version);
+        ReleaseUriPolicy.RequireInitialDownloadUri(downloadUri, release.TagName!, asset.Name!);
         var releaseSummary = ReleaseSummaryFormatter.Format(release.Body);
-        return new UpdateRelease(version, expectedName, asset.Size.Value, sha256, downloadUri, releaseSummary);
+        return new UpdateRelease(version, release.TagName!, asset.Name!, asset.Size.Value, sha256, downloadUri, releaseSummary);
     }
 
     internal static bool TryNormalizeSha256(string? digest, out string sha256)
@@ -108,6 +108,9 @@ internal static class GitHubReleaseParser
     {
         [JsonPropertyName("tag_name")]
         public string? TagName { get; init; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; init; }
 
         [JsonPropertyName("draft")]
         public bool? Draft { get; init; }

--- a/src/Wisp.Update/ReleaseIdentity.cs
+++ b/src/Wisp.Update/ReleaseIdentity.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+
+namespace Wisp.Update;
+
+internal static class ReleaseIdentity
+{
+    private const string InstallerPrefix = "Wisp-Setup-";
+    private const string InstallerSuffix = ".exe";
+    private const string PrereleaseWords = "alpha|beta|rc|preview|nightly|pre|prerelease|dev|canary|experimental|candidate|unstable";
+    private static readonly Regex SafeTagPattern = new(
+        "\\A[A-Za-z0-9][A-Za-z0-9._-]{0,127}\\z",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+    private static readonly Regex PrereleaseTagPattern = new(
+        $"(?:\\A|[^a-z])(?:{PrereleaseWords})(?:[0-9]|\\z|[^a-z])",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+    private static readonly Regex PrereleaseTitlePattern = new(
+        $"\\A(?:Wisp[ _-]+)?v?[0-9]+(?:\\.[0-9]+){{0,2}}[ ._-]+(?:{PrereleaseWords})(?:[ ._-]*[0-9]+)*\\z",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
+    internal static bool IsInstallerAsset(string? name) =>
+        name is not null &&
+        name.StartsWith(InstallerPrefix, StringComparison.OrdinalIgnoreCase) &&
+        name.EndsWith(InstallerSuffix, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool TryParseInstallerVersion(string? name, out SemanticVersion version)
+    {
+        version = default;
+        return name is not null &&
+            name.StartsWith(InstallerPrefix, StringComparison.Ordinal) &&
+            name.EndsWith(InstallerSuffix, StringComparison.Ordinal) &&
+            SemanticVersion.TryParseReleaseVersion(
+                name[InstallerPrefix.Length..^InstallerSuffix.Length], out version);
+    }
+
+    internal static bool IsSafeTag(string? tag) =>
+        tag is not null && SafeTagPattern.IsMatch(tag) &&
+        !tag.Contains("..", StringComparison.Ordinal) && !tag.EndsWith('.');
+
+    internal static void RequireMatchingTag(string? tag, SemanticVersion version)
+    {
+        if (!IsSafeTag(tag) || PrereleaseTagPattern.IsMatch(tag!))
+        {
+            throw new UpdateSecurityException("The release tag is unsafe or identifies a prerelease.");
+        }
+
+        var numericTag = tag!.EndsWith("-stable", StringComparison.OrdinalIgnoreCase) ? tag[..^7] : tag;
+        if (SemanticVersion.TryParseReleaseVersion(numericTag, out var tagVersion))
+        {
+            if (tagVersion != version)
+            {
+                throw new UpdateSecurityException("The release tag and installer versions disagree.");
+            }
+        }
+        else if (char.IsAsciiDigit(tag[0]) ||
+                 (tag.Length > 1 && (tag[0] is 'v' or 'V') && char.IsAsciiDigit(tag[1])))
+        {
+            throw new UpdateSecurityException("The release tag contains an invalid numeric version.");
+        }
+    }
+
+    internal static void RequireStableTitle(string? title)
+    {
+        if (title is not null && PrereleaseTitlePattern.IsMatch(title.Trim()))
+        {
+            throw new UpdateSecurityException("The release title identifies a prerelease.");
+        }
+    }
+}

--- a/src/Wisp.Update/ReleaseUriPolicy.cs
+++ b/src/Wisp.Update/ReleaseUriPolicy.cs
@@ -13,16 +13,23 @@ internal static class ReleaseUriPolicy
 
     internal static string InstallerFileName(SemanticVersion version) => $"Wisp-Setup-{version}.exe";
 
-    internal static Uri InitialDownloadUri(SemanticVersion version)
+    internal static Uri InitialDownloadUri(SemanticVersion version) =>
+        InitialDownloadUri(version.ToTagString(), InstallerFileName(version));
+
+    internal static Uri InitialDownloadUri(string tagName, string fileName)
     {
-        var fileName = InstallerFileName(version);
-        return new Uri($"https://{GitHubHost}/Views2k/Wisp/releases/download/{version.ToTagString()}/{fileName}");
+        if (!ReleaseIdentity.IsSafeTag(tagName) || !ReleaseIdentity.TryParseInstallerVersion(fileName, out _))
+        {
+            throw new UpdateSecurityException("The release URL identity is invalid.");
+        }
+
+        return new Uri($"https://{GitHubHost}/Views2k/Wisp/releases/download/{tagName}/{fileName}");
     }
 
-    internal static void RequireInitialDownloadUri(Uri actual, SemanticVersion version)
+    internal static void RequireInitialDownloadUri(Uri actual, string tagName, string fileName)
     {
         ArgumentNullException.ThrowIfNull(actual);
-        var expected = InitialDownloadUri(version);
+        var expected = InitialDownloadUri(tagName, fileName);
         if (!IsCleanHttpsUri(actual) ||
             !string.Equals(actual.AbsoluteUri, expected.AbsoluteUri, StringComparison.Ordinal))
         {
@@ -30,7 +37,7 @@ internal static class ReleaseUriPolicy
         }
     }
 
-    internal static void RequireRedirectTarget(Uri target, SemanticVersion version)
+    internal static void RequireRedirectTarget(Uri target, string tagName, string fileName)
     {
         ArgumentNullException.ThrowIfNull(target);
         if (!IsCleanHttpsUri(target))
@@ -38,7 +45,7 @@ internal static class ReleaseUriPolicy
             throw new UpdateSecurityException("The installer redirect target is not a clean HTTPS URL.");
         }
 
-        var canonical = InitialDownloadUri(version);
+        var canonical = InitialDownloadUri(tagName, fileName);
         if (string.Equals(target.AbsoluteUri, canonical.AbsoluteUri, StringComparison.Ordinal))
         {
             return;

--- a/src/Wisp.Update/SemanticVersion.cs
+++ b/src/Wisp.Update/SemanticVersion.cs
@@ -13,6 +13,10 @@ public readonly record struct SemanticVersion : IComparable<SemanticVersion>
         "\\Av(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\z",
         RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
 
+    private static readonly Regex ReleaseVersionPattern = new(
+        "\\A[vV]?(0|[1-9][0-9]*)(?:\\.(0|[1-9][0-9]*))?(?:\\.(0|[1-9][0-9]*))?\\z",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
     public SemanticVersion(int major, int minor, int patch)
     {
         ValidateComponent(major, nameof(major));
@@ -52,6 +56,9 @@ public readonly record struct SemanticVersion : IComparable<SemanticVersion>
 
     public static bool TryParseTag(string? value, out SemanticVersion version) =>
         TryParseMatch(value, TagPattern, out version);
+
+    public static bool TryParseReleaseVersion(string? value, out SemanticVersion version) =>
+        TryParseMatch(value, ReleaseVersionPattern, out version);
 
     public static SemanticVersion FromSystemVersion(Version version)
     {
@@ -99,8 +106,8 @@ public readonly record struct SemanticVersion : IComparable<SemanticVersion>
         var match = pattern.Match(value);
         if (!match.Success ||
             !TryParseComponent(match.Groups[1].Value, out var major) ||
-            !TryParseComponent(match.Groups[2].Value, out var minor) ||
-            !TryParseComponent(match.Groups[3].Value, out var patch))
+            !TryParseComponent(match.Groups[2].Success ? match.Groups[2].Value : "0", out var minor) ||
+            !TryParseComponent(match.Groups[3].Success ? match.Groups[3].Value : "0", out var patch))
         {
             return false;
         }

--- a/src/Wisp.Update/UpdateModels.cs
+++ b/src/Wisp.Update/UpdateModels.cs
@@ -6,6 +6,7 @@ public sealed class UpdateRelease
 {
     internal UpdateRelease(
         SemanticVersion version,
+        string tagName,
         string fileName,
         long size,
         string sha256,
@@ -13,6 +14,7 @@ public sealed class UpdateRelease
         string releaseSummary)
     {
         Version = version;
+        TagName = tagName;
         FileName = fileName;
         Size = size;
         Sha256 = sha256;
@@ -21,6 +23,7 @@ public sealed class UpdateRelease
     }
 
     public SemanticVersion Version { get; }
+    public string TagName { get; }
     public string FileName { get; }
     public long Size { get; }
     public string Sha256 { get; }

--- a/src/Wisp.Update/WispUpdateClient.cs
+++ b/src/Wisp.Update/WispUpdateClient.cs
@@ -188,11 +188,11 @@ public sealed class WispUpdateClient : IDisposable
         {
             if (redirects == 0)
             {
-                ReleaseUriPolicy.RequireInitialDownloadUri(current, release.Version);
+                ReleaseUriPolicy.RequireInitialDownloadUri(current, release.TagName, release.FileName);
             }
             else
             {
-                ReleaseUriPolicy.RequireRedirectTarget(current, release.Version);
+                ReleaseUriPolicy.RequireRedirectTarget(current, release.TagName, release.FileName);
             }
 
             if (!visited.Add(current.AbsoluteUri))
@@ -224,7 +224,7 @@ public sealed class WispUpdateClient : IDisposable
                 var location = response.Headers.Location ??
                     throw new UpdateSecurityException("The installer redirect omitted its Location header.");
                 current = location.IsAbsoluteUri ? location : new Uri(current, location);
-                ReleaseUriPolicy.RequireRedirectTarget(current, release.Version);
+                ReleaseUriPolicy.RequireRedirectTarget(current, release.TagName, release.FileName);
             }
             catch
             {
@@ -351,8 +351,7 @@ public sealed class WispUpdateClient : IDisposable
 
     private static void ValidateReleaseForDownload(UpdateRelease release)
     {
-        var expectedName = ReleaseUriPolicy.InstallerFileName(release.Version);
-        if (!string.Equals(release.FileName, expectedName, StringComparison.Ordinal) ||
+        if (!ReleaseIdentity.TryParseInstallerVersion(release.FileName, out var version) || version != release.Version ||
             release.Size is <= 0 or > MaximumInstallerSizeBytes ||
             !GitHubReleaseParser.TryNormalizeSha256($"sha256:{release.Sha256}", out var normalized) ||
             !string.Equals(normalized, release.Sha256, StringComparison.Ordinal))
@@ -360,7 +359,8 @@ public sealed class WispUpdateClient : IDisposable
             throw new UpdateSecurityException("The release metadata is not a canonical Wisp installer.");
         }
 
-        ReleaseUriPolicy.RequireInitialDownloadUri(release.DownloadUri, release.Version);
+        ReleaseIdentity.RequireMatchingTag(release.TagName, release.Version);
+        ReleaseUriPolicy.RequireInitialDownloadUri(release.DownloadUri, release.TagName, release.FileName);
     }
 
     private static void RequireIdentityEncoding(HttpResponseMessage response)

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.0.12</Version>
-    <FileVersion>1.0.12.0</FileVersion>
-    <AssemblyVersion>1.0.12.0</AssemblyVersion>
+    <Version>1.1.0</Version>
+    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/AmbientBackdropLifecycleTests.cs
+++ b/tests/Wisp.App.Tests/AmbientBackdropLifecycleTests.cs
@@ -134,20 +134,15 @@ public sealed class AmbientBackdropLifecycleTests
         Assert.Null(control.Effect);
         Assert.Null(control.OpacityMask);
         Assert.Null(control.CacheMode);
-        Assert.Equal(2, VisualTreeHelper.GetChildrenCount(control));
+        Assert.Equal(1, VisualTreeHelper.GetChildrenCount(control));
         var background = Assert.IsType<DrawingVisual>(VisualTreeHelper.GetChild(control, 0));
         var backgroundDrawing = Assert.IsType<DrawingGroup>(background.Drawing);
-        Assert.Single(backgroundDrawing.Children);
+        var image = Assert.IsType<ImageDrawing>(Assert.Single(backgroundDrawing.Children));
+        Assert.IsType<System.Windows.Media.Imaging.WriteableBitmap>(image.ImageSource);
+        Assert.Equal(new Rect(0, 0, 1280, 800), image.Rect);
         Assert.Equal(1, background.Opacity);
         Assert.Null(background.OpacityMask);
-        var scene = Assert.IsType<DrawingVisual>(VisualTreeHelper.GetChild(control, 1));
-        var drawing = Assert.IsType<DrawingGroup>(scene.Drawing);
-        Assert.False(drawing.Bounds.IsEmpty);
-        Assert.InRange(drawing.Bounds.Left, 0, 1280 * 0.12);
-        Assert.InRange(drawing.Bounds.Right, 1280 * 0.88, 1280);
-        Assert.Equal(0.78, scene.Opacity, 3);
-        Assert.Null(scene.OpacityMask);
-        Assert.Equal(AmbientBackdropScene.ParticleCount, drawing.Children.Count);
+        Assert.Equal(1, control.Intensity);
     });
 
     [Fact]

--- a/tests/Wisp.App.Tests/AmbientBackdropRasterizerTests.cs
+++ b/tests/Wisp.App.Tests/AmbientBackdropRasterizerTests.cs
@@ -1,0 +1,112 @@
+using Wisp.App;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class AmbientBackdropRasterizerTests
+{
+    [Fact]
+    public void BackgroundMatchesWebsiteSideLightWithUnbiasedEightBitRounding()
+    {
+        var renderer = new AmbientBackdropRasterizer(256, 160);
+        renderer.Render([], 1);
+        var error = new double[3];
+        for (var y = 0; y < renderer.Height; y++)
+            for (var x = 0; x < renderer.Width; x++)
+            {
+                var expected = BackgroundAt(x, y, renderer.Width, renderer.Height);
+                var index = (y * renderer.Width + x) * 4;
+                Assert.Equal(255, renderer.Pixels[index + 3]);
+                for (var channel = 0; channel < 3; channel++)
+                {
+                    var difference = renderer.Pixels[index + 2 - channel] - expected[channel];
+                    Assert.InRange(difference, -1.001, 1.001);
+                    error[channel] += difference;
+                }
+            }
+        Assert.All(error, sum => Assert.InRange(sum / (256 * 160), -0.02, 0.02));
+
+        // A nearly flat dark patch contains neighboring quantization levels,
+        // rather than a wide, uniformly rounded contour band.
+        var patch = new HashSet<byte>();
+        for (var y = 70; y < 86; y++)
+            for (var x = 120; x < 136; x++)
+                patch.Add(renderer.Pixels[(y * 256 + x) * 4 + 1]);
+        Assert.True(patch.Count >= 2);
+    }
+
+    [Fact]
+    public void OverlappingFaintSpritesAreCompositedBeforeQuantization()
+    {
+        var renderer = new AmbientBackdropRasterizer(65, 65);
+        var particle = new AmbientParticle(new AmbientPoint(32.5, 32.5), 8, 0.0035, 0.4, 0.54, 0.60, 0.60);
+        renderer.Render([particle, particle, particle], 1);
+        var expected = BackgroundAt(32, 32, 65, 65);
+        double[] color = [0.54 * 255, 0.60 * 255, 0.60 * 255];
+        for (var repeat = 0; repeat < 3; repeat++)
+            for (var channel = 0; channel < 3; channel++)
+                expected[channel] += (color[channel] - expected[channel]) * particle.Opacity;
+        var index = (32 * 65 + 32) * 4;
+        for (var channel = 0; channel < 3; channel++)
+            Assert.InRange(renderer.Pixels[index + 2 - channel] - expected[channel], -1.001, 1.001);
+    }
+
+    [Fact]
+    public void RadialSpriteFadesWithoutAVisibleRectangleAndDisabledIntensityRetainsBackground()
+    {
+        var renderer = new AmbientBackdropRasterizer(65, 65);
+        renderer.Render([], 1);
+        var background = renderer.Pixels.ToArray();
+        var particle = new AmbientParticle(new AmbientPoint(32.5, 32.5), 12, 0.3, 0.82, 0.5, 0.6, 0.6);
+        renderer.Render([particle], 1);
+        var center = (32 * 65 + 32) * 4;
+        var middle = (32 * 65 + 38) * 4;
+        var corner = (22 * 65 + 22) * 4;
+        Assert.True(renderer.Pixels[center] > renderer.Pixels[middle]);
+        Assert.True(renderer.Pixels[middle] > background[middle]);
+        Assert.Equal(background.AsSpan(corner, 4).ToArray(), renderer.Pixels.AsSpan(corner, 4).ToArray());
+        renderer.Render([particle], 0);
+        Assert.Equal(background, renderer.Pixels);
+    }
+
+    [Fact]
+    public void FramesReuseStorageAndStableNoiseWithoutLeavingTrails()
+    {
+        var renderer = new AmbientBackdropRasterizer(128, 80);
+        var storage = renderer.Pixels;
+        var particle = new AmbientParticle(new AmbientPoint(32.5, 32.5), 8, 0.2, 0.4, 0.54, 0.6, 0.6);
+        renderer.Render([], 1);
+        var background = storage.ToArray();
+        var allocated = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 10; index++)
+            renderer.Render([particle], 1);
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - allocated);
+        renderer.Render([], 1);
+        Assert.Same(storage, renderer.Pixels);
+        Assert.Equal(background, storage);
+    }
+
+    [Fact]
+    public void AllocationIsBoundedAndMalformedParticlesCannotCorruptOutput()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AmbientBackdropRasterizer(0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AmbientBackdropRasterizer(2000, 2000));
+        var renderer = new AmbientBackdropRasterizer(32, 32);
+        renderer.Render([], 1);
+        var expected = renderer.Pixels.ToArray();
+        renderer.Render([
+            new AmbientParticle(new AmbientPoint(double.NaN, 0), 8, 0.2, 0.4, 1, 1, 1),
+            new AmbientParticle(new AmbientPoint(16, 16), double.PositiveInfinity, 0.2, 0.4, 1, 1, 1),
+            new AmbientParticle(new AmbientPoint(16, 16), 8, double.NaN, 0.4, 1, 1, 1)
+        ], 1);
+        Assert.Equal(expected, renderer.Pixels);
+    }
+
+    private static double[] BackgroundAt(int x, int y, int width, int height)
+    {
+        var dx = ((x + 0.5) / width - 1.2) * (width / (double)height) * 0.58;
+        var dy = (1 - (y + 0.5) / height - 0.42) * 0.8;
+        var light = Math.Exp(-(dx * dx + dy * dy) * 1.24) * 0.135;
+        return [9 + 10 * light, 13 + 30 * light, 18 + 26 * light];
+    }
+}

--- a/tests/Wisp.App.Tests/AmbientBackdropSceneTests.cs
+++ b/tests/Wisp.App.Tests/AmbientBackdropSceneTests.cs
@@ -39,93 +39,101 @@ public sealed class AmbientBackdropSceneTests
     [InlineData(1280, 800)]
     [InlineData(1920, 1080)]
     [InlineData(3840, 2160)]
-    public void FramesStayFiniteLayeredAndFormAGroupedRibbon(double width, double height)
+    public void FramesStayFiniteAndBoundedAcrossViewports(double width, double height)
     {
         var scene = new AmbientBackdropScene();
-        foreach (var seconds in new[] { 0d, 1d / AmbientBackdropClock.FramesPerSecond, 12.5, 80, 239.9, 100_000 })
+        foreach (var seconds in new[] { 0d, 1d / 30, 12.5, 80, 239.9, 100_000 })
         {
             scene.Update(width, height, seconds);
 
-            Assert.Equal(AmbientBackdropScene.ParticleCount, scene.Particles.Length);
-            var particles = scene.Particles.ToArray();
-            Assert.Equal(AmbientBackdropScene.FarParticleCount,
-                particles.Count(particle => particle.Layer == AmbientParticleLayer.Far));
-            Assert.Equal(AmbientBackdropScene.MiddleParticleCount,
-                particles.Count(particle => particle.Layer == AmbientParticleLayer.Middle));
-            Assert.Equal(AmbientBackdropScene.NearParticleCount,
-                particles.Count(particle => particle.Layer == AmbientParticleLayer.Near));
-            foreach (var particle in particles)
+            Assert.Equal(2048, scene.Particles.Length);
+            foreach (var particle in scene.Particles)
             {
-                AssertPoint(particle.Position, width, height);
-                Assert.InRange(particle.Shade, 0, AmbientBackdropScene.PaletteSize - 1);
-                AssertRadius(particle);
-                var along = particle.Position.X / width;
-                var verticalDistance = Math.Abs(
-                    particle.Position.Y / height - AmbientBackdropScene.RibbonCenter(along, seconds));
-                var envelope = particle.Layer switch
-                {
-                    AmbientParticleLayer.Far => 0.24,
-                    AmbientParticleLayer.Middle => 0.16,
-                    _ => 0.10
-                };
-                Assert.InRange(verticalDistance, 0, envelope);
+                Assert.InRange(particle.Position.X, -width, width * 2);
+                Assert.InRange(particle.Position.Y, -height, height * 2);
+                Assert.InRange(particle.Radius, 0.5, 21);
+                Assert.InRange(particle.Opacity, 0, 0.4);
+                Assert.InRange(particle.Softness, 0.18, 0.82);
+                Assert.InRange(particle.Red, 0.25, 0.54);
+                Assert.InRange(particle.Green, 0.40, 0.60);
+                Assert.InRange(particle.Blue, 0.39, 0.60);
             }
-            Assert.True(particles.Min(particle => particle.Position.X) < width * 0.08);
-            Assert.True(particles.Max(particle => particle.Position.X) > width * 0.92);
-            AssertGroupedOccupancy(particles, width, height);
         }
     }
 
     [Fact]
-    public void FirstFrameIsAlreadyAMatureRibbonWithoutWarmup()
+    public void FirstFrameHasMultiplePopulatedStreamsAndContinuousDepth()
     {
         var scene = new AmbientBackdropScene();
-        scene.Update(1280, 800, 0);
-
+        scene.Update(1280, 900, 0);
         var particles = scene.Particles.ToArray();
-        Assert.Equal(240, particles.Length);
-        AssertGroupedOccupancy(particles, 1280, 800);
-        var near = particles.Where(particle => particle.Layer == AmbientParticleLayer.Near).ToArray();
-        Assert.True(near.Count(particle =>
-            Math.Abs(particle.Position.Y / 800 -
-                AmbientBackdropScene.RibbonCenter(particle.Position.X / 1280, 0)) <= 0.08) >= 116);
+        var visible = particles.Where(particle =>
+            particle.Position.X >= 0 && particle.Position.X <= 1280 &&
+            particle.Position.Y >= 0 && particle.Position.Y <= 900 &&
+            particle.Opacity > 0.01).ToArray();
+        var occupiedRows = visible.Select(particle => (int)(particle.Position.Y / 150)).Distinct().Count();
+
+        Assert.InRange(visible.Length, 700, 2048);
+        Assert.True(occupiedRows >= 5);
+        Assert.True(visible.Count(particle => particle.Radius < 2.2) > 100);
+        Assert.True(particles.Count(particle => particle.Radius > 4) > 50);
+        Assert.True(particles.Count(particle => particle.Softness > 0.5) > 50);
+        Assert.True(particles.Select(particle => Math.Round(particle.Softness, 3)).Distinct().Count() > 100);
     }
 
     [Fact]
-    public void PointerInfluenceIsBoundedLocalAndDepthOrdered()
+    public void ProjectionUsesProductionPerspectiveAndDarkMaterial()
     {
-        const double width = 1280;
-        const double height = 800;
-        const double seconds = 40;
-        var pointer = new AmbientPoint(0.49, AmbientBackdropScene.RibbonCenter(0.49, seconds));
-        var scene = new AmbientBackdropScene();
-        scene.Update(width, height, seconds);
-        var neutral = scene.Particles.ToArray();
-        scene.Update(width, height, seconds, pointer, 1);
-        var influenced = scene.Particles.ToArray();
+        var particle = AmbientBackdropScene.Project(1, -1, -1.65, 0.5, 0, 1280, 900);
+        var pointSize = 1.15 + Math.Pow(0.56, 1.38) * 31;
 
-        var maximumByLayer = new Dictionary<AmbientParticleLayer, double>();
-        foreach (var layer in Enum.GetValues<AmbientParticleLayer>())
-            maximumByLayer[layer] = 0;
-        var localEnergy = 0d;
-        var remoteEnergy = 0d;
+        Assert.Equal((1 + 1.7320508 / 6.65) * 640, particle.Position.X, 10);
+        Assert.Equal((1 + 1.7320508 / 6.65) * 450, particle.Position.Y, 10);
+        Assert.Equal(pointSize / 2, particle.Radius, 10);
+        Assert.Equal(0.115 * 0.78 / Math.Sqrt(Math.Max(1, pointSize * 0.20)), particle.Opacity, 10);
+        Assert.Equal(0.82, particle.Softness, 10);
+        Assert.Equal(0.3776, particle.Red, 10);
+        Assert.Equal(0.488, particle.Green, 10);
+        Assert.Equal(0.4824, particle.Blue, 10);
+    }
+
+    [Fact]
+    public void LifeFadesAtBothBoundariesAndOutputHeightControlsPointSize()
+    {
+        var born = AmbientBackdropScene.Project(0, 0, 0, 1, 0.5, 1280, 900);
+        var mature = AmbientBackdropScene.Project(0, 0, 0, 0.5, 0.5, 1280, 900);
+        var expired = AmbientBackdropScene.Project(0, 0, 0, 0, 0.5, 1280, 900);
+        var larger = AmbientBackdropScene.Project(0, 0, 0, 0.5, 0.5, 2560, 1800);
+
+        Assert.Equal(0, born.Opacity);
+        Assert.Equal(0, expired.Opacity);
+        Assert.True(mature.Opacity > 0.25);
+        Assert.Equal(mature.Radius * 2, larger.Radius, 10);
+        Assert.True(larger.Opacity <= mature.Opacity);
+    }
+
+    [Fact]
+    public void PointerInfluenceIsBoundedAndLocal()
+    {
+        var pointer = new AmbientPoint(0.49, 0.5);
+        var scene = new AmbientBackdropScene();
+        scene.Update(1280, 800, 40);
+        var neutral = scene.Particles.ToArray();
+        scene.Update(1280, 800, 40, pointer, 1);
+        var changed = 0;
+
         for (var index = 0; index < neutral.Length; index++)
         {
-            var displacement = Distance(neutral[index].Position, influenced[index].Position);
-            maximumByLayer[neutral[index].Layer] = Math.Max(maximumByLayer[neutral[index].Layer], displacement);
-            Assert.InRange(displacement, 0, Math.Min(width, height) * 0.013);
-            var pointerDistance = Distance(neutral[index].Position,
-                new AmbientPoint(pointer.X * width, pointer.Y * height));
-            if (pointerDistance <= Math.Min(width, height) * 0.22)
-                localEnergy += displacement * displacement;
-            else
-                remoteEnergy += displacement * displacement;
+            var next = scene.Particles[index];
+            var displacement = Distance(neutral[index].Position, next.Position);
+            Assert.InRange(displacement, 0, 800 * 0.013);
+            Assert.Equal(neutral[index] with { Position = next.Position }, next);
+            if (Distance(neutral[index].Position, new AmbientPoint(pointer.X * 1280, pointer.Y * 800)) >= 800 * 0.22)
+                Assert.Equal(0, displacement);
+            if (displacement > 0)
+                changed++;
         }
-
-        Assert.True(maximumByLayer[AmbientParticleLayer.Near] > maximumByLayer[AmbientParticleLayer.Middle]);
-        Assert.True(maximumByLayer[AmbientParticleLayer.Middle] > maximumByLayer[AmbientParticleLayer.Far]);
-        Assert.True(localEnergy > 0);
-        Assert.Equal(0, remoteEnergy, 8);
+        Assert.True(changed > 20);
     }
 
     [Fact]
@@ -150,7 +158,6 @@ public sealed class AmbientBackdropSceneTests
     {
         var scene = new AmbientBackdropScene();
         scene.Update(1280, 800, 20);
-
         scene.Update(width, height, 20);
 
         Assert.True(scene.Particles.IsEmpty);
@@ -165,24 +172,9 @@ public sealed class AmbientBackdropSceneTests
         var scene = new AmbientBackdropScene();
         scene.Update(1280, 800, 0);
         var particles = scene.Particles.ToArray();
-
         scene.Update(1280, 800, seconds);
 
         Assert.Equal(particles, scene.Particles.ToArray());
-    }
-
-    [Fact]
-    public void FieldEvolvesWithoutAShortSynchronizedReset()
-    {
-        var scene = new AmbientBackdropScene();
-        scene.Update(1280, 800, 0);
-        var particles = scene.Particles.ToArray();
-
-        scene.Update(1280, 800, 80);
-
-        Assert.True(particles.Zip(scene.Particles.ToArray())
-            .Count(pair => pair.First.Position != pair.Second.Position) >= AmbientBackdropScene.ParticleCount - 2);
-        Assert.Equal(80, AmbientBackdropScene.NormalizeTime(80));
     }
 
     [Theory]
@@ -190,58 +182,40 @@ public sealed class AmbientBackdropSceneTests
     [InlineData(31.99)]
     [InlineData(79.99)]
     [InlineData(500)]
-    public void FrameMotionIsSlowContinuousAndCoherent(double seconds)
+    public void VisibleParticlesMoveContinuouslyWithoutSynchronizedResets(double seconds)
     {
         var scene = new AmbientBackdropScene();
         scene.Update(1280, 800, seconds);
         var particles = scene.Particles.ToArray();
-
         scene.Update(1280, 800, seconds + 1d / AmbientBackdropClock.FramesPerSecond);
+        var compared = 0;
 
-        var moving = 0;
         for (var index = 0; index < particles.Length; index++)
         {
             var next = scene.Particles[index];
-            var displacement = Distance(particles[index].Position, next.Position);
-            Assert.InRange(displacement, 0, 0.5);
-            if (displacement > 0.000001)
-                moving++;
-            Assert.Equal(particles[index].Radius, next.Radius);
-            Assert.Equal(particles[index].Layer, next.Layer);
+            if (particles[index].Opacity <= 0.01 || next.Opacity <= 0.01)
+                continue;
+            Assert.InRange(Distance(particles[index].Position, next.Position), 0, 4);
+            Assert.InRange(Math.Abs(particles[index].Opacity - next.Opacity), 0, 0.05);
+            compared++;
         }
-        Assert.True(moving >= AmbientBackdropScene.ParticleCount - 2);
-    }
-
-    [Theory]
-    [InlineData(0)]
-    [InlineData(31.99)]
-    [InlineData(79.99)]
-    public void OneSecondOfMotionIsVisibleWithoutBreakingTheRibbon(double seconds)
-    {
-        var scene = new AmbientBackdropScene();
-        scene.Update(1280, 800, seconds);
-        var particles = scene.Particles.ToArray();
-
-        scene.Update(1280, 800, seconds + 1);
-
-        var displacements = particles
-            .Zip(scene.Particles.ToArray())
-            .Select(pair => Distance(pair.First.Position, pair.Second.Position))
-            .ToArray();
-        Assert.True(displacements.Average() > 0.5);
-        Assert.True(displacements.Count(displacement => displacement > 0.25) >= 180);
-        Assert.All(displacements, displacement => Assert.InRange(displacement, 0, 14));
+        Assert.True(compared > 1800);
+        Assert.Equal(seconds, AmbientBackdropScene.NormalizeTime(seconds));
     }
 
     [Fact]
-    public void ResizeAndReturningToZeroRestoresTheStaticFrame()
+    public void ResizePreservesNormalizedProjectionAndReturningToZeroRestoresFrame()
     {
         var scene = new AmbientBackdropScene();
         scene.Update(1280, 800, 0);
         var particles = scene.Particles.ToArray();
-
+        scene.Update(640, 400, 0);
+        for (var index = 0; index < particles.Length; index++)
+        {
+            Assert.Equal(particles[index].Position.X / 2, scene.Particles[index].Position.X, 10);
+            Assert.Equal(particles[index].Position.Y / 2, scene.Particles[index].Position.Y, 10);
+        }
         scene.Update(480, 760, 60);
-        Assert.Equal(AmbientBackdropScene.ParticleCount, scene.Particles.Length);
         scene.Update(1280, 800, 0);
 
         Assert.Equal(particles, scene.Particles.ToArray());
@@ -252,63 +226,17 @@ public sealed class AmbientBackdropSceneTests
     {
         var scene = new AmbientBackdropScene();
         var pointer = new AmbientPoint(0.49, 0.5);
-        for (var index = 0; index < 200; index++)
-            scene.Update(1280, 800, index / 24d, pointer, index % 2);
-
+        for (var index = 0; index < 100; index++)
+            scene.Update(1280, 800, index / 30d, pointer, index % 2);
         var allocated = GC.GetAllocatedBytesForCurrentThread();
-        for (var index = 0; index < 1000; index++)
-            scene.Update(1280, 800, index / 24d, pointer, index % 2);
+        for (var index = 0; index < 200; index++)
+            scene.Update(1280, 800, index / 30d, pointer, index % 2);
         allocated = GC.GetAllocatedBytesForCurrentThread() - allocated;
 
         Assert.Equal(0L, allocated);
-        Assert.Equal(40, AmbientBackdropScene.FarParticleCount);
-        Assert.Equal(72, AmbientBackdropScene.MiddleParticleCount);
-        Assert.Equal(128, AmbientBackdropScene.NearParticleCount);
-        Assert.Equal(240, AmbientBackdropScene.ParticleCount);
-    }
-
-    private static void AssertGroupedOccupancy(
-        IReadOnlyCollection<AmbientParticle> particles,
-        double width,
-        double height)
-    {
-        var horizontalBins = new int[20];
-        var occupancy = new bool[10, 8];
-        foreach (var particle in particles)
-        {
-            var x = Math.Clamp((int)(particle.Position.X / width * horizontalBins.Length), 0, horizontalBins.Length - 1);
-            horizontalBins[x]++;
-            var gridX = Math.Clamp((int)(particle.Position.X / width * 10), 0, 9);
-            var gridY = Math.Clamp((int)(particle.Position.Y / height * 8), 0, 7);
-            occupancy[gridX, gridY] = true;
-        }
-
-        Assert.True(horizontalBins.Count(count => count >= 14) >= 4);
-        Assert.True(horizontalBins.Count(count => count <= 6) >= 3);
-        Assert.True(occupancy.Cast<bool>().Count(occupied => !occupied) >= 24);
-    }
-
-    private static void AssertRadius(AmbientParticle particle)
-    {
-        var limits = particle.Layer switch
-        {
-            AmbientParticleLayer.Far => (2.16, 14.18),
-            AmbientParticleLayer.Middle => (1.00, 5.68),
-            _ => (0.39, 2.98)
-        };
-        Assert.InRange(particle.Radius, limits.Item1, limits.Item2);
+        Assert.Equal(AmbientBackdropScene.ParticleCount, scene.Particles.Length);
     }
 
     private static double Distance(AmbientPoint a, AmbientPoint b) =>
         Math.Sqrt((a.X - b.X) * (a.X - b.X) + (a.Y - b.Y) * (a.Y - b.Y));
-
-    private static void AssertPoint(AmbientPoint point, double width, double height)
-    {
-        Assert.True(double.IsFinite(point.X) && double.IsFinite(point.Y));
-        // Far-field centers may sit just outside the clipped viewport. Bound them by the
-        // physical ribbon width instead of clamping them into visible edge-aligned rows.
-        var padding = Math.Min(width, height) * 0.20;
-        Assert.InRange(point.X, -padding, width + padding);
-        Assert.InRange(point.Y, -padding, height + padding);
-    }
 }

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -1,0 +1,29 @@
+using Wisp.Update;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class ApplicationVersionInfoTests
+{
+    [Theory]
+    [InlineData("1.1.0", "1.1")]
+    [InlineData("2.0.0", "2.0")]
+    [InlineData("1.0.12", "1.0.12")]
+    [InlineData("1.1.10", "1.1.10")]
+    public void DisplayFormattingDoesNotChangeMachineIdentity(string machine, string display)
+    {
+        var version = SemanticVersion.Parse(machine);
+        Assert.Equal(display, ApplicationVersionInfo.Format(version));
+        Assert.Equal(display, ApplicationVersionInfo.Format(version.ToSystemVersion()));
+        Assert.Equal(machine, version.ToString());
+    }
+
+    [Fact]
+    public void CurrentVersionLabelsShareTheAssemblyVersion()
+    {
+        Assert.Equal("1.1", ApplicationVersionInfo.DisplayVersion);
+        Assert.EndsWith(" 1.1", ApplicationVersionInfo.FooterText);
+        Assert.Contains("current 1.1 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
+    }
+}

--- a/tests/Wisp.App.Tests/MaintenancePersistenceTests.cs
+++ b/tests/Wisp.App.Tests/MaintenancePersistenceTests.cs
@@ -1,0 +1,257 @@
+using System.IO;
+using System.Reflection;
+using System.Security;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Controls;
+using Wisp.App;
+using Wisp.Core;
+using Wisp.Update;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class MaintenancePersistenceTests
+{
+    [Theory]
+    [InlineData("io")]
+    [InlineData("access")]
+    [InlineData("security")]
+    public async Task FailedProfileSaveRetriesLatestSettingsWithoutAddingAnotherProfile(string failure)
+    {
+        var settings = CompletedSettings();
+        var failSave = true;
+        var saveAttempts = 0;
+        string? persisted = null;
+        await using var controller = new AppController(settings, value =>
+        {
+            saveAttempts++;
+            if (failSave)
+            {
+                throw SaveFailure(failure);
+            }
+            persisted = JsonSerializer.Serialize(value);
+        }, new NoStartupRegistration());
+
+        Assert.True(controller.TryCreateHudPreset("Night driving", out var created, out var error), error);
+        Assert.NotNull(created);
+        Assert.Equal(0, saveAttempts);
+        Assert.False(controller.TrySavePendingSettings());
+        Assert.Equal(1, saveAttempts);
+        Assert.Null(persisted);
+        Assert.Same(created, Assert.Single(settings.HudPresets));
+
+        settings.OverlayOpacity = 0.62;
+        settings.SpeedUnit = SpeedUnit.KilometersPerHour;
+        failSave = false;
+
+        Assert.True(controller.TrySavePendingSettings());
+        Assert.Equal(2, saveAttempts);
+        var restored = JsonSerializer.Deserialize<AppSettings>(Assert.IsType<string>(persisted))!;
+        Assert.Equal(created.Id, Assert.Single(restored.HudPresets).Id);
+        Assert.Equal("Night driving", restored.HudPresets[0].Name);
+        Assert.Equal(0.62, restored.OverlayOpacity);
+        Assert.Equal(SpeedUnit.KilometersPerHour, restored.SpeedUnit);
+        Assert.Same(created, Assert.Single(settings.HudPresets));
+    }
+
+    [Fact]
+    public async Task IncompleteSetupNeverReportsSettingsSavedOrInvokesPersistence()
+    {
+        var settings = new AppSettings
+        {
+            StartWithWindows = false,
+            AutomaticApplicationUpdateChecks = false
+        };
+        var saveAttempts = 0;
+        await using var controller = new AppController(
+            settings, _ => saveAttempts++, new NoStartupRegistration());
+
+        Assert.True(settings.RequiresSetup);
+        Assert.False(controller.TrySavePendingSettings());
+        Assert.Equal(0, saveAttempts);
+
+        await controller.DisposeAsync();
+
+        Assert.False(controller.TrySavePendingSettings());
+        Assert.Equal(0, saveAttempts);
+    }
+
+    [Fact]
+    public async Task ShutdownRetriesFailedSaveAndDisposedControllerRejectsFurtherAttempts()
+    {
+        var saveAttempts = 0;
+        await using var controller = new AppController(CompletedSettings(), _ =>
+        {
+            saveAttempts++;
+            throw new IOException("Synthetic settings failure");
+        }, new NoStartupRegistration());
+
+        Assert.True(controller.TryCreateHudPreset("Night driving", out _, out var error), error);
+        Assert.False(controller.TrySavePendingSettings());
+        Assert.Equal(1, saveAttempts);
+
+        await controller.DisposeAsync();
+
+        Assert.Equal(2, saveAttempts);
+        Assert.False(controller.TrySavePendingSettings());
+        Assert.Equal(2, saveAttempts);
+    }
+
+    [Theory]
+    [InlineData("1.0.13", "Maintenance fixes retained after staging.")]
+    [InlineData("1.0.14", "")]
+    [InlineData(null, "")]
+    public async Task StagedInstallerShowsOnlyItsMatchingReleaseSummary(
+        string? retainedVersion,
+        string expectedSummary)
+    {
+        var temporaryDirectory = Path.Combine(
+            Path.GetTempPath(), "Wisp.App.Tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(temporaryDirectory);
+            var stagedPath = Path.Combine(temporaryDirectory, "staged-installer.fixture");
+            File.WriteAllBytes(stagedPath, [0]);
+            var pending = (VerifiedInstaller)Activator.CreateInstance(
+                typeof(VerifiedInstaller),
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                args: [stagedPath, new SemanticVersion(1, 0, 13), 1L, new string('A', 64)],
+                culture: null)!;
+            await using var controller = new AppController(
+                CompletedSettings(), _ => { }, new NoStartupRegistration());
+            SetPendingField(controller, "_pendingInstaller", pending);
+            SetPendingField(
+                controller,
+                "_pendingApplicationUpdateDetails",
+                retainedVersion is null
+                    ? null
+                    : new ApplicationUpdateDetails(
+                        retainedVersion, "Maintenance fixes retained after staging."));
+
+            var details = await controller.GetAvailableApplicationUpdateDetailsAsync();
+
+            Assert.NotNull(details);
+            Assert.Equal("1.0.13", details.Version);
+            Assert.Equal(expectedSummary, details.ReleaseSummary);
+        }
+        finally
+        {
+            if (Directory.Exists(temporaryDirectory))
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+        }
+    }
+
+    internal static void AssertProfileSaveRetryOnCurrentDispatcher()
+    {
+        var settings = CompletedSettings();
+        var failSave = true;
+        var saveAttempts = 0;
+        string? persisted = null;
+        var controller = new AppController(settings, value =>
+        {
+            saveAttempts++;
+            if (failSave)
+            {
+                throw new IOException("Synthetic settings failure");
+            }
+            persisted = JsonSerializer.Serialize(value);
+        }, new NoStartupRegistration());
+        MainWindow? window = null;
+        try
+        {
+            window = new MainWindow(controller);
+            var modeType = typeof(MainWindow).GetNestedType(
+                "HudProfileDialogMode", BindingFlags.NonPublic);
+            var showDialog = typeof(MainWindow).GetMethod(
+                "ShowHudProfileDialog", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(modeType);
+            Assert.NotNull(showDialog);
+            showDialog.Invoke(window, [Enum.Parse(modeType, "Create"), null]);
+            var nameInput = Assert.IsType<TextBox>(window.FindName("HudProfileNameInput"));
+            var confirm = Assert.IsType<Button>(window.FindName("ConfirmHudProfileButton"));
+            var dialog = Assert.IsType<Grid>(window.FindName("HudProfileDialog"));
+            var error = Assert.IsType<TextBlock>(window.FindName("HudProfileDialogError"));
+            var status = Assert.IsType<TextBlock>(window.FindName("HudProfileStatusText"));
+            nameInput.Text = "Night driving";
+
+            confirm.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            var created = Assert.Single(settings.HudPresets);
+            Assert.Equal(1, saveAttempts);
+            Assert.Null(persisted);
+            Assert.Equal(Visibility.Visible, dialog.Visibility);
+            Assert.Equal(Visibility.Visible, error.Visibility);
+            Assert.Contains("could not write", error.Text, StringComparison.Ordinal);
+            Assert.Equal("Try again", confirm.Content);
+            Assert.Equal("The last profile save attempt failed.", status.Text);
+            Assert.False(nameInput.IsEnabled);
+
+            failSave = false;
+            confirm.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            Assert.Equal(2, saveAttempts);
+            Assert.Same(created, Assert.Single(settings.HudPresets));
+            var restored = JsonSerializer.Deserialize<AppSettings>(Assert.IsType<string>(persisted))!;
+            Assert.Equal(created.Id, Assert.Single(restored.HudPresets).Id);
+            Assert.Equal(Visibility.Collapsed, dialog.Visibility);
+            Assert.Empty(error.Text);
+            Assert.Equal("Night driving saved.", status.Text);
+        }
+        finally
+        {
+            window?.Close();
+            controller.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    private static AppSettings CompletedSettings()
+    {
+        var settings = new AppSettings
+        {
+            StartWithWindows = false,
+            AutomaticApplicationUpdateChecks = false
+        };
+        var now = DateTimeOffset.UtcNow;
+        var preferences = SetupPreferences.FromSettings(settings) with
+        {
+            DataOutConfirmed = true,
+            DisplayModeConfirmed = true,
+            StockHudConfirmed = true
+        };
+        SetupCompletion.Save(
+            settings,
+            preferences,
+            new SetupTelemetryEvidence(
+                settings.UdpPort, 12, 12, TimeSpan.FromMilliseconds(550), now),
+            _ => { },
+            now);
+        return settings;
+    }
+
+    private static Exception SaveFailure(string failure) => failure switch
+    {
+        "io" => new IOException("Synthetic settings failure"),
+        "access" => new UnauthorizedAccessException("Synthetic settings failure"),
+        "security" => new SecurityException("Synthetic settings failure"),
+        _ => throw new ArgumentOutOfRangeException(nameof(failure))
+    };
+
+    private static void SetPendingField(AppController controller, string name, object? value)
+    {
+        var field = typeof(AppController).GetField(
+            name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field.SetValue(controller, value);
+    }
+
+    private sealed class NoStartupRegistration : IStartupRegistrationService
+    {
+        public void Apply(bool startWithWindows, bool startWithForza)
+        {
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));

--- a/tests/Wisp.App.Tests/ReleaseNotesLayoutAssertions.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesLayoutAssertions.cs
@@ -1,0 +1,49 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+internal static class ReleaseNotesLayoutAssertions
+{
+    internal static void Verify(MainWindow window, FrameworkElement surface, TabControl tabs)
+    {
+        tabs.SelectedItem = window.FindName("ReleaseNotesTab");
+        foreach (var size in new[] { new Size(720, 440), new Size(980, 750), new Size(1440, 900) })
+        {
+            surface.Measure(size);
+            surface.Arrange(new Rect(size));
+            surface.UpdateLayout();
+            var versions = Descendants(surface).OfType<TextBlock>()
+                .Where(text => text.Name == "ReleaseVersionText").ToArray();
+            Assert.Equal(ReleaseNotesCatalog.Entries.Count, versions.Length);
+            foreach (var version in versions)
+            {
+                Assert.Equal(TextWrapping.Wrap, version.TextWrapping);
+                var natural = new TextBlock
+                {
+                    Text = version.Text,
+                    FontFamily = version.FontFamily,
+                    FontSize = version.FontSize,
+                    FontWeight = version.FontWeight,
+                    FontStyle = version.FontStyle,
+                    FontStretch = version.FontStretch
+                };
+                natural.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                Assert.True(version.ActualWidth >= natural.DesiredSize.Width - 1,
+                    $"{version.Text} is clipped at {size.Width}: {version.ActualWidth} < {natural.DesiredSize.Width}.");
+            }
+        }
+    }
+
+    private static IEnumerable<DependencyObject> Descendants(DependencyObject root)
+    {
+        for (var index = 0; index < VisualTreeHelper.GetChildrenCount(root); index++)
+        {
+            var child = VisualTreeHelper.GetChild(root, index);
+            yield return child;
+            foreach (var descendant in Descendants(child)) yield return descendant;
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/ReleaseTagPolicyTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseTagPolicyTests.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class ReleaseTagPolicyTests
+{
+    [Fact]
+    public async Task NumericTagGateNormalizesOnlyStableBoundedVersions()
+    {
+        var shell = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System),
+            "WindowsPowerShell", "v1.0", "powershell.exe");
+        Assert.True(File.Exists(shell));
+        var startInfo = new ProcessStartInfo(shell)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-EncodedCommand");
+        startInfo.ArgumentList.Add(Convert.ToBase64String(Encoding.Unicode.GetBytes(Harness)));
+        startInfo.Environment["PSModulePath"] = Path.Combine(Path.GetDirectoryName(shell)!, "Modules");
+        startInfo.Environment["WISP_RELEASE_TAG_SCRIPT"] = Path.Combine(
+            RepositoryRoot(), ".github", "scripts", "Test-ReleaseTag.ps1");
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+        var errors = process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("The release-tag parser check exceeded its deadline.");
+        }
+        var result = await output;
+        var diagnostics = await errors;
+        Assert.True(process.ExitCode == 0, $"Release-tag parser check failed: {result} {diagnostics}");
+        Assert.Contains("release-tag-parser-ok", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseAutomationKeepsCanonicalArtifactsAndBothTagCasesProtected()
+    {
+        var root = RepositoryRoot();
+        var workflow = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+        var policy = File.ReadAllText(Path.Combine(root, ".github", "scripts", "Test-ReleaseTag.ps1"));
+        var rules = File.ReadAllText(Path.Combine(root, ".github", "rulesets", "protect-release-tags.json"));
+        Assert.Contains("tags: [\"v*\", \"V*\"]", workflow, StringComparison.Ordinal);
+        Assert.Contains("src/Wisp.App/Wisp.App.csproj", workflow, StringComparison.Ordinal);
+        Assert.Contains("display_version=\"${version%.0}\"", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("${GITHUB_REF_NAME#v}", workflow, StringComparison.Ordinal);
+        Assert.Contains("Wisp-Setup-${version}.exe", workflow, StringComparison.Ordinal);
+        Assert.Contains("--title \"Wisp ${display_version}\"", workflow, StringComparison.Ordinal);
+        Assert.Contains("refs/tags/v*", rules, StringComparison.Ordinal);
+        Assert.Contains("refs/tags/V*", rules, StringComparison.Ordinal);
+        Assert.Contains("$tagCommit[0] -cne $head[0]", policy, StringComparison.Ordinal);
+        Assert.Contains("$head[0] -cne $main[0]", policy, StringComparison.Ordinal);
+        Assert.Contains("$projectVersion -cne $version -or $installerVersion -cne $version", policy,
+            StringComparison.Ordinal);
+        Assert.Contains("$releaseNotesHeading -cne \"# Wisp $version\"", policy, StringComparison.Ordinal);
+        Assert.Contains("$releaseNotesHeading -cne \"# Wisp $displayVersion\"", policy, StringComparison.Ordinal);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Wisp.sln")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not locate Wisp.sln from the test output directory.");
+    }
+
+    private const string Harness = """
+        $ErrorActionPreference = 'Stop'
+        try {
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $env:WISP_RELEASE_TAG_SCRIPT, [ref]$tokens, [ref]$errors)
+            if ($errors.Count -ne 0) { throw 'The release-tag script has syntax errors.' }
+            $function = $ast.Find({ param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'ConvertTo-CanonicalReleaseVersion'
+            }, $true)
+            if ($null -eq $function) { throw 'The numeric tag parser is missing.' }
+            . ([scriptblock]::Create($function.Extent.Text))
+            $accepted = [ordered]@{
+                'v1' = '1.0.0'; 'v1.0' = '1.0.0'; 'v1.0.0' = '1.0.0'
+                'V1.1' = '1.1.0'; '1.1' = '1.1.0'; '0' = '0.0.0'
+                'v1-stable' = '1.0.0'; 'V1.1-STABLE' = '1.1.0'
+                'v1.2.3-stable' = '1.2.3'; 'v65535.65535.65535' = '65535.65535.65535'
+            }
+            foreach ($entry in $accepted.GetEnumerator()) {
+                $actual = ConvertTo-CanonicalReleaseVersion $entry.Key
+                if ($actual -cne $entry.Value) { throw "Incorrect normalization for $($entry.Key)." }
+            }
+            foreach ($value in @(
+                'v01', 'v1.02', 'v1.0.00', 'v1.0.0.0', 'v1.', 'v1..0', 'v1 stable',
+                'v1.1-rc.1', 'v1.1-stable.1', 'v65536', 'v1.65536', 'v1.0.65536',
+                'v99999999999999999999999', ' v1', "v1`n", '-1', 'v-1', 'v1-stable ',
+                'v1+build', 'stable', 'version1', ('v' + ('1' * 128)))) {
+                $rejected = $false
+                try { $null = ConvertTo-CanonicalReleaseVersion $value }
+                catch { $rejected = $true }
+                if (-not $rejected) { throw 'An invalid numeric release tag was accepted.' }
+            }
+            Write-Output 'release-tag-parser-ok'
+        }
+        catch {
+            Write-Output $_.Exception.Message
+            exit 1
+        }
+        """;
+}

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -339,7 +339,9 @@ public sealed class WpfStyleRuntimeTests
                 }
 
                 ScrollLayoutAssertions.Verify(mainWindow, surface, tabs);
+                ReleaseNotesLayoutAssertions.Verify(mainWindow, surface, tabs);
                 CalmSidebarTests.AssertOnCurrentDispatcher(mainWindow, surface);
+                MaintenancePersistenceTests.AssertProfileSaveRetryOnCurrentDispatcher();
 
                 tabs.SelectedIndex = 2;
                 surface.UpdateLayout();

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -218,9 +218,8 @@ public sealed class XamlContractTests
             element.Attribute("Content")?.Value == "Use current theme");
 
         var footer = document.Descendants(Presentation + "TextBlock")
-            .Single(element => element.Attribute("Text")?.Value?.StartsWith(
-                "WHEEL-INDICATED SPEED PANEL", StringComparison.Ordinal) == true);
-        Assert.Equal("WHEEL-INDICATED SPEED PANEL 1.0.12", footer.Attribute("Text")?.Value);
+            .Single(element => element.Attribute(Xaml + "Name")?.Value == "ApplicationVersionFooter");
+        Assert.Equal("{x:Static local:ApplicationVersionInfo.FooterText}", footer.Attribute("Text")?.Value);
     }
 
     [Fact]

--- a/tests/Wisp.Core.Tests/CalibrationPersistenceIdentityTests.cs
+++ b/tests/Wisp.Core.Tests/CalibrationPersistenceIdentityTests.cs
@@ -1,0 +1,124 @@
+using Xunit;
+
+namespace Wisp.Core.Tests;
+
+public sealed class CalibrationPersistenceIdentityTests
+{
+    [Fact]
+    public void CapturesOnlySnapshotsAcceptedByTheEstimator()
+    {
+        var estimator = new RollingRadiusEstimator();
+        var accepted = Snapshot();
+        estimator.ImportSnapshots(new[]
+        {
+            accepted,
+            accepted with { CarOrdinal = 101, CalibrationRevision = 0 },
+            accepted with { CarOrdinal = 102, SampleCount = CalibrationOptions.DefaultMinimumSamples - 1 },
+            accepted with { CarOrdinal = 103, Drivetrain = (DrivetrainType)99 },
+            accepted with { CarOrdinal = 104, FrontRadiusMeters = double.NaN },
+            accepted with { CarOrdinal = 0 }
+        });
+
+        var captured = CalibrationPersistenceIdentity.Capture(estimator);
+
+        Assert.Equal(accepted.CarOrdinal, Assert.Single(captured).Key);
+        Assert.True(captured[accepted.CarOrdinal].Matches(Identity()));
+    }
+
+    [Fact]
+    public void RejectedDuplicateCannotReplaceTheLastAcceptedIdentity()
+    {
+        var estimator = new RollingRadiusEstimator();
+        var accepted = Snapshot();
+        estimator.ImportSnapshots(new[]
+        {
+            accepted with { Drivetrain = DrivetrainType.FrontWheelDrive },
+            accepted,
+            accepted with { CalibrationRevision = 0, RearRadiusMeters = 0.4 }
+        });
+
+        var captured = CalibrationPersistenceIdentity.Capture(estimator);
+
+        Assert.True(Assert.Single(captured).Value.Matches(Identity()));
+    }
+
+    [Fact]
+    public void ChangedDrivetrainIsNotHiddenByEqualRadii()
+    {
+        var saved = Identity();
+        var current = saved with { Drivetrain = DrivetrainType.AllWheelDrive };
+
+        Assert.False(saved.Matches(current));
+    }
+
+    [Fact]
+    public void ChangedRevisionIsNotHiddenByEqualRadii()
+    {
+        var saved = Identity() with { CalibrationRevision = 0 };
+
+        Assert.False(saved.Matches(Identity()));
+    }
+
+    [Fact]
+    public void SampleCountGrowthDoesNotRequestAnotherSave()
+    {
+        var first = new RollingRadiusEstimator();
+        first.ImportSnapshots(new[] { Snapshot() });
+        var second = new RollingRadiusEstimator();
+        second.ImportSnapshots(new[] { Snapshot() with { SampleCount = 100 } });
+
+        var saved = Assert.Single(CalibrationPersistenceIdentity.Capture(first)).Value;
+        var current = Assert.Single(CalibrationPersistenceIdentity.Capture(second)).Value;
+
+        Assert.True(saved.Matches(current));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EitherAxleRetainsTheExistingRelativeRadiusTolerance(bool frontAxle)
+    {
+        var saved = Identity();
+        var belowTolerance = saved with
+        {
+            Radii = frontAxle
+                ? new RollingRadii(0.3 * (1 + 0.5e-9), 0.3)
+                : new RollingRadii(0.3, 0.3 * (1 + 0.5e-9))
+        };
+        var aboveTolerance = saved with
+        {
+            Radii = frontAxle
+                ? new RollingRadii(0.3 * (1 + 2e-9), 0.3)
+                : new RollingRadii(0.3, 0.3 * (1 + 2e-9))
+        };
+
+        Assert.True(saved.Matches(belowTolerance));
+        Assert.False(saved.Matches(aboveTolerance));
+    }
+
+    [Fact]
+    public void RejectedLoadedRevisionCannotSuppressEqualRadiusRelearning()
+    {
+        var estimator = new RollingRadiusEstimator();
+        estimator.ImportSnapshots(new[] { Snapshot() with { CalibrationRevision = 0 } });
+        var saved = CalibrationPersistenceIdentity.Capture(estimator);
+        for (var index = 0; index < CalibrationOptions.DefaultMinimumSamples; index++)
+        {
+            estimator.Observe(TestVehicleState.Create());
+        }
+
+        var relearned = Assert.Single(CalibrationPersistenceIdentity.Capture(estimator));
+
+        Assert.False(saved.ContainsKey(relearned.Key));
+        Assert.True(relearned.Value.Matches(Identity()));
+    }
+
+    private static CalibrationPersistenceIdentity Identity() => new(
+        DrivetrainType.RearWheelDrive,
+        RollingRadiusEstimator.CurrentCalibrationRevision,
+        new RollingRadii(0.3, 0.3));
+
+    private static CalibrationSnapshot Snapshot() => new(
+        100, 0.3, CalibrationOptions.DefaultMinimumSamples, DrivetrainType.RearWheelDrive,
+        RollingRadiusEstimator.CurrentCalibrationRevision, 0.3, 0.3);
+}

--- a/tests/Wisp.Core.Tests/SpeedModelTests.cs
+++ b/tests/Wisp.Core.Tests/SpeedModelTests.cs
@@ -262,41 +262,89 @@ public sealed class SpeedModelTests
     }
 
     [Theory]
-    [InlineData(100, 400)]
-    [InlineData(400, 100)]
-    public void MaximumSmoothingStaysWithinOnePointFiveMphOfLiveWheelSpeed(
-        float firstWheelSpeed,
-        float currentWheelSpeed)
+    [InlineData(0)]
+    [InlineData(1)]
+    public void RapidWheelSpeedSwingsAreAttenuatedOnlyWhenSmoothingIsEnabled(double smoothing)
     {
         const double radiusMeters = 0.3;
         var model = new SpeedModel();
+        var elapsed = TimeSpan.FromSeconds(1d / 60);
+        double? previousMph = null;
+        double maximumFrameChangeMph = 0;
+        var settled = new List<double>();
+
+        for (var frame = 0; frame < 120; frame++)
+        {
+            var rawMph = frame % 2 == 0 ? 100d : 200d;
+            var angularSpeed = (float)(rawMph /
+                SpeedModel.MetersPerSecondToMilesPerHour / radiusMeters);
+            var state = TestVehicleState.Create(
+                wheelSpeed: new WheelValues(angularSpeed, angularSpeed, angularSpeed, angularSpeed));
+            var speed = model.Calculate(
+                state, radiusMeters, SpeedUnit.MilesPerHour,
+                WheelAggregationMode.RawDrivenWheels, smoothing, elapsed);
+
+            Assert.True(speed.IsAvailable);
+            if (smoothing == 0)
+            {
+                Assert.Equal(rawMph, speed.DisplayValue, 4);
+            }
+            if (previousMph is { } previous)
+            {
+                maximumFrameChangeMph = Math.Max(
+                    maximumFrameChangeMph, Math.Abs(speed.DisplayValue - previous));
+            }
+            previousMph = speed.DisplayValue;
+            if (frame >= 90)
+            {
+                settled.Add(speed.DisplayValue);
+            }
+        }
+
+        if (smoothing == 1)
+        {
+            Assert.InRange(maximumFrameChangeMph, 0, 7);
+            Assert.InRange(settled.Min(), 148, 149);
+            Assert.InRange(settled.Max(), 151, 152);
+        }
+        else
+        {
+            Assert.InRange(maximumFrameChangeMph, 99.99, 100.01);
+        }
+    }
+
+    [Theory]
+    [InlineData(60, SpeedUnit.MilesPerHour)]
+    [InlineData(120, SpeedUnit.KilometersPerHour)]
+    public void MaximumSmoothingFollowsTheQuarterSecondExponentialResponse(
+        int framesPerSecond,
+        SpeedUnit unit)
+    {
+        const double radiusMeters = 0.3;
+        const double initialMetersPerSecond = 100 * radiusMeters;
+        const double targetMetersPerSecond = 400 * radiusMeters;
+        var model = new SpeedModel();
+        var elapsed = TimeSpan.FromSeconds(1d / framesPerSecond);
         model.Calculate(
-            TestVehicleState.Create(wheelSpeed: new WheelValues(
-                firstWheelSpeed,
-                firstWheelSpeed,
-                firstWheelSpeed,
-                firstWheelSpeed)),
-            radiusMeters,
-            SpeedUnit.MilesPerHour,
-            WheelAggregationMode.RawDrivenWheels,
-            smoothing: 1,
-            elapsed: TimeSpan.FromMilliseconds(16));
+            TestVehicleState.Create(wheelSpeed: new WheelValues(100, 100, 100, 100)),
+            radiusMeters, unit, WheelAggregationMode.RawDrivenWheels, 1, elapsed);
+        var changed = TestVehicleState.Create(wheelSpeed: new WheelValues(400, 400, 400, 400));
+        var multiplier = unit == SpeedUnit.MilesPerHour
+            ? SpeedModel.MetersPerSecondToMilesPerHour
+            : SpeedModel.MetersPerSecondToKilometersPerHour;
 
-        var current = model.Calculate(
-            TestVehicleState.Create(wheelSpeed: new WheelValues(
-                currentWheelSpeed,
-                currentWheelSpeed,
-                currentWheelSpeed,
-                currentWheelSpeed)),
-            radiusMeters,
-            SpeedUnit.MilesPerHour,
-            WheelAggregationMode.RawDrivenWheels,
-            smoothing: 1,
-            elapsed: TimeSpan.FromMilliseconds(16));
-        var rawMph = currentWheelSpeed * radiusMeters *
-                     SpeedModel.MetersPerSecondToMilesPerHour;
+        for (var frame = 1; frame <= framesPerSecond * 3 / 4; frame++)
+        {
+            var speed = model.Calculate(
+                changed, radiusMeters, unit, WheelAggregationMode.RawDrivenWheels, 1, elapsed);
+            var elapsedSeconds = elapsed.TotalSeconds * frame;
+            var expected = targetMetersPerSecond +
+                (initialMetersPerSecond - targetMetersPerSecond) * Math.Exp(-elapsedSeconds / 0.25);
 
-        Assert.InRange(Math.Abs(current.DisplayValue - rawMph), 0, 1.500001);
+            Assert.Equal(expected, speed.MetersPerSecond, 9);
+            Assert.Equal(expected * multiplier, speed.DisplayValue, 9);
+            Assert.InRange(speed.MetersPerSecond, initialMetersPerSecond, targetMetersPerSecond);
+        }
     }
 
     [Fact]

--- a/tests/Wisp.Core.Tests/TelemetryFreshnessTests.cs
+++ b/tests/Wisp.Core.Tests/TelemetryFreshnessTests.cs
@@ -1,18 +1,109 @@
+using System.Diagnostics;
 using Xunit;
 
 namespace Wisp.Core.Tests;
 
 public sealed class TelemetryFreshnessTests
 {
+    private static readonly long Origin = Stopwatch.Frequency * 10;
+
     [Fact]
     public void TransitionsFromConnectedToLostAfterTimeout()
     {
-        var origin = new DateTimeOffset(2026, 8, 13, 12, 0, 0, TimeSpan.Zero);
         var freshness = new TelemetryFreshness(TimeSpan.FromMilliseconds(750));
 
-        Assert.Equal(TelemetryConnectionState.Waiting, freshness.GetState(origin));
-        freshness.RecordPacket(origin);
-        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(origin.AddMilliseconds(749)));
-        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(origin.AddMilliseconds(751)));
+        Assert.Equal(TelemetryConnectionState.Waiting, freshness.GetState(Origin));
+        Assert.Null(freshness.GetAge(Origin));
+        freshness.RecordPacket(Origin);
+        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(AtMilliseconds(749)));
+        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(AtMilliseconds(750)));
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(751)));
+        Assert.Equal(TimeSpan.FromMilliseconds(751), freshness.GetAge(AtMilliseconds(751)));
     }
+
+    [Fact]
+    public void StoppedInputStaysLostUntilANewArrivalReconnects()
+    {
+        var freshness = new TelemetryFreshness(TimeSpan.FromMilliseconds(300));
+        freshness.RecordPacket(Origin);
+
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(301)));
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(10_000)));
+
+        freshness.RecordPacket(AtMilliseconds(10_000));
+
+        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(AtMilliseconds(10_000)));
+        Assert.Equal(TimeSpan.Zero, freshness.GetAge(AtMilliseconds(10_000)));
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(10_301)));
+    }
+
+    [Theory]
+    [InlineData(-24)]
+    [InlineData(24)]
+    public void WallClockChangesDoNotAlterArrivalExpiry(int wallClockShiftHours)
+    {
+        var freshness = new TelemetryFreshness(TimeSpan.FromMilliseconds(300));
+        var packet = TestVehicleState.Create() with
+        {
+            ReceivedAtUtc = new DateTimeOffset(2026, 8, 13, 12, 0, 0, TimeSpan.Zero),
+            ReceivedTimestamp = Origin
+        };
+        freshness.RecordPacket(packet.ReceivedTimestamp);
+
+        var next = packet with
+        {
+            ReceivedAtUtc = packet.ReceivedAtUtc.AddHours(wallClockShiftHours),
+            ReceivedTimestamp = AtMilliseconds(100)
+        };
+        freshness.RecordPacket(next.ReceivedTimestamp);
+
+        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(AtMilliseconds(399)));
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(401)));
+        Assert.Equal(TimeSpan.FromMilliseconds(301), freshness.GetAge(AtMilliseconds(401)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void MissingOrInvalidArrivalCannotEstablishFreshness(long? receivedTimestamp)
+    {
+        var freshness = new TelemetryFreshness();
+        freshness.RecordPacket(receivedTimestamp);
+
+        Assert.Equal(TelemetryConnectionState.Waiting, freshness.GetState(Origin));
+        Assert.Null(freshness.GetAge(Origin));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void MissingOrInvalidArrivalCannotExtendExistingFreshness(long? receivedTimestamp)
+    {
+        var freshness = new TelemetryFreshness(TimeSpan.FromMilliseconds(300));
+        freshness.RecordPacket(Origin);
+        freshness.RecordPacket(receivedTimestamp);
+
+        Assert.Equal(TelemetryConnectionState.Connected, freshness.GetState(AtMilliseconds(299)));
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(301)));
+        Assert.Equal(TimeSpan.FromMilliseconds(301), freshness.GetAge(AtMilliseconds(301)));
+
+        freshness.RecordPacket(receivedTimestamp);
+
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(AtMilliseconds(1_000)));
+    }
+
+    [Fact]
+    public void ObservationBeforeArrivalFailsClosed()
+    {
+        var freshness = new TelemetryFreshness();
+        freshness.RecordPacket(Origin);
+
+        Assert.Equal(TelemetryConnectionState.Lost, freshness.GetState(Origin - 1));
+        Assert.Null(freshness.GetAge(Origin - 1));
+    }
+
+    private static long AtMilliseconds(int milliseconds) =>
+        Origin + Stopwatch.Frequency * milliseconds / 1_000;
 }

--- a/tests/Wisp.Update.Tests/GitHubReleaseTests.cs
+++ b/tests/Wisp.Update.Tests/GitHubReleaseTests.cs
@@ -48,6 +48,7 @@ public sealed class GitHubReleaseTests
         var release = await client.GetLatestReleaseAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(ReleaseTestData.FixtureVersion, release.Version);
+        Assert.Equal("v9.8.7", release.TagName);
         Assert.Equal("Wisp-Setup-9.8.7.exe", release.FileName);
         Assert.Equal(123, release.Size);
         Assert.Equal(new string('a', 64), release.Sha256);
@@ -123,11 +124,132 @@ public sealed class GitHubReleaseTests
     [InlineData("v01.2.3")]
     [InlineData("v1.2.3-rc.1")]
     [InlineData("v1.2.3+build")]
-    public async Task NonCanonicalReleaseTagsAreRejected(string tag)
+    public async Task InvalidOrConflictingReleaseTagsAreRejected(string tag)
     {
         var json = ReleaseTestData.CreateJson(mutateRelease: release => release["tag_name"] = tag);
 
         await AssertRejectedAsync(json);
+    }
+
+    [Theory]
+    [InlineData("1", "Wisp-Setup-1.exe", "1.0.0")]
+    [InlineData("v1", "Wisp-Setup-v1.0.0.exe", "1.0.0")]
+    [InlineData("V1.1", "Wisp-Setup-1.1.exe", "1.1.0")]
+    [InlineData("1.1.0", "Wisp-Setup-V1.1.0.exe", "1.1.0")]
+    [InlineData("v1-stable", "Wisp-Setup-1.0.exe", "1.0.0")]
+    [InlineData("v1.1.0-Stable", "Wisp-Setup-1.1.exe", "1.1.0")]
+    [InlineData("Wisp1Stable", "Wisp-Setup-1.0.exe", "1.0.0")]
+    [InlineData("September-Stable", "Wisp-Setup-1.1.0.exe", "1.1.0")]
+    public async Task StableReleaseNamesUseAssetIdentityAndRetainExactDownloadNames(
+        string tag, string fileName, string expectedVersion)
+    {
+        var json = ReleaseTestData.CreateJson(tagName: tag, fileName: fileName, title: "Wisp 1 Stable");
+        using var handler = new ScriptedHttpHandler((_, _, _) =>
+            Task.FromResult(ScriptedHttpHandler.JsonResponse(json)));
+        using var http = new HttpClient(handler);
+        using var client = new WispUpdateClient(http);
+
+        var release = await client.GetLatestReleaseAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedVersion, release.Version.ToString());
+        Assert.Equal(tag, release.TagName);
+        Assert.Equal(fileName, release.FileName);
+        Assert.Equal($"https://github.com/Views2k/Wisp/releases/download/{tag}/{fileName}", release.DownloadUri.AbsoluteUri);
+    }
+
+    [Theory]
+    [InlineData("v2-stable")]
+    [InlineData("1.2")]
+    [InlineData("01")]
+    [InlineData("v1.01")]
+    [InlineData("1.1.0.0")]
+    [InlineData("v65536")]
+    [InlineData("v1.1-final")]
+    [InlineData("../stable")]
+    [InlineData("stable..release")]
+    [InlineData("stable.")]
+    [InlineData("release/stable")]
+    [InlineData("stable%2frelease")]
+    [InlineData("stable?redirect=1")]
+    [InlineData("stable#fragment")]
+    [InlineData("Wisp 1.1 Stable")]
+    [InlineData("preview")]
+    [InlineData("nightly-2026")]
+    [InlineData("release-beta1")]
+    [InlineData("v1.1-rc.1")]
+    public async Task ConflictingMalformedUnsafeAndPrereleaseTagsAreRejected(string tag)
+    {
+        await AssertRejectedAsync(ReleaseTestData.CreateJson(
+            tagName: tag, fileName: "Wisp-Setup-1.1.exe"));
+    }
+
+    [Theory]
+    [InlineData("Wisp 1.1 Beta")]
+    [InlineData("1.1.0-rc.1")]
+    [InlineData("v1 preview")]
+    public async Task ExplicitPrereleaseTitlesAreRejectedEvenWithStableFlags(string title)
+    {
+        await AssertRejectedAsync(ReleaseTestData.CreateJson(title: title));
+    }
+
+    [Fact]
+    public async Task DescriptiveTitleDoesNotOverrideAssetVersionOrBecomeAPrereleaseFlag()
+    {
+        var json = ReleaseTestData.CreateJson(title: "Wisp 1.1 fixes beta telemetry");
+        using var handler = new ScriptedHttpHandler((_, _, _) =>
+            Task.FromResult(ScriptedHttpHandler.JsonResponse(json)));
+        using var http = new HttpClient(handler);
+        using var client = new WispUpdateClient(http);
+
+        var release = await client.GetLatestReleaseAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(ReleaseTestData.FixtureVersion, release.Version);
+    }
+
+    [Theory]
+    [InlineData("Wisp-Setup-9.8.exe")]
+    [InlineData("Wisp-Setup-9.8.7-arm64.exe")]
+    [InlineData("wisp-setup-9.8.7.exe")]
+    public async Task ASecondVersionedOrMalformedInstallerMakesTheReleaseAmbiguous(string secondName)
+    {
+        var json = ReleaseTestData.CreateJson(mutateRelease: release =>
+        {
+            var assets = (JsonArray)release["assets"]!;
+            var second = assets[0]!.DeepClone();
+            second["name"] = secondName;
+            assets.Add(second);
+        });
+
+        await AssertRejectedAsync(json);
+    }
+
+    [Theory]
+    [InlineData("https://github.com/Views2k/Wisp/releases/download/v1.1.0/Wisp-Setup-1.1.exe")]
+    [InlineData("https://github.com/Views2k/Wisp/releases/download/stable/Wisp-Setup-1.1.0.exe")]
+    [InlineData("https://github.com/Views2k/Other/releases/download/stable/Wisp-Setup-1.1.exe")]
+    [InlineData("https://github.com/Views2k/Wisp/releases/download/stable/Wisp-Setup-1.1.exe?unexpected=1")]
+    public async Task FlexibleLabelsCannotChangeTheValidatedRepositoryTagOrFilename(string url)
+    {
+        await AssertRejectedAsync(ReleaseTestData.CreateJson(
+            tagName: "stable", fileName: "Wisp-Setup-1.1.exe",
+            mutateAsset: asset => asset["browser_download_url"] = url));
+    }
+
+    [Theory]
+    [InlineData("1.0.12.0", true)]
+    [InlineData("1.1.0.0", false)]
+    [InlineData("2.0.0.0", false)]
+    public async Task AssetDerivedVersionCannotOfferAnEqualVersionOrDowngrade(string current, bool available)
+    {
+        var json = ReleaseTestData.CreateJson(tagName: "stable", fileName: "Wisp-Setup-1.1.exe");
+        using var handler = new ScriptedHttpHandler((_, _, _) =>
+            Task.FromResult(ScriptedHttpHandler.JsonResponse(json)));
+        using var http = new HttpClient(handler);
+        using var client = new WispUpdateClient(http);
+
+        var result = await client.CheckForUpdateAsync(Version.Parse(current), TestContext.Current.CancellationToken);
+
+        Assert.Equal(available, result is not null);
     }
 
     [Theory]

--- a/tests/Wisp.Update.Tests/InstallerDownloadTests.cs
+++ b/tests/Wisp.Update.Tests/InstallerDownloadTests.cs
@@ -75,6 +75,66 @@ public sealed class InstallerDownloadTests
         Assert.Empty(Directory.EnumerateFileSystemEntries(directory.Path));
     }
 
+    [Theory]
+    [InlineData("release-stable")]
+    [InlineData("V9.8.7-Stable")]
+    public async Task LabelledReleaseKeepsExactAssetIdentityThroughDownloadVerification(string tag)
+    {
+        const string fileName = "Wisp-Setup-V9.8.7.exe";
+        var installer = File.ReadAllBytes(ReleaseTestData.FixtureExecutablePath());
+        var digest = ReleaseTestData.Sha256(installer);
+        var assetUri = new Uri($"https://github.com/Views2k/Wisp/releases/download/{tag}/{fileName}");
+        using var directory = new TemporaryDirectory();
+        using var handler = new ScriptedHttpHandler((request, sequence, _) =>
+        {
+            if (sequence == 1)
+            {
+                return Task.FromResult(ScriptedHttpHandler.JsonResponse(ReleaseTestData.CreateJson(
+                    size: installer.LongLength, sha256: digest, tagName: tag, fileName: fileName)));
+            }
+
+            if (sequence == 2)
+            {
+                Assert.Equal(assetUri, request.RequestUri);
+                return Task.FromResult(Redirect(DeliveryUri));
+            }
+
+            Assert.Equal(3, sequence);
+            Assert.Equal(DeliveryUri, request.RequestUri);
+            return Task.FromResult(Bytes(installer));
+        });
+        using var http = new HttpClient(handler);
+        using var client = new WispUpdateClient(http);
+        var release = await client.GetLatestReleaseAsync(TestContext.Current.CancellationToken);
+
+        var verified = await client.DownloadInstallerAsync(
+            release, directory.Path, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(Path.Combine(directory.Path, fileName), verified.StagedPath);
+        Assert.Equal(ReleaseTestData.FixtureVersion, verified.Version);
+        Assert.Equal(digest, verified.Sha256);
+        Assert.Equal(installer, await File.ReadAllBytesAsync(verified.StagedPath, TestContext.Current.CancellationToken));
+        Assert.Equal(3, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task LabelledReleaseCannotRedirectToAReconstructedNumericReleaseUrl()
+    {
+        using var directory = new TemporaryDirectory();
+        using var handler = new ScriptedHttpHandler((_, sequence, _) => Task.FromResult(sequence == 1
+            ? ScriptedHttpHandler.JsonResponse(ReleaseTestData.CreateJson(tagName: "release-stable"))
+            : Redirect(ReleaseUriPolicy.InitialDownloadUri(ReleaseTestData.FixtureVersion))));
+        using var http = new HttpClient(handler);
+        using var client = new WispUpdateClient(http);
+        var release = await client.GetLatestReleaseAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<UpdateSecurityException>(() => client.DownloadInstallerAsync(
+            release, directory.Path, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(2, handler.RequestCount);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(directory.Path));
+    }
+
     [Fact]
     public async Task MoreThanThreeRedirectsAreRejected()
     {

--- a/tests/Wisp.Update.Tests/ReleaseTestData.cs
+++ b/tests/Wisp.Update.Tests/ReleaseTestData.cs
@@ -13,23 +13,28 @@ internal static class ReleaseTestData
         long size = 123,
         string? sha256 = null,
         Action<JsonObject>? mutateRelease = null,
-        Action<JsonObject>? mutateAsset = null)
+        Action<JsonObject>? mutateAsset = null,
+        string? tagName = null,
+        string? fileName = null,
+        string? title = null)
     {
         var selectedVersion = version ?? FixtureVersion;
-        var fileName = ReleaseUriPolicy.InstallerFileName(selectedVersion);
+        var selectedFileName = fileName ?? ReleaseUriPolicy.InstallerFileName(selectedVersion);
+        var selectedTagName = tagName ?? selectedVersion.ToTagString();
         var asset = new JsonObject
         {
-            ["name"] = fileName,
+            ["name"] = selectedFileName,
             ["state"] = "uploaded",
             ["size"] = size,
             ["digest"] = $"sha256:{sha256 ?? new string('a', 64)}",
-            ["browser_download_url"] = ReleaseUriPolicy.InitialDownloadUri(selectedVersion).AbsoluteUri
+            ["browser_download_url"] = $"https://github.com/Views2k/Wisp/releases/download/{selectedTagName}/{selectedFileName}"
         };
         mutateAsset?.Invoke(asset);
 
         var release = new JsonObject
         {
-            ["tag_name"] = selectedVersion.ToTagString(),
+            ["tag_name"] = selectedTagName,
+            ["name"] = title,
             ["draft"] = false,
             ["prerelease"] = false,
             ["immutable"] = true,

--- a/tests/Wisp.Update.Tests/SemanticVersionTests.cs
+++ b/tests/Wisp.Update.Tests/SemanticVersionTests.cs
@@ -63,6 +63,37 @@ public sealed class SemanticVersionTests
         Assert.Throws<ArgumentException>(() => SemanticVersion.FromSystemVersion(new Version(1, 2, 3, 4)));
     }
 
+    [Theory]
+    [InlineData("1", "1.0.0")]
+    [InlineData("v1", "1.0.0")]
+    [InlineData("V1.0", "1.0.0")]
+    [InlineData("1.1", "1.1.0")]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("65535.65535.65535", "65535.65535.65535")]
+    public void ReleaseVersionsNormalizeWithoutChangingMachineVersionFormatting(string value, string expected)
+    {
+        Assert.True(SemanticVersion.TryParseReleaseVersion(value, out var parsed));
+        Assert.Equal(expected, parsed.ToString());
+        Assert.Equal(SemanticVersion.Parse(expected), parsed);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("01")]
+    [InlineData("1.01")]
+    [InlineData("1.0.0.0")]
+    [InlineData("1.0-beta")]
+    [InlineData("1.0+build")]
+    [InlineData("1.0-stable")]
+    [InlineData("1.")]
+    [InlineData("1.0 ")]
+    [InlineData("65536")]
+    public void ReleaseVersionsRejectAmbiguousOrNonNumericInput(string? value)
+    {
+        Assert.False(SemanticVersion.TryParseReleaseVersion(value, out _));
+    }
+
     [Fact]
     public void VersionsUseSemanticOrdering()
     {


### PR DESCRIPTION
Makes wheel-indicated speed smoothing honor the selected amount during wheelspin, hardens profile and calibration saves, and uses monotonic telemetry freshness. Preserves downloaded update details on retry, improves the setup background, and fixes clipped release-history versions.

Adds flexible release labels while retaining exact installer identity, size, SHA-256, embedded version, and downgrade checks. This bridge release uses v1.1.0 and Wisp-Setup-1.1.0.exe so existing 1.0.12 installations can discover it. Public display name: Wisp 1.1.

Validation: the private installer passed 2,600 .NET tests, 75 Python tests, formatting, and installer artifact validation. Setup and release-history layout checks passed. The only subsequent app edits finalize release wording. Required CI will validate this exact commit. Installer lifecycle runs only on the ephemeral runner.

No changes to tire-learning rules, HUD layouts, saved colors, or historical releases. This does not claim to resolve intermittent tachometer lag.