### PR TITLE
Wisp 1.1.1: Xbox app and Microsoft Store compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.1.1 - 2026-09-06
+
+### Added
+
+- Native HUD support for the Xbox app and Microsoft Store Windows PC edition of FH6, build `3.430.771.0`. Steam build `6.430.771.0` retains its existing compatibility path.
+
+### Fixed
+
+- Validate the supported Store build using its Windows package identity and bounded loaded-image checks when the protected executable cannot be opened for a file hash.
+- Recognize the supported Store executable's Windows path aliases only after confirming both paths identify the same file. No administrator access, permission changes, or game modifications are required.
+
+HUD settings, profiles, tire calibration, and speed-smoothing behavior are unchanged from 1.1.
+
 ## 1.1.0 - 2026-09-06
 
 Wisp 1.1 maintenance release.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,23 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
-## New in Wisp 1.1
+## New in Wisp 1.1.1
 
 [Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.1.1 release notes](docs/releases/Wisp-1.1.1-release-notes.md)
+
+- **Xbox app and Microsoft Store support.** Native HUD compatibility now includes
+  the Windows PC release of FH6, build `3.430.771.0`. Steam build `6.430.771.0`
+  remains supported through its existing compatibility path.
+- **The same local setup.** Enable FH6 Data Out and complete Wisp's setup wizard.
+  No administrator access, permission changes, or game modifications are needed.
+
+This is support for the PC game, not Xbox consoles or cloud gaming. Existing
+HUD layouts, colors, profiles, and tire calibration are preserved.
+
+## New in Wisp 1.1
+
+[Download 1.1](https://github.com/Views2k/Wisp/releases/tag/v1.1.0) ·
 [1.1 release notes](docs/releases/Wisp-1.1.0-release-notes.md)
 
 - **More readable wheel speed while drifting.** Speed smoothing now follows the
@@ -179,9 +193,11 @@ Wisp 1.1 with custom colors. The Release Notes capture shows the 1.1 preview ent
 - Borderless fullscreen, windowed, or another desktop-composited display mode.
   Exclusive fullscreen can cover ordinary Windows overlays.
 
-Native process-derived HUD state currently supports the recorded Steam FH6
-build `6.430.771.0` and its exact executable fingerprint. Data Out reception and
-dashboard calculations remain independent of that compatibility contract.
+Native process-derived HUD state supports Steam FH6 build `6.430.771.0` and
+Xbox app / Microsoft Store PC build `3.430.771.0`, each through its own reviewed
+build contract. Data Out reception and dashboard calculations remain independent
+of those contracts. Wisp runs on Windows alongside the game, not on Xbox consoles
+or a cloud-gaming session.
 
 The installer is self-contained and installs for the current user. It does not
 require administrator access or a separate .NET runtime.
@@ -260,18 +276,18 @@ needs different placement or scale.
 
 The Native provider opens the supported FH6 process with query/read
 access only. It does not inject code, hook rendering, call game functions, or
-write process memory. Changed or unknown executable fingerprints disable the
+write process memory. Changed or unknown game build identities disable the
 affected process-derived state rather than reusing data from another build.
 
 See [Compatibility and Update Safety](docs/COMPATIBILITY.md) for the supported
-build, validation boundary, and update behavior.
+builds, validation boundary, and update behavior.
 
 ## Privacy and limitations
 
 - Telemetry is accepted only from `127.0.0.1`.
 - Settings and tire profiles remain in the current user's local application data.
 - The installer is not code-signed.
-- A changed FH6 executable fingerprint requires a reviewed Wisp update.
+- A changed FH6 build identity requires a reviewed Wisp update.
 - FH6 exposes no tune identifier. Relearn the current tires after changing wheel
   or tire diameter.
 - Software-only WPF captures do not reproduce the live Native HUD shaders.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,10 +2,15 @@
 
 ## Current support
 
-The current Wisp build contains a Native HUD compatibility contract for the Steam
-FH6 build `6.430.771.0` and its recorded executable fingerprint. Support is
-fingerprint-specific; Wisp does not assume that another storefront binary with
-the same version string is compatible.
+Wisp 1.1.1 includes separate Native HUD compatibility contracts for:
+
+- Steam FH6 build `6.430.771.0`, identified by its recorded executable fingerprint;
+- Xbox app / Microsoft Store Windows PC build `3.430.771.0`, identified by its
+  Store package and bounded loaded-image checks.
+
+Support is build-specific; Wisp does not reuse one storefront's contract for
+another binary with a similar version. Wisp runs alongside a local Windows
+installation, not on Xbox consoles or inside cloud gaming.
 
 Data Out speed and G-force use the local 324-byte UDP packet. Exact Native
 redline, assist, and electric-gauge state use a separate guarded read-only path
@@ -25,8 +30,8 @@ matched to the unique current local-player source, and redline and tach maximum
 come from that vehicle's live model.
 
 A new car or tune that uses the supported runtime schema does not need a new
-lookup row. A content update that also changes the executable fingerprint still
-requires a reviewed compatibility contract. Changed packet fields, powertrain
+lookup row. A content update that also changes the validated game build identity
+still requires a reviewed compatibility contract. Changed packet fields, powertrain
 semantics, or renderer behavior can require an application update rather than a
 data-only contract.
 
@@ -38,12 +43,20 @@ reading from the previous session.
 
 Before accepting Native state, Wisp validates:
 
-- executable version, byte length, SHA-256, and image size;
+- the storefront-specific build identity described below;
 - compatibility schema and bounded module-relative addresses;
 - process generation, executable path, and module identity;
 - vtable guards and field alignment;
 - a unique local-player source;
 - Data Out car identity, current RPM, and maximum RPM agreement.
+
+Steam retains its executable version, byte length, SHA-256, and image-size checks.
+The Store path checks the exact Windows package name and version, Store origin,
+installation path, PE machine type, timestamp, image size, and hashes of bounded
+read-only executable regions. When Windows reports different paths for the same
+Store executable, attribute-only file handles must confirm the same file identity
+and metadata. These checks do not claim a full-file hash of the protected Store
+executable and do not require elevated access or permission changes.
 
 The electric-gauge path adds a bounded registry traversal with exact wrapper,
 context, HUD, subobject, outer-control, child, and provider guards. Its child
@@ -81,8 +94,10 @@ The runtime includes strict validation for signed contracts, revision floors,
 an offline cache, and an HTTPS client. Automatic distribution is not configured
 in the current build: the production endpoint and publisher keys are empty, so the
 application makes no compatibility-update request and keeps import/check
-controls disabled. Recovery from a new or changed executable fingerprint
+controls disabled. Recovery from a new or changed game build identity
 therefore requires a reviewed Wisp release containing a compatible contract.
+Store contracts are supplied only by the application release and are not accepted
+through the signed-pack import path.
 
 Distribution can be enabled only with pinned release-owned keys and reviewed
 contracts. A failed download or signature check leaves the accepted catalog

--- a/docs/HOW-WISP-WAS-BUILT.md
+++ b/docs/HOW-WISP-WAS-BUILT.md
@@ -96,11 +96,14 @@ digits, fade decisions, power/regeneration presentation, or electric needle
 state. Wisp reads that limited state through guarded Windows query/read process
 access only.
 
-Before a value is accepted, the provider validates the executable version,
-length, SHA-256, image bounds, compatibility contract, process generation,
-vtable guards, unique local-player source, car identity, current RPM, and
-maximum RPM. All reads are bounded. There is no process write, injection,
-remote thread, debugger, driver, or game-function call.
+Before a value is accepted, the provider validates the storefront-specific build
+identity, image bounds, compatibility contract, process generation, vtable guards,
+unique local-player source, car identity, current RPM, and maximum RPM. Steam
+uses the executable version, length, and SHA-256. The Xbox app / Microsoft Store
+path instead checks the exact Store package, installation path, PE identity,
+and hashes of bounded loaded-code regions; Windows file identity resolves the
+supported executable's path aliases. All reads are bounded. There is no process
+write, injection, remote thread, debugger, driver, or game-function call.
 
 Capabilities fail independently after the shared identity checks. A redline
 failure removes the redline without disabling UDP reception or dashboard speed.
@@ -108,7 +111,7 @@ An assist failure removes the affected state instead of leaving an icon from a
 previous car. Visible driving overlays separately require validated Native
 gameplay visibility and fail closed when that state is unavailable.
 
-The electric gauge uses a second, fingerprint-specific ownership chain from the
+The electric gauge uses a second, build-specific ownership chain from the
 HUD registry to the exact Native child and provider. Wisp takes one bounded
 child snapshot, validates its digits, booleans, ranges, vtables, and back
 references, then rechecks the chain before publishing it. The final digit state

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -50,12 +50,14 @@ the installer/checksum pair before promotion.
 - compositor lifetime, recorded tachometer traces, and bounded Native needle
   playback/reset behavior;
 - process-memory permission boundaries and identity guards;
+- Store package origin/path validation, same-file alias binding, and bounded
+  loaded-image identity checks, including mismatch and partial-read rejection;
 - compatibility contract, signature, cache, update, and failure behavior;
 - latest-release parsing, semantic-version ordering, bounded downloads,
   redirect policy, byte-length checks, and SHA-256 rejection paths;
 - staged update-request validation, exact parent-process binding, installer and
   installed-app identity checks, silent apply arguments, and restart ordering;
-- fingerprint-gated EV digits, fade flags, gears, power/regeneration, needle,
+- build-identity-gated EV digits, fade flags, gears, power/regeneration, needle,
   and invalid-field rejection;
 - menu/loading/cutscene visibility while telemetry remains active;
 - dashboard horsepower/torque formatting and unavailable-state behavior;

--- a/docs/releases/Wisp-1.1.1-release-notes.md
+++ b/docs/releases/Wisp-1.1.1-release-notes.md
@@ -1,0 +1,34 @@
+# Wisp 1.1.1
+
+Wisp now supports the Xbox app and Microsoft Store Windows PC edition of
+Forza Horizon 6, alongside Steam.
+
+## Xbox app and Microsoft Store compatibility
+
+- Adds Native HUD support for FH6 PC build `3.430.771.0` with a separate,
+  build-specific compatibility contract.
+- Validates the Store installation through Windows package identity and bounded
+  checks of the loaded game image, without requiring a file hash of the protected
+  executable.
+- Handles the supported installation's Windows path aliases by confirming they
+  identify the same file, while retaining the existing process and read-only
+  data checks.
+- Uses the same local Data Out setup as Steam. No administrator access, file
+  permission changes, or game modifications are required.
+
+Steam FH6 build `6.430.771.0` remains supported through its existing compatibility
+path. Both storefronts require their matching reviewed build; an unfamiliar game
+build is not treated as compatible automatically.
+
+This support is for FH6 installed locally on a Windows PC, not Xbox consoles or
+Xbox Cloud Gaming.
+
+## Updating
+
+Use **Check for updates** in Wisp's Extras page, or download the latest installer
+from [GitHub Releases](https://github.com/Views2k/Wisp/releases/latest).
+The release tag is `v1.1.1` and the installer is `Wisp-Setup-1.1.1.exe`, preserving
+update discovery for existing installations.
+
+HUD layouts, colors, profiles, tire calibration, and speed-smoothing behavior
+are unchanged from Wisp 1.1.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,6 +1,6 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.1.0"
-#define MyAppDisplayVersion "1.1"
+#define MyAppVersion "1.1.1"
+#define MyAppDisplayVersion "1.1.1"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/NativeCompatibility/NativeCompatibilityCatalog.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeCompatibilityCatalog.cs
@@ -203,6 +203,10 @@ public static class NativeCompatibilityEnvelope
             }
 
             var pack = NativeHudCompatibilityPack.Parse(Encoding.UTF8.GetBytes(signed["pack"].GetRawText()));
+            if (pack.StoreIdentity is not null)
+            {
+                throw Invalid("Store compatibility is currently supplied only by the application release.");
+            }
             return new NativeVerifiedCompatibilityEnvelope(
                 pack, keyId, Convert.ToHexString(SHA256.HashData(payload)), issuedUtc, expiresUtc);
         }

--- a/src/Wisp.App/NativeCompatibility/NativeHudCompatibilityPack.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeHudCompatibilityPack.cs
@@ -29,6 +29,11 @@ public sealed class NativeHudCompatibilityPack
         .Append("nativeGauge")
         .ToFrozenSet(StringComparer.Ordinal);
 
+    private static readonly FrozenSet<string> StorePackProperties = VersionThreePackProperties
+        .Except(new[] { "executableLength", "executableSha256" })
+        .Append("storeIdentity")
+        .ToFrozenSet(StringComparer.Ordinal);
+
     private static readonly FrozenSet<string> SlotProperties = new[]
     {
         "offset", "targetRva"
@@ -219,24 +224,31 @@ public sealed class NativeHudCompatibilityPack
             throw new FormatException("The game version must contain four numeric version parts.");
         }
 
-        ExecutableLength = ReadInt64(properties["executableLength"]);
-        if (ExecutableLength is < 4096 or > MaximumExecutableLength)
+        if (SchemaVersion != 4)
         {
-            throw new FormatException("The executable length is outside the supported bounds.");
-        }
+            ExecutableLength = ReadInt64(properties["executableLength"]);
+            if (ExecutableLength is < 4096 or > MaximumExecutableLength)
+            {
+                throw new FormatException("The executable length is outside the supported bounds.");
+            }
 
-        var hash = ReadString(properties["executableSha256"]);
-        if (hash.Length != 64 || !hash.All(char.IsAsciiHexDigit))
-        {
-            throw new FormatException("The executable SHA-256 must contain exactly 64 hexadecimal digits.");
-        }
+            var hash = ReadString(properties["executableSha256"]);
+            if (hash.Length != 64 || !hash.All(char.IsAsciiHexDigit))
+            {
+                throw new FormatException("The executable SHA-256 must contain exactly 64 hexadecimal digits.");
+            }
 
-        ExecutableSha256 = hash.ToUpperInvariant();
+            ExecutableSha256 = hash.ToUpperInvariant();
+        }
         ImageSize = ReadUInt32(properties["imageSize"]);
         if (ImageSize is < 4096 or > MaximumImageSize)
         {
             throw new FormatException("The image size is outside the supported bounds.");
         }
+
+        StoreIdentity = SchemaVersion == 4
+            ? NativeHudStoreBuildIdentity.Parse(properties["storeIdentity"], GameVersion, ImageSize)
+            : null;
 
         SourceVectorRva = ReadUInt64(properties["sourceVectorRva"]);
         ThresholdRva = ReadUInt64(properties["thresholdRva"]);
@@ -256,9 +268,13 @@ public sealed class NativeHudCompatibilityPack
         GameplayVisibility = SchemaVersion >= 2
             ? ReadGameplayVisibility(properties["gameplayVisibility"], ImageSize)
             : null;
-        NativeGauge = SchemaVersion == 3
+        NativeGauge = SchemaVersion >= 3 && properties["nativeGauge"].ValueKind != JsonValueKind.Null
             ? ReadNativeGauge(properties["nativeGauge"], ImageSize)
             : null;
+        if (SchemaVersion == 3 && NativeGauge is null)
+        {
+            throw new FormatException("The native gauge layout is required by schema three.");
+        }
     }
 
     public int SchemaVersion { get; }
@@ -267,7 +283,8 @@ public sealed class NativeHudCompatibilityPack
     public int Revision { get; }
     public string GameVersion { get; }
     public long ExecutableLength { get; }
-    public string ExecutableSha256 { get; }
+    public string ExecutableSha256 { get; } = string.Empty;
+    public NativeHudStoreBuildIdentity? StoreIdentity { get; }
     public uint ImageSize { get; }
     public ulong SourceVectorRva { get; }
     public ulong ThresholdRva { get; }
@@ -302,6 +319,7 @@ public sealed class NativeHudCompatibilityPack
     }
 
     public bool Matches(string? version, long length, string? sha256) =>
+        StoreIdentity is null &&
         string.Equals(version?.Trim(), GameVersion, StringComparison.Ordinal) &&
         length == ExecutableLength &&
         string.Equals(sha256?.Trim(), ExecutableSha256, StringComparison.OrdinalIgnoreCase);
@@ -318,6 +336,7 @@ public sealed class NativeHudCompatibilityPack
             1 => LegacyPackProperties,
             2 => VersionTwoPackProperties,
             3 => VersionThreePackProperties,
+            4 => StorePackProperties,
             _ => throw new FormatException("The compatibility pack schema or reader version is unsupported.")
         };
         return ReadObject(root, expectedProperties);

--- a/src/Wisp.App/NativeCompatibility/NativeHudStoreBuildIdentity.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeHudStoreBuildIdentity.cs
@@ -1,0 +1,120 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace Wisp.App;
+
+// Store executables cannot be opened for a file hash. This contract combines
+// OS package provenance with exact, release-owned guards on the reader's code.
+public sealed class NativeHudStoreBuildIdentity
+{
+    private readonly CodeGuard[] _guards;
+
+    private NativeHudStoreBuildIdentity(string packageFullName, uint timestamp, uint imageSize, CodeGuard[] guards)
+    {
+        PackageFullName = packageFullName;
+        TimeDateStamp = timestamp;
+        ImageSize = imageSize;
+        _guards = guards;
+    }
+
+    public string PackageFullName { get; }
+    public uint TimeDateStamp { get; }
+    public uint ImageSize { get; }
+
+    internal static NativeHudStoreBuildIdentity Parse(JsonElement element, string gameVersion, uint imageSize)
+    {
+        var fields = NativeCompatibilityJson.ReadObject(element, "packageFullName", "timeDateStamp", "codeGuards");
+        var name = NativeCompatibilityJson.ReadString(fields["packageFullName"]);
+        if (name != $"Microsoft.ForteBaseGame_{gameVersion}_x64__8wekyb3d8bbwe" ||
+            !fields["timeDateStamp"].TryGetUInt32(out var timestamp) || timestamp == 0 ||
+            fields["codeGuards"].ValueKind != JsonValueKind.Array || fields["codeGuards"].GetArrayLength() is < 2 or > 8)
+        {
+            throw new FormatException("The Store build identity is invalid.");
+        }
+
+        var guards = new List<CodeGuard>();
+        foreach (var item in fields["codeGuards"].EnumerateArray())
+        {
+            var guard = NativeCompatibilityJson.ReadObject(item, "rva", "length", "sha256");
+            if (!guard["rva"].TryGetUInt32(out var rva) || !guard["length"].TryGetInt32(out var length) ||
+                length is < 16 or > 256 || rva < 4096 || rva >= imageSize || length > imageSize - rva ||
+                guards.Any(existing => rva < existing.Rva + existing.Length && existing.Rva < rva + length))
+            {
+                throw new FormatException("A Store code guard is outside its bounds or overlaps another guard.");
+            }
+
+            guards.Add(new CodeGuard(rva, length, Convert.FromHexString(NativeCompatibilityJson.ReadHash(guard["sha256"]))));
+        }
+
+        return new NativeHudStoreBuildIdentity(name, timestamp, imageSize, guards.ToArray());
+    }
+
+    internal bool MatchesImage(IReadOnlyProcessMemory memory, ulong moduleBase)
+    {
+        if (!NativeHudProcessMemory.IsValidModuleRange(moduleBase, ImageSize))
+        {
+            return false;
+        }
+
+        Span<byte> header = stackalloc byte[4096];
+        if (!memory.TryReadBytes(moduleBase, header) || BinaryPrimitives.ReadUInt16LittleEndian(header) != 0x5A4D)
+        {
+            return false;
+        }
+
+        var pe = BinaryPrimitives.ReadInt32LittleEndian(header[0x3C..]);
+        if (pe is < 64 or > 2048 || BinaryPrimitives.ReadUInt32LittleEndian(header[pe..]) != 0x4550 ||
+            BinaryPrimitives.ReadUInt16LittleEndian(header[(pe + 4)..]) != 0x8664 ||
+            BinaryPrimitives.ReadUInt32LittleEndian(header[(pe + 8)..]) != TimeDateStamp ||
+            BinaryPrimitives.ReadUInt16LittleEndian(header[(pe + 24)..]) != 0x20B ||
+            BinaryPrimitives.ReadUInt32LittleEndian(header[(pe + 80)..]) != ImageSize)
+        {
+            return false;
+        }
+
+        var sectionCount = BinaryPrimitives.ReadUInt16LittleEndian(header[(pe + 6)..]);
+        var optionalSize = BinaryPrimitives.ReadUInt16LittleEndian(header[(pe + 20)..]);
+        var sections = pe + 24 + optionalSize;
+        if (sectionCount is < 1 or > 32 || optionalSize < 112 || sections + sectionCount * 40 > header.Length)
+        {
+            return false;
+        }
+
+        Span<byte> code = stackalloc byte[256];
+        Span<byte> hash = stackalloc byte[32];
+        foreach (var guard in _guards)
+        {
+            var executableSection = false;
+            for (var index = 0; index < sectionCount; index++)
+            {
+                var section = header[(sections + index * 40)..];
+                var size = BinaryPrimitives.ReadUInt32LittleEndian(section[8..]);
+                var rva = BinaryPrimitives.ReadUInt32LittleEndian(section[12..]);
+                var flags = BinaryPrimitives.ReadUInt32LittleEndian(section[36..]);
+                if (rva >= 4096 && rva < ImageSize && size <= ImageSize - rva &&
+                    guard.Rva >= rva && guard.Rva - rva <= size && guard.Length <= size - (guard.Rva - rva) &&
+                    (flags & 0x20000000) != 0 && (flags & 0x80000000) == 0)
+                {
+                    executableSection = true;
+                    break;
+                }
+            }
+
+            if (!executableSection || !memory.TryReadBytes(moduleBase + guard.Rva, code[..guard.Length]))
+            {
+                return false;
+            }
+
+            SHA256.HashData(code[..guard.Length], hash);
+            if (!CryptographicOperations.FixedTimeEquals(hash, guard.Hash))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed record CodeGuard(uint Rva, int Length, byte[] Hash);
+}

--- a/src/Wisp.App/NativeCompatibility/NativeStorePackageIdentity.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeStorePackageIdentity.cs
@@ -1,0 +1,240 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Wisp.App;
+
+// Package provenance is separate from the Store pack's bounded image guards, not a file hash.
+internal readonly record struct NativeStorePackageIdentity(string PackageFullName, string ExecutablePath)
+{
+    internal const string SupportedPackageFullName = "Microsoft.ForteBaseGame_3.430.771.0_x64__8wekyb3d8bbwe";
+    internal const int StoreOrigin = 3;
+    private const int InsufficientBuffer = 122;
+    private const uint MaximumPackageNameCharacters = 512;
+    private const uint MaximumPathCharacters = 32768;
+
+    internal static bool TryRead(SafeProcessHandle handle, string executablePath, out NativeStorePackageIdentity identity) =>
+        TryRead(handle, executablePath, WindowsPackageApi.Instance, out identity);
+
+    internal static bool TryRead(
+        SafeProcessHandle handle, string executablePath, IPackageApi api, out NativeStorePackageIdentity identity)
+    {
+        identity = default;
+        if (handle is null || handle.IsClosed || handle.IsInvalid)
+        {
+            return false;
+        }
+
+        try
+        {
+            // No-package and unavailable API results are ordinary nonmatches; Steam still uses its file fingerprint.
+            if (!TryReadString((ref uint length, char[]? buffer) => api.GetFullName(handle, ref length, buffer),
+                    MaximumPackageNameCharacters, out var name) ||
+                !string.Equals(name, SupportedPackageFullName, StringComparison.Ordinal) ||
+                api.GetOrigin(name, out var origin) != 0 || origin != StoreOrigin ||
+                !TryReadString((ref uint length, char[]? buffer) => api.GetPath(name, 0, ref length, buffer),
+                    MaximumPathCharacters, out var originalPath) ||
+                !TryReadString((ref uint length, char[]? buffer) => api.GetPath(name, 2, ref length, buffer),
+                    MaximumPathCharacters, out var effectivePath))
+            {
+                return false;
+            }
+
+            return TryValidate(name, origin, originalPath, effectivePath, executablePath, out identity);
+        }
+        catch (Exception exception) when (exception is DllNotFoundException or EntryPointNotFoundException or
+            ObjectDisposedException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    internal static bool TryValidate(
+        string? packageFullName, int origin, string? originalPackagePath, string? effectivePackagePath,
+        string? executablePath, out NativeStorePackageIdentity identity)
+    {
+        identity = default;
+        if (!string.Equals(packageFullName, SupportedPackageFullName, StringComparison.Ordinal) ||
+            origin != StoreOrigin || string.IsNullOrWhiteSpace(originalPackagePath) ||
+            string.IsNullOrWhiteSpace(effectivePackagePath) || string.IsNullOrWhiteSpace(executablePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var original = NativeHudFingerprintCache.NormalizePath(originalPackagePath);
+            var effective = NativeHudFingerprintCache.NormalizePath(effectivePackagePath);
+            var executable = NativeHudFingerprintCache.NormalizePath(executablePath);
+            // This reviewed build uses the same original/effective directory; do not accept an unverified projection.
+            if (original != effective ||
+                executable != NativeHudFingerprintCache.NormalizePath(Path.Combine(effective, "ForzaHorizon6.exe")))
+            {
+                return false;
+            }
+
+            identity = new NativeStorePackageIdentity(SupportedPackageFullName, executable);
+            return true;
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    internal static bool MatchesExecutableFileAlias(string expectedPath, string observedPath) =>
+        MatchesExecutableFileAlias(expectedPath, observedPath, WindowsFileAliasApi.Instance);
+
+    internal static bool MatchesExecutableFileAlias(string expectedPath, string observedPath, IFileAliasApi api)
+    {
+        try
+        {
+            var expected = NativeHudFingerprintCache.NormalizePath(expectedPath);
+            var observed = NativeHudFingerprintCache.NormalizePath(observedPath);
+            if (!IsLocalGameExecutable(expected) || !IsLocalGameExecutable(observed))
+            {
+                return false;
+            }
+
+            // Keep both attribute-only handles open so file identifiers cannot be recycled between reads.
+            using var first = api.OpenAttributes(expected);
+            if (first.IsInvalid || first.IsClosed)
+            {
+                return false;
+            }
+
+            using var second = api.OpenAttributes(observed);
+            return !second.IsInvalid && !second.IsClosed &&
+                api.TryReadIdentity(first, out var firstIdentity) &&
+                api.TryReadIdentity(second, out var secondIdentity) &&
+                MatchesFileIdentity(firstIdentity, secondIdentity);
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException or
+            DllNotFoundException or EntryPointNotFoundException or ObjectDisposedException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsLocalGameExecutable(string path) =>
+        path.Length >= 3 && char.IsAsciiLetter(path[0]) && path[1] == ':' && path[2] == '\\' &&
+        string.Equals(Path.GetFileName(path), "ForzaHorizon6.exe", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool MatchesFileIdentity(FileAliasIdentity first, FileAliasIdentity second) =>
+        first.IsValid && second.IsValid && first.Volume == second.Volume &&
+        first.FileIdLow == second.FileIdLow && first.FileIdHigh == second.FileIdHigh &&
+        first.Length == second.Length && first.CreationTime == second.CreationTime && first.LastWriteTime == second.LastWriteTime;
+
+    internal readonly record struct FileAliasIdentity(
+        ulong Volume, ulong FileIdLow, ulong FileIdHigh, ulong Length, ulong CreationTime, ulong LastWriteTime, uint Attributes)
+    {
+        internal bool IsValid => Volume != 0 && (FileIdLow != 0 || FileIdHigh != 0) &&
+            Length is >= 4096 and <= 2UL * 1024 * 1024 * 1024 && CreationTime != 0 && LastWriteTime != 0 &&
+            (Attributes & (0x10U | 0x40U)) == 0;
+    }
+
+    internal interface IFileAliasApi
+    {
+        SafeFileHandle OpenAttributes(string path);
+        bool TryReadIdentity(SafeFileHandle handle, out FileAliasIdentity identity);
+    }
+
+    private sealed class WindowsFileAliasApi : IFileAliasApi
+    {
+        internal static readonly WindowsFileAliasApi Instance = new();
+
+        public SafeFileHandle OpenAttributes(string path) =>
+            CreateFile(path, 0x80, 0x1 | 0x2 | 0x4, IntPtr.Zero, 3, 0x80, IntPtr.Zero);
+
+        public bool TryReadIdentity(SafeFileHandle handle, out FileAliasIdentity identity)
+        {
+            identity = default;
+            if (!GetFileInformationByHandle(handle, out var information) ||
+                !GetFileInformationByHandleEx(handle, 18, out var fileId, 24))
+            {
+                return false;
+            }
+
+            identity = new FileAliasIdentity(fileId.Volume, fileId.Low, fileId.High,
+                ((ulong)information.SizeHigh << 32) | information.SizeLow,
+                ((ulong)information.CreationHigh << 32) | information.CreationLow,
+                ((ulong)information.WriteHigh << 32) | information.WriteLow, information.Attributes);
+            return identity.IsValid;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FileInformation
+        {
+            public uint Attributes, CreationLow, CreationHigh, AccessLow, AccessHigh, WriteLow, WriteHigh;
+            public uint Volume, SizeHigh, SizeLow, Links, IndexHigh, IndexLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ExtendedFileId
+        {
+            public ulong Volume, Low, High;
+        }
+
+        [DllImport("kernel32.dll", EntryPoint = "CreateFileW", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern SafeFileHandle CreateFile(
+            string path, uint access, uint share, IntPtr security, uint disposition, uint attributes, IntPtr template);
+
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetFileInformationByHandle(SafeFileHandle handle, out FileInformation information);
+
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetFileInformationByHandleEx(
+            SafeFileHandle handle, int informationClass, out ExtendedFileId information, uint size);
+    }
+
+    private delegate int StringQuery(ref uint length, char[]? buffer);
+
+    private static bool TryReadString(StringQuery query, uint maximumCharacters, out string value)
+    {
+        value = string.Empty;
+        uint length = 0;
+        if (query(ref length, null) != InsufficientBuffer || length < 2 || length > maximumCharacters)
+        {
+            return false;
+        }
+
+        var capacity = length;
+        var buffer = new char[capacity];
+        if (query(ref length, buffer) != 0 || length < 2 || length > capacity ||
+            buffer[length - 1] != '\0' || Array.IndexOf(buffer, '\0', 0, (int)length - 1) >= 0)
+        {
+            return false;
+        }
+
+        value = new string(buffer, 0, (int)length - 1);
+        return true;
+    }
+
+    internal interface IPackageApi
+    {
+        int GetFullName(SafeProcessHandle handle, ref uint length, char[]? buffer);
+        int GetOrigin(string fullName, out int origin);
+        int GetPath(string fullName, int pathType, ref uint length, char[]? buffer);
+    }
+
+    private sealed class WindowsPackageApi : IPackageApi
+    {
+        internal static readonly WindowsPackageApi Instance = new();
+        public int GetFullName(SafeProcessHandle handle, ref uint length, char[]? buffer) =>
+            GetPackageFullName(handle, ref length, buffer);
+        public int GetOrigin(string fullName, out int origin) => GetStagedPackageOrigin(fullName, out origin);
+        public int GetPath(string fullName, int pathType, ref uint length, char[]? buffer) =>
+            GetPackagePathByFullName2(fullName, pathType, ref length, buffer);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern int GetPackageFullName(SafeProcessHandle process, ref uint length, [Out] char[]? fullName);
+
+        [DllImport("kernelbase.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern int GetStagedPackageOrigin(string fullName, out int origin);
+
+        [DllImport("kernelbase.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern int GetPackagePathByFullName2(string fullName, int pathType, ref uint length, [Out] char[]? path);
+    }
+}

--- a/src/Wisp.App/NativeCompatibility/fh6-store-3.430.771.0.json
+++ b/src/Wisp.App/NativeCompatibility/fh6-store-3.430.771.0.json
@@ -1,0 +1,233 @@
+{
+  "schemaVersion": 4,
+  "readerVersion": 4,
+  "id": "fh6-store-3.430.771.0-x64",
+  "revision": 1,
+  "gameVersion": "3.430.771.0",
+  "imageSize": 188211200,
+  "sourceVectorRva": 177017440,
+  "thresholdRva": 104556548,
+  "leadVtableRva": 108496768,
+  "expectedThresholdBits": 1036831949,
+  "fields": {
+    "sourceProvider": 30528,
+    "sourceCarOrdinal": 29708,
+    "providerRpm": 432,
+    "providerSimRedlineAngularVelocity": 584,
+    "providerTachometerMaximumAngularVelocity": 588,
+    "localPlayerFlag": 5220,
+    "localPlayerProviderFlag": 49968,
+    "stmState": 5168,
+    "absState": 5172,
+    "stmAvailable": 6068,
+    "tcrAvailable": 6069,
+    "absAvailable": 6070,
+    "lcAvailable": 6071,
+    "lcPrimary": 5356,
+    "lcMode": 8060,
+    "lcSecondary": 49696,
+    "tcrSecondary": 49696,
+    "tcrPrimary": 49700,
+    "tcrTertiary": 49704,
+    "tcrWheelValues": 49864,
+    "firstWheelPointer": 2976,
+    "secondWheelPointer": 2984,
+    "thirdWheelPointer": 2992,
+    "wheelId": 1440
+  },
+  "gameplayVisibility": {
+    "uiServiceRva": 176526888,
+    "uiServiceVtableRva": 107652968,
+    "dependencyVtableRva": 107571304,
+    "transitionManagerVtableRva": 107571192,
+    "hudPageVtableRva": 115813672,
+    "serviceDependencyOffset": 160,
+    "rootTransitionManagerOffset": 56,
+    "managerOwnerOffset": 192,
+    "managerCurrentPageOffset": 144,
+    "managerStateOffset": 104,
+    "pageTransitionManagerOffset": 656,
+    "pageUiVisibleOffset": 964
+  },
+  "nativeGauge": {
+    "registryGlobalRva": 176253464,
+    "registryKeyHash": 14601433220641418792,
+    "registryWrapperVtableRva": 106463440,
+    "registryContextVtableRva": 109517456,
+    "registryContextControlVtableRva": 106466584,
+    "registryContextOffset": 8,
+    "registryContextControlOffset": 16,
+    "registrySentinelOffset": 504,
+    "registryCountOffset": 512,
+    "registryBucketsOffset": 520,
+    "registryBucketsEndOffset": 528,
+    "registryBucketsCapacityOffset": 536,
+    "registryMaskOffset": 544,
+    "registryBucketCountOffset": 552,
+    "registryBucketStride": 16,
+    "registryBucketBoundaryOffset": 0,
+    "registryBucketNodeOffset": 8,
+    "registryNodeNextOffset": 8,
+    "registryNodeHashOffset": 16,
+    "registryNodeObjectOffset": 24,
+    "registryNodeControlOffset": 32,
+    "sharedControlObjectOffset": 16,
+    "hudVtableRva": 109554456,
+    "hudControlVtableRva": 105182248,
+    "hudSubobjectOffset": 48,
+    "hudSubobjectPointerOffset": 304,
+    "hudSubobjectVtableRva": 109554536,
+    "hudSubobjectSlotZeroTargetRva": 5092448,
+    "hudSubobjectSlotZeroPrologueHex": "488D4170C3",
+    "hudTypeVectorOffset": 112,
+    "hudTypeVectorMaximumCount": 64,
+    "hudTypeVectorBeginOffset": 0,
+    "hudTypeVectorEndOffset": 8,
+    "hudTypeVectorCapacityOffset": 16,
+    "hudTypeVectorEntryStride": 32,
+    "hudTypeTokenRva": 178658408,
+    "hudTypeTokenOffset": 0,
+    "hudTypeInstancesBeginOffset": 8,
+    "hudTypeInstancesEndOffset": 16,
+    "hudTypeInstancesCapacityOffset": 24,
+    "hudTypeInstanceCount": 1,
+    "hudTypeInstanceStride": 16,
+    "hudTypeInstanceObjectOffset": 0,
+    "hudTypeInstanceControlOffset": 8,
+    "outerControlVtableRva": 109536584,
+    "outerPrimaryVtableRva": 117399288,
+    "outerSecondaryVtableRva": 117399576,
+    "outerSecondaryOffset": 8,
+    "outerHudBackReferenceOffset": 16,
+    "outerHudControlBackReferenceOffset": 24,
+    "outerChildOffset": 56,
+    "outerSourceOffset": 64,
+    "outerPowerFillOffset": 112,
+    "outerRegenFillOffset": 136,
+    "childlessRegenPowerRatioBits": 1050253722,
+    "childVtableRva": 117981760,
+    "childModeOffset": 228,
+    "childAngleOffset": 244,
+    "childBlurOffset": 248,
+    "childSpeedDigitOneOffset": 252,
+    "childSpeedDigitTenOffset": 256,
+    "childSpeedDigitHundredOffset": 260,
+    "childSpeedLessOrEqualOneOffset": 264,
+    "childSpeedLessTenOffset": 265,
+    "childSpeedLessHundredOffset": 266,
+    "childHeadlightsOnOffset": 268,
+    "childGearOffset": 272,
+    "childGearPreviousOffset": 276,
+    "childGearNextOffset": 280,
+    "childRegenOffset": 304,
+    "childPowerOffset": 308,
+    "childGearGaugeStateOffset": 312,
+    "childUseDriveFor1Offset": 316,
+    "childRatioOffset": 320,
+    "childSpeedUnitObjectOffset": 360,
+    "childMaximumTachometerOffset": 368,
+    "childElectricMaximumSpeedOffset": 392,
+    "speedUnitEnumOffset": 4,
+    "speedUnitMphValue": 22,
+    "speedUnitKphValue": 23,
+    "providerPowerLimitFirstOffset": 9136,
+    "providerPowerLimitSecondOffset": 9148,
+    "providerPowerNumeratorOffset": 504,
+    "providerPowerDenominatorOffset": 2696,
+    "providerRegenTargetOffset": 5160,
+    "providerPowerDenominatorScaleBits": 1008981770,
+    "providerRegenScaleBits": 3214934016,
+    "providerRegenUpperBaseBits": 1048576000,
+    "providerElectricSpeedOffset": 5356,
+    "requiredProviderVtableSlots": [
+      {
+        "offset": 664,
+        "targetRva": 32156304
+      },
+      {
+        "offset": 856,
+        "targetRva": 32167200
+      },
+      {
+        "offset": 1464,
+        "targetRva": 32182192
+      },
+      {
+        "offset": 1824,
+        "targetRva": 32166704
+      },
+      {
+        "offset": 1944,
+        "targetRva": 32176416
+      },
+      {
+        "offset": 3624,
+        "targetRva": 32181952
+      }
+    ]
+  },
+  "requiredVtableSlots": [
+    {
+      "offset": 528,
+      "targetRva": 32167248
+    },
+    {
+      "offset": 680,
+      "targetRva": 32185968
+    },
+    {
+      "offset": 688,
+      "targetRva": 32182272
+    },
+    {
+      "offset": 696,
+      "targetRva": 32155376
+    },
+    {
+      "offset": 1664,
+      "targetRva": 32167232
+    },
+    {
+      "offset": 4184,
+      "targetRva": 32184448
+    },
+    {
+      "offset": 4192,
+      "targetRva": 32153456
+    },
+    {
+      "offset": 4200,
+      "targetRva": 32169312
+    },
+    {
+      "offset": 4216,
+      "targetRva": 32169456
+    }
+  ],
+  "storeIdentity": {
+    "packageFullName": "Microsoft.ForteBaseGame_3.430.771.0_x64__8wekyb3d8bbwe",
+    "timeDateStamp": 1787153332,
+    "codeGuards": [
+      {
+        "rva": 103163586,
+        "length": 38,
+        "sha256": "5DBD543FAD5FBD0926E709BFA7AC95D189852DF62079ADD3E05EF3ED83ABAED0"
+      },
+      {
+        "rva": 25831055,
+        "length": 49,
+        "sha256": "B24F11A3C73A74A852F59DF76BC1069C0AB748A422B0D1BFC54AE2B80F74C64D"
+      },
+      {
+        "rva": 32387834,
+        "length": 51,
+        "sha256": "9A73CCEF3EF7873E3CA975D4AE499F655EA01563EDD83B8295CF227DE424174A"
+      },
+      {
+        "rva": 7021413,
+        "length": 40,
+        "sha256": "9BE8817D37D7200095C9B83B5997A9478F1448E4E4148918889215A546997A68"
+      }
+    ]
+  }
+}

--- a/src/Wisp.App/NativeHudBuildContract.cs
+++ b/src/Wisp.App/NativeHudBuildContract.cs
@@ -7,6 +7,7 @@ public static class NativeHudBuildContract
     // Embedded packs are trusted with the application. External packs must pass
     // the signed catalog before the process reader can select them.
     public static NativeHudCompatibilityPack BuiltIn { get; } = LoadBuiltIn();
+    internal static NativeHudCompatibilityPack StoreBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.Store.json");
 
     public static string SupportedVersion => BuiltIn.GameVersion;
     public static long SupportedExecutableLength => BuiltIn.ExecutableLength;
@@ -19,10 +20,10 @@ public static class NativeHudBuildContract
     public static bool Matches(string? version, long length, string? sha256) =>
         BuiltIn.Matches(version, length, sha256);
 
-    private static NativeHudCompatibilityPack LoadBuiltIn()
+    private static NativeHudCompatibilityPack LoadBuiltIn(string resource = "Wisp.NativeCompatibility.BuiltIn.json")
     {
         using var stream = typeof(NativeHudBuildContract).Assembly.GetManifestResourceStream(
-            "Wisp.NativeCompatibility.BuiltIn.json")
+            resource)
             ?? throw new InvalidDataException("The bundled Native compatibility pack is missing.");
         using var bytes = new MemoryStream();
         stream.CopyTo(bytes);

--- a/src/Wisp.App/NativeHudProcessMemory.cs
+++ b/src/Wisp.App/NativeHudProcessMemory.cs
@@ -165,7 +165,7 @@ public sealed class NativeHudProcessMemoryFactory : INativeHudProcessMemoryFacto
             var identity = CaptureIdentity(process);
             if (!TrySelectCompatibility(identity, out var pack, out var fingerprint, out status))
             {
-                return false;
+                return TryOpenStoreProcess(process, identity, out memory, ref status);
             }
 
             handle = NativeHudProcessMemory.OpenReadOnly(process.Id);
@@ -199,6 +199,56 @@ public sealed class NativeHudProcessMemoryFactory : INativeHudProcessMemoryFacto
                 : NativeAssistProviderStatus.ReadFailure;
             SetStatus("FH6 process or executable identity could not be verified");
             return false;
+        }
+        finally
+        {
+            handle?.Dispose();
+        }
+    }
+
+    private bool TryOpenStoreProcess(
+        Process process, NativeHudProcessIdentity identity, out NativeHudProcessMemory? memory,
+        ref NativeAssistProviderStatus status)
+    {
+        memory = null;
+        var pack = NativeHudBuildContract.StoreBuiltIn;
+        if (identity.ImageSize != pack.ImageSize || pack.StoreIdentity is not { } storeBuild)
+        {
+            return false;
+        }
+
+        SafeProcessHandle? handle = NativeHudProcessMemory.OpenReadOnly(identity.ProcessId);
+        try
+        {
+            if (handle.IsInvalid || !NativeStorePackageIdentity.TryRead(handle, identity.ExecutablePath, out var package) ||
+                package.PackageFullName != storeBuild.PackageFullName)
+            {
+                return false;
+            }
+
+            var candidate = new NativeHudProcessMemory(handle, identity.ModuleBase, pack);
+            if (!storeBuild.MatchesImage(candidate, identity.ModuleBase))
+            {
+                status = NativeAssistProviderStatus.UnsupportedBuild;
+                SetStatus("The Xbox/Store FH6 image does not match the bundled reader guards");
+                return false;
+            }
+
+            process.Refresh();
+            if (CaptureIdentity(process) != identity || !NativeHudProcessMemory.HandleMatchesIdentity(handle, identity, allowStoreFileAlias: true) ||
+                !NativeStorePackageIdentity.TryRead(handle, identity.ExecutablePath, out var currentPackage) ||
+                currentPackage != package || !storeBuild.MatchesImage(candidate, identity.ModuleBase))
+            {
+                status = NativeAssistProviderStatus.ReadFailure;
+                SetStatus("The Xbox/Store FH6 identity changed during attachment");
+                return false;
+            }
+
+            memory = candidate;
+            handle = null;
+            status = NativeAssistProviderStatus.Ready;
+            SetStatus($"Xbox/Store FH6 {pack.GameVersion}; Store origin and reader guards verified; pack {pack.Id} r{pack.Revision}");
+            return true;
         }
         finally
         {
@@ -310,7 +360,8 @@ public sealed class NativeHudProcessMemory : INativeHudProcessMemory
 
     internal static SafeProcessHandle OpenReadOnly(int processId) => OpenProcess(RequiredProcessAccess, false, processId);
 
-    internal static bool HandleMatchesIdentity(SafeProcessHandle handle, NativeHudProcessIdentity identity)
+    internal static bool HandleMatchesIdentity(
+        SafeProcessHandle handle, NativeHudProcessIdentity identity, bool allowStoreFileAlias = false)
     {
         if (!GetProcessTimes(handle, out var creation, out _, out _, out _) ||
             NativeHudFingerprintFileSystem.FileTimeTicks(creation) != identity.StartTimeUtcTicks)
@@ -320,8 +371,14 @@ public sealed class NativeHudProcessMemory : INativeHudProcessMemory
 
         var path = new StringBuilder(32768);
         uint length = (uint)path.Capacity;
-        return QueryFullProcessImageName(handle, 0, path, ref length) &&
-               NativeHudFingerprintCache.NormalizePath(path.ToString()) == identity.ExecutablePath;
+        if (!QueryFullProcessImageName(handle, 0, path, ref length))
+        {
+            return false;
+        }
+
+        var observedPath = NativeHudFingerprintCache.NormalizePath(path.ToString());
+        return observedPath == identity.ExecutablePath ||
+               (allowStoreFileAlias && NativeStorePackageIdentity.MatchesExecutableFileAlias(identity.ExecutablePath, observedPath));
     }
 
     private bool CanRead(ulong address, ulong length) =>

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,26 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.1.1",
+            "September 6, 2026",
+            "COMPATIBILITY HOTFIX",
+            "Xbox app and Microsoft Store editions of Forza Horizon 6 on Windows are now supported.",
+            true,
+            [
+                Group("Compatibility",
+                    "Adds a separate Native HUD compatibility path for Xbox app and Microsoft Store FH6 build 3.430.771.0. Other Store builds remain unsupported.",
+                    "Checks the Store package and targeted code guards, including Windows executable-path aliases, without opening protected executable contents as a file.",
+                    "Restores Native HUD attachment, gameplay visibility, exact redline, driver-assist data, and stock needle data on the supported Store build."),
+                Group("Unchanged",
+                    "The existing Steam compatibility path is preserved.",
+                    "Wisp runs without administrator permissions and does not modify Forza or its game files.")
+            ]),
+        new(
             "1.1",
             "September 6, 2026",
             "MAINTENANCE",
             "Focused corrections to settings saves, calibration persistence, and connection timing.",
-            true,
+            false,
             [
                 Group("Fixed",
                     "Profile changes are confirmed only after the settings write succeeds. Failed writes can be retried without creating duplicate profiles.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.1.0</Version>
-    <FileVersion>1.1.0.0</FileVersion>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <Version>1.1.1</Version>
+    <FileVersion>1.1.1.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />
@@ -24,6 +24,7 @@
     <Resource Include="Assets\Wisp-logo.png" />
     <Resource Include="Assets\Native\**\*.png" />
     <EmbeddedResource Include="NativeCompatibility\fh6-6.430.771.0.json" LogicalName="Wisp.NativeCompatibility.BuiltIn.json" />
+    <EmbeddedResource Include="NativeCompatibility\fh6-store-3.430.771.0.json" LogicalName="Wisp.NativeCompatibility.Store.json" />
     <Resource Include="Shaders\*.ps" />
     <None Include="Shaders\*.hlsl" />
     <Content Include="Assets\Native\ASSET-MANIFEST.csv" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.1.0.0" name="Wisp.App" />
+  <assemblyIdentity version="1.1.1.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.1.0</Version>
-    <FileVersion>1.1.0.0</FileVersion>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <Version>1.1.1</Version>
+    <FileVersion>1.1.1.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -21,9 +21,9 @@ public sealed class ApplicationVersionInfoTests
     [Fact]
     public void CurrentVersionLabelsShareTheAssemblyVersion()
     {
-        Assert.Equal("1.1", ApplicationVersionInfo.DisplayVersion);
-        Assert.EndsWith(" 1.1", ApplicationVersionInfo.FooterText);
-        Assert.Contains("current 1.1 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.Equal("1.1.1", ApplicationVersionInfo.DisplayVersion);
+        Assert.EndsWith(" 1.1.1", ApplicationVersionInfo.FooterText);
+        Assert.Contains("current 1.1.1 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
         Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
     }
 }

--- a/tests/Wisp.App.Tests/NativeHudStoreBuildIdentityTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudStoreBuildIdentityTests.cs
@@ -1,0 +1,385 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class NativeHudStoreBuildIdentityTests
+{
+    private const string StoreVersion = "3.430.771.0";
+    private const uint ImageSize = 0x5000;
+    private const uint Timestamp = 1787153332;
+    private const int Pe = 0x80;
+    private const int Section = Pe + 24 + 240;
+    private const ulong Module = 0x140000000;
+
+    [Fact]
+    public void ExactSyntheticImageMatchesWithOnlyHeaderAndTwoGuardReads()
+    {
+        var memory = new Memory();
+        var identity = ParseIdentity(IdentityDocument(memory));
+
+        Assert.True(identity.MatchesImage(memory, Module));
+        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(Timestamp, identity.TimeDateStamp);
+        Assert.Equal(ImageSize, identity.ImageSize);
+        Assert.Equal(new[] { (Module, 4096), (Module + 0x1100, 32), (Module + 0x1200, 64) }, memory.Reads);
+    }
+
+    [Theory]
+    [InlineData("missing-name")]
+    [InlineData("extra-property")]
+    [InlineData("wrong-name")]
+    [InlineData("wrong-version")]
+    [InlineData("wrong-architecture")]
+    [InlineData("wrong-publisher")]
+    [InlineData("null-name")]
+    [InlineData("timestamp-zero")]
+    [InlineData("timestamp-negative")]
+    [InlineData("timestamp-string")]
+    [InlineData("timestamp-overflow")]
+    [InlineData("guards-null")]
+    [InlineData("guards-object")]
+    [InlineData("one-guard")]
+    [InlineData("nine-guards")]
+    [InlineData("missing-length")]
+    [InlineData("guard-extra")]
+    [InlineData("guard-null")]
+    [InlineData("rva-before-code")]
+    [InlineData("rva-at-image-end")]
+    [InlineData("rva-overflow")]
+    [InlineData("rva-negative")]
+    [InlineData("rva-string")]
+    [InlineData("length-zero")]
+    [InlineData("length-small")]
+    [InlineData("length-large")]
+    [InlineData("length-string")]
+    [InlineData("length-crosses-image")]
+    [InlineData("overlap")]
+    [InlineData("same-guard")]
+    [InlineData("hash-short")]
+    [InlineData("hash-nonhex")]
+    [InlineData("hash-null")]
+    public void MalformedStoreContractIsRejectedThroughPublicPackParser(string fault)
+    {
+        var document = StorePackDocument();
+        var store = document["storeIdentity"]!.AsObject();
+        var guards = store["codeGuards"]!.AsArray();
+        var first = guards[0]!.AsObject();
+        switch (fault)
+        {
+            case "missing-name": store.Remove("packageFullName"); break;
+            case "extra-property": store["other"] = true; break;
+            case "wrong-name": store["packageFullName"] = "Microsoft.OtherGame_3.430.771.0_x64__8wekyb3d8bbwe"; break;
+            case "wrong-version": document["gameVersion"] = "3.430.772.0"; break;
+            case "wrong-architecture": store["packageFullName"] = "Microsoft.ForteBaseGame_3.430.771.0_x86__8wekyb3d8bbwe"; break;
+            case "wrong-publisher": store["packageFullName"] = "Microsoft.ForteBaseGame_3.430.771.0_x64__other"; break;
+            case "null-name": store["packageFullName"] = null; break;
+            case "timestamp-zero": store["timeDateStamp"] = 0; break;
+            case "timestamp-negative": store["timeDateStamp"] = -1; break;
+            case "timestamp-string": store["timeDateStamp"] = "1787153332"; break;
+            case "timestamp-overflow": store["timeDateStamp"] = (ulong)uint.MaxValue + 1; break;
+            case "guards-null": store["codeGuards"] = null; break;
+            case "guards-object": store["codeGuards"] = new JsonObject(); break;
+            case "one-guard": guards.RemoveAt(1); break;
+            case "nine-guards":
+                for (var index = 2; index < 9; index++)
+                {
+                    var extra = first.DeepClone().AsObject();
+                    extra["rva"] = 0x2000 + index * 256;
+                    guards.Add(extra);
+                }
+                break;
+            case "missing-length": first.Remove("length"); break;
+            case "guard-extra": first["extra"] = 0; break;
+            case "guard-null": guards[0] = null; break;
+            case "rva-before-code": first["rva"] = 4095; break;
+            case "rva-at-image-end": first["rva"] = document["imageSize"]!.DeepClone(); break;
+            case "rva-overflow": first["rva"] = (ulong)uint.MaxValue + 1; break;
+            case "rva-negative": first["rva"] = -1; break;
+            case "rva-string": first["rva"] = "4352"; break;
+            case "length-zero": first["length"] = 0; break;
+            case "length-small": first["length"] = 15; break;
+            case "length-large": first["length"] = 257; break;
+            case "length-string": first["length"] = "32"; break;
+            case "length-crosses-image": first["rva"] = document["imageSize"]!.GetValue<uint>() - 16; break;
+            case "overlap": guards[1]!["rva"] = 0x111F; break;
+            case "same-guard": guards[1] = first.DeepClone(); break;
+            case "hash-short": first["sha256"] = new string('A', 63); break;
+            case "hash-nonhex": first["sha256"] = new string('G', 64); break;
+            case "hash-null": first["sha256"] = null; break;
+            default: throw new ArgumentOutOfRangeException(nameof(fault));
+        }
+
+        Assert.Throws<FormatException>(() => ParsePack(document));
+    }
+
+    [Theory]
+    [InlineData("packageFullName")]
+    [InlineData("timeDateStamp")]
+    [InlineData("codeGuards")]
+    public void DuplicateIdentityPropertiesAreRejected(string property)
+    {
+        var document = StorePackDocument();
+        var original = document["storeIdentity"]![property]!.ToJsonString();
+        var json = document.ToJsonString().Replace($"\"{property}\":{original}",
+            $"\"{property}\":{original},\"{property}\":{original}", StringComparison.Ordinal);
+        Assert.Throws<FormatException>(() => NativeHudCompatibilityPack.Parse(System.Text.Encoding.UTF8.GetBytes(json)));
+    }
+
+    [Fact]
+    public void AdjacentGuardsAtMinimumAndMaximumLengthAreAccepted()
+    {
+        var memory = new Memory();
+        var document = IdentityDocument(memory);
+        document["codeGuards"] = new JsonArray(Guard(memory, 4096, 16), Guard(memory, 4112, 256));
+        Assert.True(ParseIdentity(document).MatchesImage(memory, Module));
+    }
+
+    [Fact]
+    public void EightNonoverlappingGuardsAreAccepted()
+    {
+        var memory = new Memory();
+        var document = IdentityDocument(memory);
+        document["codeGuards"] = new JsonArray(Enumerable.Range(0, 8)
+            .Select(index => (JsonNode)Guard(memory, (uint)(4096 + index * 32), 16)).ToArray());
+        Assert.True(ParseIdentity(document).MatchesImage(memory, Module));
+    }
+
+    [Theory]
+    [InlineData("dos")]
+    [InlineData("pe-negative")]
+    [InlineData("pe-small")]
+    [InlineData("pe-large")]
+    [InlineData("signature")]
+    [InlineData("machine")]
+    [InlineData("timestamp")]
+    [InlineData("optional-magic")]
+    [InlineData("image-size")]
+    [InlineData("sections-zero")]
+    [InlineData("sections-many")]
+    [InlineData("optional-size-small")]
+    [InlineData("section-table-overflow")]
+    [InlineData("section-before-code")]
+    [InlineData("section-past-image")]
+    [InlineData("section-size-overflow")]
+    [InlineData("guard-crosses-section")]
+    [InlineData("section-not-executable")]
+    [InlineData("section-writable")]
+    [InlineData("first-hash-changed")]
+    [InlineData("second-hash-changed")]
+    public void CorruptOrMismatchedSyntheticImageIsRejected(string fault)
+    {
+        var memory = new Memory();
+        var identity = ParseIdentity(IdentityDocument(memory));
+        switch (fault)
+        {
+            case "dos": memory.U16(0, 0); break;
+            case "pe-negative": memory.U32(0x3C, uint.MaxValue); break;
+            case "pe-small": memory.U32(0x3C, 63); break;
+            case "pe-large": memory.U32(0x3C, 2049); break;
+            case "signature": memory.U32(Pe, 0); break;
+            case "machine": memory.U16(Pe + 4, 0x14C); break;
+            case "timestamp": memory.U32(Pe + 8, Timestamp + 1); break;
+            case "optional-magic": memory.U16(Pe + 24, 0x10B); break;
+            case "image-size": memory.U32(Pe + 80, ImageSize + 4096); break;
+            case "sections-zero": memory.U16(Pe + 6, 0); break;
+            case "sections-many": memory.U16(Pe + 6, 33); break;
+            case "optional-size-small": memory.U16(Pe + 20, 111); break;
+            case "section-table-overflow": memory.U16(Pe + 20, 4096); break;
+            case "section-before-code": memory.U32(Section + 12, 4095); break;
+            case "section-past-image": memory.U32(Section + 12, ImageSize); break;
+            case "section-size-overflow": memory.U32(Section + 8, uint.MaxValue); break;
+            case "guard-crosses-section": memory.U32(Section + 8, 0x11F); break;
+            case "section-not-executable": memory.U32(Section + 36, 0x40000040); break;
+            case "section-writable": memory.U32(Section + 36, 0xE0000020); break;
+            case "first-hash-changed": memory.Bytes[0x1100] ^= 1; break;
+            case "second-hash-changed": memory.Bytes[0x1200] ^= 1; break;
+            default: throw new ArgumentOutOfRangeException(nameof(fault));
+        }
+
+        Assert.False(identity.MatchesImage(memory, Module));
+        Assert.InRange(memory.Reads.Count, 1, 3);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(0x1100)]
+    [InlineData(0x1200)]
+    public void FailedOrPartialReadCannotAcceptStaleBufferContents(int failedRva)
+    {
+        var memory = new Memory();
+        var identity = ParseIdentity(IdentityDocument(memory));
+        memory.PartialReadAddress = Module + (ulong)failedRva;
+        Assert.False(identity.MatchesImage(memory, Module));
+        Assert.Equal(memory.PartialReadAddress, memory.Reads[^1].Address);
+    }
+
+    [Theory]
+    [InlineData(0UL)]
+    [InlineData(0xFFFFUL)]
+    [InlineData(Module + 1)]
+    [InlineData(0x00007FFFFFFFE000UL)]
+    [InlineData(0x0000800000000000UL)]
+    [InlineData(0xFFFFFFFFFFFFFFF8UL)]
+    public void InvalidOrOverflowingModuleRangeIsRejectedWithoutReads(ulong module)
+    {
+        var memory = new Memory();
+        var identity = ParseIdentity(IdentityDocument(memory));
+        Assert.False(identity.MatchesImage(memory, module));
+        Assert.Empty(memory.Reads);
+    }
+
+    [Fact]
+    public void GuardHashesAreCopiedAndCaseInsensitive()
+    {
+        var memory = new Memory();
+        var document = IdentityDocument(memory);
+        document["codeGuards"]![0]!["sha256"] = document["codeGuards"]![0]!["sha256"]!.GetValue<string>().ToLowerInvariant();
+        var identity = ParseIdentity(document);
+        document["codeGuards"]!.AsArray().Clear();
+        Assert.True(identity.MatchesImage(memory, Module));
+        Assert.All(typeof(NativeHudStoreBuildIdentity).GetProperties(), property => Assert.Null(property.SetMethod));
+    }
+
+    [Fact]
+    public void StorePackCannotBeSelectedAsAFileFingerprintAndSteamStillCan()
+    {
+        var store = ParsePack(StorePackDocument());
+        var steam = NativeHudBuildContract.BuiltIn;
+        Assert.NotNull(store.StoreIdentity);
+        Assert.Equal(0, store.ExecutableLength);
+        Assert.Equal(string.Empty, store.ExecutableSha256);
+        Assert.False(store.Matches(store.GameVersion, 0, string.Empty));
+        Assert.False(store.Matches(store.GameVersion, steam.ExecutableLength, steam.ExecutableSha256));
+        Assert.Null(steam.StoreIdentity);
+        Assert.True(steam.Matches(steam.GameVersion, steam.ExecutableLength, steam.ExecutableSha256));
+    }
+
+    [Theory]
+    [InlineData("executableLength")]
+    [InlineData("executableSha256")]
+    public void StoreSchemaCannotCarryASyntheticFileFingerprint(string property)
+    {
+        var document = StorePackDocument();
+        document[property] = property == "executableLength" ? JsonValue.Create(4096) : JsonValue.Create(new string('A', 64));
+        Assert.Throws<FormatException>(() => ParsePack(document));
+    }
+
+    [Fact]
+    public void EvenTrustedSignedEnvelopeCannotSupplyAStorePack()
+    {
+        var now = new DateTimeOffset(2026, 9, 6, 12, 0, 0, TimeSpan.Zero);
+        using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var publicKey = key.ExportSubjectPublicKeyInfo();
+        var keyId = NativeCompatibilitySignature.GetKeyId(publicKey);
+        var payload = JsonSerializer.SerializeToUtf8Bytes(new JsonObject
+        {
+            ["format"] = 1,
+            ["purpose"] = "wisp-native-hud-compatibility",
+            ["issuedUtc"] = "2026-09-06T11:00:00Z",
+            ["expiresUtc"] = "2026-09-07T12:00:00Z",
+            ["pack"] = StorePackDocument()
+        });
+        var signature = key.SignData(NativeCompatibilitySignature.CreateSigningInput(payload),
+            HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+        var envelope = JsonSerializer.SerializeToUtf8Bytes(new JsonObject
+        {
+            ["format"] = 1,
+            ["keyId"] = keyId,
+            ["payload"] = Convert.ToBase64String(payload),
+            ["signature"] = Convert.ToBase64String(signature)
+        });
+        var exception = Assert.Throws<NativeCompatibilityEnvelopeException>(() => NativeCompatibilityEnvelope.Verify(
+            envelope, new Dictionary<string, byte[]> { [keyId] = publicKey }, now));
+        Assert.Equal(NativeCompatibilityInstallCode.InvalidEnvelope, exception.Code);
+        Assert.Contains("application release", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static JsonObject StorePackDocument()
+    {
+        using var stream = typeof(NativeHudBuildContract).Assembly.GetManifestResourceStream("Wisp.NativeCompatibility.BuiltIn.json");
+        Assert.NotNull(stream);
+        var document = JsonNode.Parse(stream)!.AsObject();
+        document["schemaVersion"] = 4;
+        document["readerVersion"] = 4;
+        document["gameVersion"] = StoreVersion;
+        document.Remove("executableLength");
+        document.Remove("executableSha256");
+        document["storeIdentity"] = IdentityDocument(new Memory());
+        document["nativeGauge"] = null;
+        return document;
+    }
+
+    private static NativeHudCompatibilityPack ParsePack(JsonObject document) =>
+        NativeHudCompatibilityPack.Parse(JsonSerializer.SerializeToUtf8Bytes(document));
+
+    private static NativeHudStoreBuildIdentity ParseIdentity(JsonObject document)
+    {
+        using var json = JsonDocument.Parse(document.ToJsonString());
+        return NativeHudStoreBuildIdentity.Parse(json.RootElement, StoreVersion, ImageSize);
+    }
+
+    private static JsonObject IdentityDocument(Memory memory) => new()
+    {
+        ["packageFullName"] = NativeStorePackageIdentity.SupportedPackageFullName,
+        ["timeDateStamp"] = Timestamp,
+        ["codeGuards"] = new JsonArray(Guard(memory, 0x1100, 32), Guard(memory, 0x1200, 64))
+    };
+
+    private static JsonObject Guard(Memory memory, uint rva, int length) => new()
+    {
+        ["rva"] = rva,
+        ["length"] = length,
+        ["sha256"] = Convert.ToHexString(SHA256.HashData(memory.Bytes.AsSpan((int)rva, length)))
+    };
+
+    private sealed class Memory : IReadOnlyProcessMemory
+    {
+        internal byte[] Bytes { get; } = new byte[ImageSize];
+        internal List<(ulong Address, int Length)> Reads { get; } = [];
+        internal ulong? PartialReadAddress { get; set; }
+
+        internal Memory()
+        {
+            U16(0, 0x5A4D);
+            U32(0x3C, Pe);
+            U32(Pe, 0x4550);
+            U16(Pe + 4, 0x8664);
+            U16(Pe + 6, 1);
+            U32(Pe + 8, Timestamp);
+            U16(Pe + 20, 240);
+            U16(Pe + 24, 0x20B);
+            U32(Pe + 80, ImageSize);
+            U32(Section + 8, 0x2000);
+            U32(Section + 12, 0x1000);
+            U32(Section + 36, 0x60000020);
+            for (var index = 0x1000; index < 0x3000; index++) Bytes[index] = (byte)(index % 251);
+        }
+
+        internal void U16(int offset, ushort value) => BinaryPrimitives.WriteUInt16LittleEndian(Bytes.AsSpan(offset), value);
+        internal void U32(int offset, uint value) => BinaryPrimitives.WriteUInt32LittleEndian(Bytes.AsSpan(offset), value);
+
+        public bool TryReadBytes(ulong address, Span<byte> destination)
+        {
+            Reads.Add((address, destination.Length));
+            if (address < Module || address - Module > ImageSize || (ulong)destination.Length > ImageSize - (address - Module))
+                return false;
+            var source = Bytes.AsSpan((int)(address - Module), destination.Length);
+            if (PartialReadAddress == address)
+            {
+                source[..(source.Length / 2)].CopyTo(destination);
+                return false;
+            }
+            source.CopyTo(destination);
+            return true;
+        }
+
+        public bool TryReadByte(ulong address, out byte value) => throw new InvalidOperationException("Unexpected scalar read.");
+        public bool TryReadUInt32(ulong address, out uint value) => throw new InvalidOperationException("Unexpected scalar read.");
+        public bool TryReadUInt64(ulong address, out ulong value) => throw new InvalidOperationException("Unexpected scalar read.");
+        public bool TryReadSingle(ulong address, out float value) => throw new InvalidOperationException("Unexpected scalar read.");
+    }
+}

--- a/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
+++ b/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
@@ -1,0 +1,312 @@
+using Microsoft.Win32.SafeHandles;
+using Wisp.App;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class NativeStorePackageIdentityTests
+{
+    private const string PackagePath = @"C:\Games\Forza\Content";
+    private const string ExecutablePath = PackagePath + @"\ForzaHorizon6.exe";
+
+    [Fact]
+    public void ExactStorePackageAndExecutableMatch()
+    {
+        Assert.True(Validate(ExecutablePath, out var identity));
+        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(ExecutablePath.ToUpperInvariant(), identity.ExecutablePath);
+    }
+
+    [Theory]
+    [InlineData(@"c:\games\forza\content\FORZAHORIZON6.EXE")]
+    [InlineData(@"\\?\C:\Games\Forza\Content\ForzaHorizon6.exe")]
+    [InlineData(@"C:\Games\Forza\Content\.\ForzaHorizon6.exe")]
+    public void EquivalentAbsoluteExecutablePathsAreNormalized(string path) => Assert.True(Validate(path, out _));
+
+    [Theory]
+    [InlineData(@"C:\Games\Forza\ContentOther\ForzaHorizon6.exe")]
+    [InlineData(@"C:\Games\Forza\Content\..\ForzaHorizon6.exe")]
+    [InlineData(@"C:\Games\Forza\Content\Other\ForzaHorizon6.exe")]
+    [InlineData(@"C:\Games\Forza\Content\Other.exe")]
+    [InlineData(@"C:\Games\Forza\Content\ForzaHorizon6.exe:stream")]
+    [InlineData(@"C:\Games\Forza\Content\ForzaHorizon6.exe.bak")]
+    [InlineData(@"Content\ForzaHorizon6.exe")]
+    [InlineData(@"\\.\C:\Games\Forza\Content\ForzaHorizon6.exe")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("C:\\Games\\Forza\\Content\\ForzaHorizon6.exe\0ignored")]
+    public void WrongOrMalformedExecutablePathIsRejected(string? path)
+    {
+        Assert.False(Validate(path, out var identity));
+        Assert.Equal(default, identity);
+    }
+
+    [Theory]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_6.430.771.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.771.0_x86__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.771.0_x64__otherpublisher")]
+    [InlineData("Microsoft.OtherGame_3.430.771.0_x64__8wekyb3d8bbwe")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void OtherPackageOrBuildIsRejected(string? name) => Assert.False(
+        NativeStorePackageIdentity.TryValidate(name, 3, PackagePath, PackagePath, ExecutablePath, out _));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    public void NonStoreOriginsAreRejected(int origin) => Assert.False(
+        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+            origin, PackagePath, PackagePath, ExecutablePath, out _));
+
+    [Theory]
+    [InlineData(null, PackagePath)]
+    [InlineData(PackagePath, null)]
+    [InlineData("", PackagePath)]
+    [InlineData(PackagePath, "relative")]
+    [InlineData(@"C:\Games\Other\Content", PackagePath)]
+    [InlineData(PackagePath, @"C:\Games\Other\Content")]
+    public void UnavailableOrUnverifiedPackagePathsAreRejected(string? original, string? effective) => Assert.False(
+        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+            3, original, effective, ExecutablePath, out _));
+
+    [Fact]
+    public void NativeQueriesUseOriginalAndEffectivePathsWithoutMutablePath()
+    {
+        using var handle = new SafeProcessHandle(new IntPtr(42), ownsHandle: false);
+        var api = new FakePackageApi();
+        Assert.True(NativeStorePackageIdentity.TryRead(handle, ExecutablePath, api, out var identity));
+        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(new[] { 0, 0, 2, 2 }, api.PathTypes);
+        Assert.Equal(2, api.NameCalls);
+    }
+
+    [Theory]
+    [InlineData("no-package")]
+    [InlineData("name-first-success")]
+    [InlineData("name-small")]
+    [InlineData("name-large")]
+    [InlineData("name-second-error")]
+    [InlineData("name-growth")]
+    [InlineData("name-no-terminator")]
+    [InlineData("name-interior-null")]
+    [InlineData("origin-error")]
+    [InlineData("original-error")]
+    [InlineData("effective-error")]
+    [InlineData("path-large")]
+    [InlineData("path-growth")]
+    [InlineData("missing-api")]
+    public void NativeErrorsAndMalformedBufferResultsFailClosed(string fault)
+    {
+        using var handle = new SafeProcessHandle(new IntPtr(42), ownsHandle: false);
+        var api = new FakePackageApi { Fault = fault };
+        Assert.False(NativeStorePackageIdentity.TryRead(handle, ExecutablePath, api, out var identity));
+        Assert.Equal(default, identity);
+        Assert.InRange(api.NameCalls, 1, 2);
+        Assert.InRange(api.PathTypes.Count, 0, 4);
+    }
+
+    [Fact]
+    public void InvalidOrClosedHandleDoesNotCallWindows()
+    {
+        var api = new FakePackageApi();
+        using var invalid = new SafeProcessHandle(IntPtr.Zero, ownsHandle: false);
+        Assert.False(NativeStorePackageIdentity.TryRead(invalid, ExecutablePath, api, out _));
+        using var closed = new SafeProcessHandle(new IntPtr(42), ownsHandle: false);
+        closed.Dispose();
+        Assert.False(NativeStorePackageIdentity.TryRead(closed, ExecutablePath, api, out _));
+        Assert.Equal(0, api.NameCalls);
+    }
+
+    private static bool Validate(string? path, out NativeStorePackageIdentity identity) =>
+        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+            3, PackagePath, PackagePath, path, out identity);
+
+    [Fact]
+    public void DifferentPathsNeedTheSameLive128BitFileIdentity()
+    {
+        var api = new FakeFileAliasApi();
+        Assert.True(NativeStorePackageIdentity.MatchesExecutableFileAlias(
+            ExecutablePath, @"C:\Projected\ForzaHorizon6.exe", api));
+        Assert.Equal(2, api.Handles.Count);
+        Assert.Equal(2, api.ReadCount);
+        Assert.All(api.Handles, handle => Assert.True(handle.IsClosed));
+    }
+
+    [Theory]
+    [InlineData("volume")]
+    [InlineData("id-low")]
+    [InlineData("id-high")]
+    [InlineData("size")]
+    [InlineData("created")]
+    [InlineData("modified")]
+    public void AliasMetadataMismatchIsRejected(string changed)
+    {
+        var expected = FakeFileAliasApi.ValidIdentity;
+        var observed = changed switch
+        {
+            "volume" => expected with { Volume = expected.Volume + 1 },
+            "id-low" => expected with { FileIdLow = expected.FileIdLow + 1 },
+            "id-high" => expected with { FileIdHigh = expected.FileIdHigh + 1 },
+            "size" => expected with { Length = expected.Length + 1 },
+            "created" => expected with { CreationTime = expected.CreationTime + 1 },
+            "modified" => expected with { LastWriteTime = expected.LastWriteTime + 1 },
+            _ => throw new ArgumentOutOfRangeException(nameof(changed))
+        };
+        Assert.False(NativeStorePackageIdentity.MatchesFileIdentity(expected, observed));
+        Assert.False(NativeStorePackageIdentity.MatchesFileIdentity(observed, expected));
+    }
+
+    [Theory]
+    [InlineData("zero-volume")]
+    [InlineData("zero-id")]
+    [InlineData("short-file")]
+    [InlineData("huge-file")]
+    [InlineData("zero-created")]
+    [InlineData("zero-modified")]
+    [InlineData("directory")]
+    [InlineData("device")]
+    public void EqualButInvalidFileMetadataCannotMatch(string changed)
+    {
+        var valid = FakeFileAliasApi.ValidIdentity;
+        var invalid = changed switch
+        {
+            "zero-volume" => valid with { Volume = 0 },
+            "zero-id" => valid with { FileIdLow = 0, FileIdHigh = 0 },
+            "short-file" => valid with { Length = 4095 },
+            "huge-file" => valid with { Length = 2147483649 },
+            "zero-created" => valid with { CreationTime = 0 },
+            "zero-modified" => valid with { LastWriteTime = 0 },
+            "directory" => valid with { Attributes = 0x10 },
+            "device" => valid with { Attributes = 0x40 },
+            _ => throw new ArgumentOutOfRangeException(nameof(changed))
+        };
+        Assert.False(NativeStorePackageIdentity.MatchesFileIdentity(invalid, invalid));
+        Assert.False(NativeStorePackageIdentity.MatchesFileIdentity(default, default));
+    }
+
+    [Fact]
+    public void HighHalfOnlyFileIdentifierIsNotTreatedAsZero()
+    {
+        var identity = FakeFileAliasApi.ValidIdentity with { FileIdLow = 0, FileIdHigh = 12 };
+        Assert.True(NativeStorePackageIdentity.MatchesFileIdentity(identity, identity));
+    }
+
+    [Theory]
+    [InlineData("open-first")]
+    [InlineData("open-second")]
+    [InlineData("read-first")]
+    [InlineData("read-second")]
+    [InlineData("access-denied")]
+    [InlineData("missing-api")]
+    public void AttributeHandleErrorsFailClosedAndReleaseHandles(string fault)
+    {
+        var api = new FakeFileAliasApi { Fault = fault };
+        Assert.False(NativeStorePackageIdentity.MatchesExecutableFileAlias(
+            ExecutablePath, @"C:\Projected\ForzaHorizon6.exe", api));
+        Assert.All(api.Handles, handle => Assert.True(handle.IsClosed));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Projected\NotForza.exe")]
+    [InlineData(@"C:\Projected\ForzaHorizon6.exe:stream")]
+    [InlineData(@"C:\Projected\ForzaHorizon6.exe.bak")]
+    [InlineData(@"\\unavailable\share\ForzaHorizon6.exe")]
+    [InlineData(@"\\.\C:\Projected\ForzaHorizon6.exe")]
+    [InlineData(@"relative\ForzaHorizon6.exe")]
+    [InlineData("")]
+    public void InvalidAliasPathDoesNotOpenAnyFile(string invalidPath)
+    {
+        var api = new FakeFileAliasApi();
+        Assert.False(NativeStorePackageIdentity.MatchesExecutableFileAlias(ExecutablePath, invalidPath, api));
+        Assert.False(NativeStorePackageIdentity.MatchesExecutableFileAlias(invalidPath, ExecutablePath, api));
+        Assert.Empty(api.Handles);
+    }
+
+    private sealed class FakeFileAliasApi : NativeStorePackageIdentity.IFileAliasApi
+    {
+        internal static readonly NativeStorePackageIdentity.FileAliasIdentity ValidIdentity = new(11, 12, 13, 50000, 100, 200, 0x80);
+        internal string Fault { get; init; } = "";
+        internal List<SafeFileHandle> Handles { get; } = [];
+        internal int ReadCount { get; private set; }
+
+        public SafeFileHandle OpenAttributes(string path)
+        {
+            if (Fault == "access-denied") throw new UnauthorizedAccessException();
+            if (Fault == "missing-api") throw new EntryPointNotFoundException();
+            var invalid = Fault == "open-first" && Handles.Count == 0 || Fault == "open-second" && Handles.Count == 1;
+            var handle = new SafeFileHandle(invalid ? new IntPtr(-1) : new IntPtr(41 + Handles.Count), ownsHandle: false);
+            Handles.Add(handle);
+            return handle;
+        }
+
+        public bool TryReadIdentity(SafeFileHandle handle, out NativeStorePackageIdentity.FileAliasIdentity identity)
+        {
+            Assert.Equal(2, Handles.Count);
+            Assert.All(Handles, existing => Assert.False(existing.IsClosed));
+            ReadCount++;
+            identity = ValidIdentity;
+            return !(Fault == "read-first" && ReadCount == 1 || Fault == "read-second" && ReadCount == 2);
+        }
+    }
+
+    private sealed class FakePackageApi : NativeStorePackageIdentity.IPackageApi
+    {
+        internal string Fault { get; init; } = "";
+        internal int NameCalls { get; private set; }
+        internal List<int> PathTypes { get; } = [];
+
+        public int GetFullName(SafeProcessHandle handle, ref uint length, char[]? buffer)
+        {
+            NameCalls++;
+            if (Fault == "missing-api") throw new EntryPointNotFoundException();
+            if (Fault == "no-package") return 15700;
+            if (buffer is null)
+            {
+                if (Fault == "name-first-success") return 0;
+                if (Fault == "name-small") { length = 1; return 122; }
+                if (Fault == "name-large") { length = uint.MaxValue; return 122; }
+            }
+            else
+            {
+                if (Fault == "name-second-error") return 122;
+                if (Fault == "name-growth") { length++; return 0; }
+            }
+
+            var result = Copy(NativeStorePackageIdentity.SupportedPackageFullName, ref length, buffer);
+            if (buffer is not null && Fault == "name-no-terminator") buffer[^1] = 'x';
+            if (buffer is not null && Fault == "name-interior-null") buffer[3] = '\0';
+            return result;
+        }
+
+        public int GetOrigin(string fullName, out int origin)
+        {
+            origin = 3;
+            return Fault == "origin-error" ? 5 : 0;
+        }
+
+        public int GetPath(string fullName, int pathType, ref uint length, char[]? buffer)
+        {
+            PathTypes.Add(pathType);
+            if (Fault == "original-error" && pathType == 0 || Fault == "effective-error" && pathType == 2) return 15707;
+            if (Fault == "path-large" && buffer is null) { length = uint.MaxValue; return 122; }
+            if (Fault == "path-growth" && buffer is not null) { length++; return 0; }
+            return Copy(PackagePath, ref length, buffer);
+        }
+
+        private static int Copy(string value, ref uint length, char[]? buffer)
+        {
+            length = (uint)value.Length + 1;
+            if (buffer is null) return 122;
+            value.CopyTo(0, buffer, 0, value.Length);
+            buffer[value.Length] = '\0';
+            return 0;
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));
@@ -17,6 +17,21 @@ public sealed class ReleaseNotesCatalogTests
             Assert.NotEmpty(entry.Groups);
             Assert.All(entry.Groups, group => Assert.NotEmpty(group.Items));
         });
+    }
+
+    [Fact]
+    public void CurrentStoreCompatibilityEntryIdentifiesTheSupportedPcBuild()
+    {
+        var entry = ReleaseNotesCatalog.Entries[0];
+        Assert.Equal("1.1.1", entry.Version);
+        Assert.Equal("COMPATIBILITY HOTFIX", entry.Label);
+        Assert.True(entry.IsCurrent);
+        var text = string.Join(' ', entry.Groups.SelectMany(group => group.Items));
+        Assert.Contains("3.430.771.0", text, StringComparison.Ordinal);
+        Assert.Contains("Xbox app and Microsoft Store", text, StringComparison.Ordinal);
+        Assert.Contains("Other Store builds remain unsupported", text, StringComparison.Ordinal);
+        Assert.Contains("on Windows", entry.Summary, StringComparison.Ordinal);
+        Assert.Contains("Steam compatibility path is preserved", text, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add Xbox app and Microsoft Store PC compatibility for FH6 build 3.430.771.0.
- Keep the Steam compatibility path unchanged, with separate Store package, loaded-image, and same-file path checks.
- Update the application, installer, README, changelog, and release notes to 1.1.1.

## Validation

- 2,756 .NET tests and 75 packaging-tool tests passed locally.
- The private installer passed both updater verification checks and checksum verification.
- Live Xbox FH6 checks confirmed attachment, local telemetry, gameplay visibility, exact redline, assist data, and stock needle data.
- Race transitions and electric-vehicle behavior were not separately verified in the live capture.

Related to #43. Close the issue after the 1.1.1 release is published.
