### PR TITLE
Release 1.1.2: restore Forza compatibility and harden map updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ _ReSharper*/
 *.snk
 *.key
 *.pem
+*.dpapi
 
 # Logs, temporary files, and crash diagnostics
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.1.2 - 2026-09-07
+
+- Add the native compatibility map for Steam FH6 `6.440.853.0`, retaining the previous Steam and Store maps.
+- Enable signed compatibility-map updates with bounded multi-build bundles, atomic cache installation, offline reuse, and revision protection.
+- Select future reviewed Store maps by their actual Windows package identity while preserving origin, path, image, and reader guards.
+
+Future changes to the reader's supported native structures or semantics can still require an application update.
+
 ## 1.1.1 - 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
+## New in Wisp 1.1.2
+
+Adds support for Steam FH6 `6.440.853.0` and signed compatibility-map updates for
+future reviewed builds. Existing Steam and Store maps remain available offline.
+Unknown native layouts still require review; changes beyond the reader's
+supported schema may need an application update.
+
+[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.1.2 release notes](docs/releases/Wisp-1.1.2-release-notes.md)
+
 ## New in Wisp 1.1.1
 
 [Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,8 +2,9 @@
 
 ## Current support
 
-Wisp 1.1.1 includes separate Native HUD compatibility contracts for:
+Wisp 1.1.2 includes separate Native HUD compatibility contracts for:
 
+- Steam FH6 build `6.440.853.0`, identified by its recorded executable fingerprint;
 - Steam FH6 build `6.430.771.0`, identified by its recorded executable fingerprint;
 - Xbox app / Microsoft Store Windows PC build `3.430.771.0`, identified by its
   Store package and bounded loaded-image checks.
@@ -90,18 +91,31 @@ A contract contains data only: executable identity, bounded module-relative
 addresses, field offsets, widths, guards, and thresholds. It cannot contain
 executable code, commands, URLs, or trust keys.
 
-The runtime includes strict validation for signed contracts, revision floors,
-an offline cache, and an HTTPS client. Automatic distribution is not configured
-in the current build: the production endpoint and publisher keys are empty, so the
-application makes no compatibility-update request and keeps import/check
-controls disabled. Recovery from a new or changed game build identity
-therefore requires a reviewed Wisp release containing a compatible contract.
-Store contracts are supplied only by the application release and are not accepted
-through the signed-pack import path.
+Wisp 1.1.2 configures a release-owned ECDSA P-256 public key and the fixed HTTPS
+endpoint `https://wispoverlay.com/compatibility/latest.json`. Checks run in the
+background at startup and once per day while Wisp stays open; Diagnostics also
+offers a manual check and signed-file import. Requests have bounded sizes and
+timeouts, no redirects, and no telemetry upload. A failed download or signature
+check leaves the accepted catalog unchanged. Bundled maps work without a
+network connection or an available publisher endpoint.
 
-Distribution can be enabled only with pinned release-owned keys and reviewed
-contracts. A failed download or signature check leaves the accepted catalog
-unchanged. No vehicle data is uploaded.
+The signed payload can contain one legacy contract (format 1) or up to eight
+contracts (format 2). A bundle can cover separate Steam and Store builds. Every
+entry must pass the same schema and identity rules, and every Store attachment
+still requires Windows package provenance and loaded-image guards. Wisp never
+uses a Steam contract for a Store executable.
+
+Bundle installation validates every entry before committing one acceptance
+ledger. Revision floors prevent replacement with an older accepted map. A
+failed write cannot publish a partially installed bundle. Previously accepted
+maps are reverified from the local cache at startup and remain usable offline,
+including after the download envelope's original expiry. Older embedded maps
+remain available for installations that have not updated Forza.
+
+This channel permits reviewed address-map updates without reinstalling Wisp.
+It cannot automatically approve an unknown native layout. A game update that
+changes field semantics, ownership rules, or the supported reader schema still
+requires code review and may require a new application release.
 
 This small pinned-key protocol is not a complete software-update framework. It
 does not claim protection from a hostile local administrator, application
@@ -151,6 +165,34 @@ Static analysis cannot prove live local-player identity, car/RPM agreement,
 gameplay visibility, protected getter semantics, electric digit/unit behavior,
 or assist transitions. A changed contract therefore needs controlled runtime
 validation before it can be accepted.
+
+### Publishing a reviewed map
+
+`tools/Sign-CompatibilityBundle.ps1` signs reviewed JSON contracts locally with
+the release owner's Windows-user-protected key. The private key stays outside
+the repository, installer, and website. Its DPAPI protection depends on the
+owning Windows profile; copying that file to a different machine is not a
+portable key backup. Never replace the established key during a routine map
+update. Changing the pinned key requires a reviewed application release.
+
+After static and live validation, sign one bundle containing the builds being
+maintained. Increment the revision of every included previously signed map
+when creating a different payload, even if its address data is unchanged:
+timestamps and the other bundle members are part of the signed payload too.
+Do not reuse a revision from a different payload. A client with a newer embedded
+map keeps that map when processing a bundle; cached revision floors still apply.
+
+```[WINDOWS POWERSHELL]
+./tools/Sign-CompatibilityBundle.ps1 -KeyFile $protectedPublisherKeyPath -Pack $reviewedPackPaths -Output ./outputs/compatibility/latest.json -Reviewed
+```
+
+Before publication, verify that exact file through Wisp's pinned-key catalog in
+an isolated cache, test a corrupted copy is rejected, and repeat acceptance from
+the cache with networking unavailable. Publish only the resulting signed JSON
+at the configured endpoint after approval. Serve JSON without a redirect or
+content encoding, with a short cache lifetime, and retain the exact published
+bytes for auditing. Publishing an HTML error page or an unsigned pack never
+changes the accepted catalog.
 
 ## Failure behavior
 

--- a/docs/releases/Wisp-1.1.2-release-notes.md
+++ b/docs/releases/Wisp-1.1.2-release-notes.md
@@ -1,0 +1,18 @@
+# Wisp 1.1.2
+
+Compatibility update for the Steam FH6 `6.440.853.0` build, with a signed
+compatibility-map channel for future reviewed game updates.
+
+- Adds a separate native memory map for the new Steam executable.
+- Retains the verified Steam `6.430.771.0` and Xbox app / Microsoft Store
+  `3.430.771.0` maps. New Store builds require their own reviewed map.
+- Enables background and manual checks for signed maps, including bundles
+  covering multiple game builds. Accepted maps remain available offline.
+- Preserves exact executable/package checks, bounded read-only access, and
+  menu visibility validation. Unknown layouts are never guessed.
+
+Some future game changes will still require an application update when they
+change the reader's supported data structures or semantics.
+
+The installer is `Wisp-Setup-1.1.2.exe`. Install over your current Wisp version
+to retain completed setup, HUD preferences, profiles, and tire calibration.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,6 +1,6 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.1.1"
-#define MyAppDisplayVersion "1.1.1"
+#define MyAppVersion "1.1.2"
+#define MyAppDisplayVersion "1.1.2"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/NativeCompatibility/NativeCompatibilityCatalog.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeCompatibilityCatalog.cs
@@ -28,7 +28,11 @@ public sealed record NativeCompatibilityInstallResult(
     bool Changed,
     NativeCompatibilityInstallCode Code,
     string Message,
-    NativeHudCompatibilityPack? Pack = null);
+    NativeHudCompatibilityPack? Pack = null)
+{
+    public IReadOnlyList<NativeHudCompatibilityPack> Packs { get; init; } =
+        Pack is null ? Array.Empty<NativeHudCompatibilityPack>() : Array.AsReadOnly(new[] { Pack });
+}
 
 public sealed class NativeCompatibilityEnvelopeException : FormatException
 {
@@ -41,20 +45,24 @@ public sealed class NativeCompatibilityEnvelopeException : FormatException
 public sealed class NativeVerifiedCompatibilityEnvelope
 {
     internal NativeVerifiedCompatibilityEnvelope(
-        NativeHudCompatibilityPack pack,
+        int payloadFormat,
+        IReadOnlyList<NativeHudCompatibilityPack> packs,
         string keyId,
         string payloadSha256,
         DateTimeOffset issuedUtc,
         DateTimeOffset expiresUtc)
     {
-        Pack = pack;
+        PayloadFormat = payloadFormat;
+        Packs = Array.AsReadOnly(packs.ToArray());
         KeyId = keyId;
         PayloadSha256 = payloadSha256;
         IssuedUtc = issuedUtc;
         ExpiresUtc = expiresUtc;
     }
 
-    public NativeHudCompatibilityPack Pack { get; }
+    public NativeHudCompatibilityPack Pack => Packs[0];
+    public int PayloadFormat { get; }
+    public IReadOnlyList<NativeHudCompatibilityPack> Packs { get; }
     public string KeyId { get; }
     public string PayloadSha256 { get; }
     public DateTimeOffset IssuedUtc { get; }
@@ -118,7 +126,7 @@ public static class NativeCompatibilitySignature
 
 /// <summary>
 /// A small pinned-key signed-pack protocol, not TUF. Envelope and payload property names are case sensitive.
-/// Payload: format=1, purpose="wisp-native-hud-compatibility", issuedUtc, expiresUtc, pack.
+/// Payload: format=1 with pack, or format=2 with packs; both share purpose, issuedUtc and expiresUtc.
 /// Envelope: format=1, keyId=SHA256(SPKI), payload=canonical base64, signature=canonical base64.
 /// UTC timestamps require a literal Z and zero to seven fractional-second digits. No executable content is accepted.
 /// </summary>
@@ -127,6 +135,7 @@ public static class NativeCompatibilityEnvelope
     public const int MaximumEnvelopeBytes = 128 * 1024;
     public const int MaximumPayloadBytes = 96 * 1024;
     public const int MaximumTrustedKeys = 16;
+    public const int MaximumPacks = 8;
     public static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
 
     public static NativeVerifiedCompatibilityEnvelope Verify(
@@ -173,10 +182,18 @@ public static class NativeCompatibilityEnvelope
             }
 
             using var payloadDocument = NativeCompatibilityJson.Parse(payload, MaximumPayloadBytes);
+            var payloadRoot = payloadDocument.RootElement;
+            var format = payloadRoot.ValueKind == JsonValueKind.Object && payloadRoot.TryGetProperty("format", out var formatElement)
+                ? NativeCompatibilityJson.ReadInt32(formatElement)
+                : 0;
+            if (format is not (1 or 2))
+            {
+                throw Invalid("The signed payload format is unsupported.");
+            }
+
             var signed = NativeCompatibilityJson.ReadObject(
-                payloadDocument.RootElement, "format", "purpose", "issuedUtc", "expiresUtc", "pack");
-            if (NativeCompatibilityJson.ReadInt32(signed["format"]) != 1 ||
-                NativeCompatibilityJson.ReadString(signed["purpose"]) != "wisp-native-hud-compatibility")
+                payloadRoot, "format", "purpose", "issuedUtc", "expiresUtc", format == 1 ? "pack" : "packs");
+            if (NativeCompatibilityJson.ReadString(signed["purpose"]) != "wisp-native-hud-compatibility")
             {
                 throw Invalid("The signed payload format or purpose is unsupported.");
             }
@@ -202,13 +219,32 @@ public static class NativeCompatibilityEnvelope
                     "Expired compatibility packs cannot be newly installed.");
             }
 
-            var pack = NativeHudCompatibilityPack.Parse(Encoding.UTF8.GetBytes(signed["pack"].GetRawText()));
-            if (pack.StoreIdentity is not null)
+            var packs = new List<NativeHudCompatibilityPack>();
+            if (format == 1)
             {
-                throw Invalid("Store compatibility is currently supplied only by the application release.");
+                packs.Add(NativeHudCompatibilityPack.Parse(Encoding.UTF8.GetBytes(signed["pack"].GetRawText())));
             }
+            else
+            {
+                var elements = signed["packs"];
+                if (elements.ValueKind != JsonValueKind.Array || elements.GetArrayLength() is < 1 or > MaximumPacks)
+                {
+                    throw Invalid("The signed bundle must contain between one and eight compatibility packs.");
+                }
+
+                foreach (var element in elements.EnumerateArray())
+                {
+                    packs.Add(NativeHudCompatibilityPack.Parse(Encoding.UTF8.GetBytes(element.GetRawText())));
+                }
+            }
+
+            if (packs.Select(NativeCompatibilityCatalog.Fingerprint).Distinct(StringComparer.Ordinal).Count() != packs.Count)
+            {
+                throw Invalid("The signed bundle has duplicate game fingerprints.");
+            }
+
             return new NativeVerifiedCompatibilityEnvelope(
-                pack, keyId, Convert.ToHexString(SHA256.HashData(payload)), issuedUtc, expiresUtc);
+                format, packs, keyId, Convert.ToHexString(SHA256.HashData(payload)), issuedUtc, expiresUtc);
         }
         catch (NativeCompatibilityEnvelopeException)
         {
@@ -285,7 +321,7 @@ public sealed class NativeCompatibilityCatalog
     private const string LedgerFileName = "accepted.json";
 
     private readonly object _gate = new();
-    private readonly NativeHudCompatibilityPack _builtIn;
+    private readonly FrozenDictionary<string, NativeHudCompatibilityPack> _builtIns;
     private readonly string? _cacheDirectory;
     private readonly FrozenDictionary<string, byte[]> _trustedPublicKeys;
     private CatalogSnapshot _snapshot;
@@ -295,11 +331,24 @@ public sealed class NativeCompatibilityCatalog
     public NativeCompatibilityCatalog(
         NativeHudCompatibilityPack builtIn,
         string? cacheDirectory,
-        IReadOnlyDictionary<string, byte[]> trustedPublicKeys)
+        IReadOnlyDictionary<string, byte[]> trustedPublicKeys,
+        IEnumerable<NativeHudCompatibilityPack>? additionalBuiltIns = null)
     {
         ArgumentNullException.ThrowIfNull(builtIn);
         ArgumentNullException.ThrowIfNull(trustedPublicKeys);
-        _builtIn = builtIn;
+        var builtIns = new Dictionary<string, NativeHudCompatibilityPack>(StringComparer.Ordinal)
+        {
+            [Fingerprint(builtIn)] = builtIn
+        };
+        foreach (var pack in additionalBuiltIns ?? [])
+        {
+            if (pack is null || builtIns.Count >= MaximumCachedPacks || !builtIns.TryAdd(Fingerprint(pack), pack))
+            {
+                throw new ArgumentException("Bundled compatibility packs must be bounded and have unique game fingerprints.", nameof(additionalBuiltIns));
+            }
+        }
+
+        _builtIns = builtIns.ToFrozenDictionary(StringComparer.Ordinal);
         _cacheDirectory = cacheDirectory is null ? null : Path.GetFullPath(cacheDirectory);
         _trustedPublicKeys = CopyTrustedKeys(trustedPublicKeys);
         _snapshot = LoadCache(DateTimeOffset.UtcNow);
@@ -312,28 +361,42 @@ public sealed class NativeCompatibilityCatalog
     public bool CacheLoadHadErrors => Volatile.Read(ref _snapshot).HasErrors;
     public IReadOnlyList<string> Diagnostics => Volatile.Read(ref _snapshot).Diagnostics;
 
-    public NativeHudCompatibilityPack? Find(string? version, long length, string? sha256)
+    public NativeHudCompatibilityPack? Find(string? version, long length, string? sha256) =>
+        FindFingerprint(Fingerprint(version, length, sha256));
+
+    // Selection is not Store provenance validation; the process-memory factory must still check the OS package and image guards.
+    public NativeHudCompatibilityPack? FindStore(string? packageFullName, uint imageSize) =>
+        FindFingerprint(StoreFingerprint(packageFullName, imageSize));
+
+    private NativeHudCompatibilityPack? FindFingerprint(string fingerprint)
     {
         var snapshot = Volatile.Read(ref _snapshot);
-        var fingerprint = Fingerprint(version, length, sha256);
         if (IsBlocked(snapshot, fingerprint))
         {
             return null;
         }
 
+        _builtIns.TryGetValue(fingerprint, out var builtIn);
         if (snapshot.Packs.TryGetValue(fingerprint, out var pack) &&
-            (!_builtIn.Matches(version, length, sha256) || pack.Revision > _builtIn.Revision))
+            (builtIn is null || pack.Revision > builtIn.Revision))
         {
             return pack;
         }
 
-        return _builtIn.Matches(version, length, sha256) ? _builtIn : null;
+        return builtIn;
     }
 
     public string? GetUnavailableReason(string? version, long length, string? sha256)
     {
         var snapshot = Volatile.Read(ref _snapshot);
         var fingerprint = Fingerprint(version, length, sha256);
+        return IsBlocked(snapshot, fingerprint) ? snapshot.Issues[fingerprint] : null;
+    }
+
+    public string? GetStoreUnavailableReason(string? packageFullName, uint imageSize)
+    {
+        var snapshot = Volatile.Read(ref _snapshot);
+        var fingerprint = StoreFingerprint(packageFullName, imageSize);
         return IsBlocked(snapshot, fingerprint) ? snapshot.Issues[fingerprint] : null;
     }
 
@@ -404,58 +467,89 @@ public sealed class NativeCompatibilityCatalog
     private NativeCompatibilityInstallResult InstallVerified(
         byte[] envelope, NativeVerifiedCompatibilityEnvelope verified, DateTimeOffset acceptedUtc)
     {
-        var pack = verified.Pack;
-        var fingerprint = Fingerprint(pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256);
         var current = _snapshot;
-        if (_builtIn.Matches(pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256) &&
-            pack.Revision <= _builtIn.Revision)
+        var replacements = new List<NativeHudCompatibilityPack>();
+        var newFingerprints = 0;
+        // Preflight the whole bundle before creating files or changing the accepted snapshot.
+        foreach (var pack in verified.Packs)
         {
-            return Failure(
-                pack.Revision < _builtIn.Revision
-                    ? NativeCompatibilityInstallCode.RollbackRejected
-                    : NativeCompatibilityInstallCode.RevisionConflict,
-                "A signed pack must have a newer revision than the trusted built-in pack for the same game fingerprint.");
-        }
-
-        if (current.Records.TryGetValue(fingerprint, out var previous))
-        {
-            if (pack.Revision < previous.Revision)
+            var fingerprint = Fingerprint(pack);
+            if (verified.PayloadFormat == 1 && _builtIns.TryGetValue(fingerprint, out var legacyBuiltIn) && pack.Revision <= legacyBuiltIn.Revision)
             {
-                return Failure(NativeCompatibilityInstallCode.RollbackRejected,
-                    "A lower compatibility revision cannot replace a previously accepted revision.");
+                return Failure(
+                    pack.Revision < legacyBuiltIn.Revision
+                        ? NativeCompatibilityInstallCode.RollbackRejected
+                        : NativeCompatibilityInstallCode.RevisionConflict,
+                    "A signed pack must have a newer revision than the trusted built-in pack for the same game fingerprint.");
             }
 
-            if (pack.Revision == previous.Revision)
+            if (current.Records.TryGetValue(fingerprint, out var previous))
             {
-                if (verified.PayloadSha256 != previous.PayloadSha256)
+                if (pack.Revision < previous.Revision)
                 {
-                    return Failure(NativeCompatibilityInstallCode.RevisionConflict,
-                        "The same compatibility revision cannot carry a different signed payload.");
+                    return Failure(NativeCompatibilityInstallCode.RollbackRejected,
+                        "A lower compatibility revision cannot replace a previously accepted revision.");
                 }
 
-                if (current.Packs.TryGetValue(fingerprint, out var installed) && previous.KeyId == verified.KeyId)
+                if (pack.Revision == previous.Revision)
                 {
-                    Volatile.Write(ref _status, "The signed compatibility pack is already installed.");
-                    return new NativeCompatibilityInstallResult(
-                        true, false, NativeCompatibilityInstallCode.AlreadyInstalled, Status, installed);
+                    if (verified.PayloadSha256 != previous.PayloadSha256)
+                    {
+                        return Failure(NativeCompatibilityInstallCode.RevisionConflict,
+                            "The same compatibility revision cannot carry a different signed payload.");
+                    }
+
+                    if (current.Packs.ContainsKey(fingerprint) && previous.KeyId == verified.KeyId)
+                    {
+                        continue;
+                    }
                 }
             }
+
+            if (_builtIns.TryGetValue(fingerprint, out var builtIn) && pack.Revision <= builtIn.Revision)
+            {
+                // A common bundle may include an older map already superseded by this application release.
+                // Never install it, and never let it bypass the cached rollback/conflict checks above.
+                continue;
+            }
+
+            if (!current.Records.ContainsKey(fingerprint))
+            {
+                newFingerprints++;
+            }
+
+            replacements.Add(pack);
         }
-        else if (current.Records.Count >= MaximumCachedPacks)
+
+        if (current.Records.Count + newFingerprints > MaximumCachedPacks)
         {
             return Failure(NativeCompatibilityInstallCode.CatalogFull,
                 "The compatibility cache has reached its supported pack limit.");
         }
 
-        var record = new CacheRecord(
-            pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256, pack.Revision,
-            Convert.ToHexString(SHA256.HashData(envelope)), verified.PayloadSha256, verified.KeyId, acceptedUtc);
+        if (replacements.Count == 0)
+        {
+            Volatile.Write(ref _status, "The signed compatibility packs are already installed.");
+            var installed = Array.AsReadOnly(verified.Packs.Select(pack => FindFingerprint(Fingerprint(pack))!).ToArray());
+            return new NativeCompatibilityInstallResult(
+                true, false, NativeCompatibilityInstallCode.AlreadyInstalled, Status, installed[0])
+            { Packs = installed };
+        }
+
+        var envelopeSha256 = Convert.ToHexString(SHA256.HashData(envelope));
         var records = current.Records.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
         var packs = current.Packs.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
         var issues = current.Issues.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
-        records[fingerprint] = record;
-        packs[fingerprint] = pack;
-        issues.Remove(fingerprint);
+        foreach (var pack in replacements)
+        {
+            var fingerprint = Fingerprint(pack);
+            records[fingerprint] = new CacheRecord(
+                pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256, pack.Revision,
+                envelopeSha256, verified.PayloadSha256, verified.KeyId, acceptedUtc,
+                pack.StoreIdentity?.PackageFullName, pack.StoreIdentity is null ? 0 : pack.ImageSize);
+            packs[fingerprint] = pack;
+            issues.Remove(fingerprint);
+        }
 
         if (_cacheDirectory is not null)
         {
@@ -463,22 +557,26 @@ public sealed class NativeCompatibilityCatalog
             {
                 // Commit the complete content-addressed envelope first, then atomically switch the sole ledger pointer.
                 // An interrupted write may leave an orphan, never a partial replacement or a selected older revision.
-                WriteAtomically(EnvelopePath(record), envelope);
+                WriteAtomically(EnvelopePath(envelopeSha256), envelope);
                 WriteAtomically(Path.Combine(_cacheDirectory, LedgerFileName), EncodeLedger(records));
             }
             catch (Exception exception) when (IsStorageException(exception))
             {
                 return Failure(NativeCompatibilityInstallCode.CacheWriteFailed,
-                    "The signed pack could not be committed to the cache; the accepted catalog is unchanged.");
+                    "The signed packs could not be committed to the cache; the accepted catalog is unchanged.");
             }
         }
 
         Publish(new CatalogSnapshot(records, packs, issues), incrementGeneration: true);
         var message = _cacheDirectory is null
-            ? "The signed compatibility pack is installed for this session; no persistent cache is configured."
-            : "The signed compatibility pack is verified and installed in the offline cache.";
+            ? "The signed compatibility packs are installed for this session; no persistent cache is configured."
+            : "The signed compatibility packs are verified and installed in the offline cache.";
         Volatile.Write(ref _status, message);
-        return new NativeCompatibilityInstallResult(true, true, NativeCompatibilityInstallCode.Installed, message, pack);
+        var selected = Array.AsReadOnly(verified.Packs.Select(pack => FindFingerprint(Fingerprint(pack))!).ToArray());
+        return new NativeCompatibilityInstallResult(true, true, NativeCompatibilityInstallCode.Installed, message, selected[0])
+        {
+            Packs = selected
+        };
     }
 
     private CatalogSnapshot LoadCache(DateTimeOffset now)
@@ -512,22 +610,23 @@ public sealed class NativeCompatibilityCatalog
             var record = pair.Value;
             try
             {
-                var bytes = ReadBounded(EnvelopePath(record), NativeCompatibilityEnvelope.MaximumEnvelopeBytes);
+                var bytes = ReadBounded(EnvelopePath(record.EnvelopeSha256), NativeCompatibilityEnvelope.MaximumEnvelopeBytes);
                 if (Convert.ToHexString(SHA256.HashData(bytes)) != record.EnvelopeSha256)
                 {
                     throw new FormatException("The cached envelope digest does not match its acceptance receipt.");
                 }
 
                 var verified = NativeCompatibilityEnvelope.Verify(bytes, _trustedPublicKeys, record.AcceptedUtc);
+                var pack = verified.Packs.SingleOrDefault(candidate => Fingerprint(candidate) == pair.Key);
                 if (verified.IssuedUtc - now > NativeCompatibilityEnvelope.ClockSkew ||
-                    verified.Pack.Revision != record.Revision || verified.KeyId != record.KeyId ||
+                    pack is null || pack.Revision != record.Revision || verified.KeyId != record.KeyId ||
                     verified.PayloadSha256 != record.PayloadSha256 ||
-                    !verified.Pack.Matches(record.GameVersion, record.ExecutableLength, record.ExecutableSha256))
+                    pack.GameVersion != record.GameVersion)
                 {
                     throw new FormatException("The cached envelope does not match its acceptance receipt.");
                 }
 
-                packs.Add(pair.Key, verified.Pack);
+                packs.Add(pair.Key, pack);
             }
             catch (NativeCompatibilityEnvelopeException exception) when (
                 exception.Code == NativeCompatibilityInstallCode.UntrustedPublisher)
@@ -549,7 +648,8 @@ public sealed class NativeCompatibilityCatalog
     {
         using var document = NativeCompatibilityJson.Parse(bytes, MaximumLedgerBytes);
         var root = NativeCompatibilityJson.ReadObject(document.RootElement, "format", "entries");
-        if (NativeCompatibilityJson.ReadInt32(root["format"]) != 1 ||
+        var format = NativeCompatibilityJson.ReadInt32(root["format"]);
+        if (format is not (1 or 2) ||
             root["entries"].ValueKind != JsonValueKind.Array || root["entries"].GetArrayLength() > MaximumCachedPacks)
         {
             throw new FormatException("The cache ledger format or size is unsupported.");
@@ -558,8 +658,21 @@ public sealed class NativeCompatibilityCatalog
         var records = new Dictionary<string, CacheRecord>(StringComparer.Ordinal);
         foreach (var element in root["entries"].EnumerateArray())
         {
-            var entry = NativeCompatibilityJson.ReadObject(element, "gameVersion", "executableLength", "executableSha256",
-                "revision", "envelopeSha256", "payloadSha256", "keyId", "acceptedUtc");
+            var kind = format == 1 ? "steam" : element.ValueKind == JsonValueKind.Object && element.TryGetProperty("kind", out var kindElement)
+                ? NativeCompatibilityJson.ReadString(kindElement)
+                : string.Empty;
+            if (kind is not ("steam" or "store"))
+            {
+                throw new FormatException("The cached game identity kind is unsupported.");
+            }
+
+            var names = new List<string> { "gameVersion", "revision", "envelopeSha256", "payloadSha256", "keyId", "acceptedUtc" };
+            if (format == 2)
+            {
+                names.Add("kind");
+            }
+            names.AddRange(kind == "steam" ? ["executableLength", "executableSha256"] : new[] { "packageFullName", "imageSize" });
+            var entry = NativeCompatibilityJson.ReadObject(element, names.ToArray());
             var version = NativeCompatibilityJson.ReadString(entry["gameVersion"]);
             var versionParts = version.Split('.');
             if (version.Length is < 7 or > 23 || versionParts.Length != 4 || versionParts.Any(part =>
@@ -569,11 +682,30 @@ public sealed class NativeCompatibilityCatalog
                 throw new FormatException("The cached game fingerprint is invalid.");
             }
 
-            var lengthElement = entry["executableLength"];
-            if (lengthElement.ValueKind != JsonValueKind.Number || !lengthElement.TryGetInt64(out var length) ||
-                length is < 4096 or > 2L * 1024 * 1024 * 1024)
+            long length = 0;
+            var executableSha256 = string.Empty;
+            string? packageFullName = null;
+            uint imageSize = 0;
+            if (kind == "steam")
             {
-                throw new FormatException("The cached game fingerprint is invalid.");
+                var lengthElement = entry["executableLength"];
+                if (lengthElement.ValueKind != JsonValueKind.Number || !lengthElement.TryGetInt64(out length) ||
+                    length is < 4096 or > 2L * 1024 * 1024 * 1024)
+                {
+                    throw new FormatException("The cached game fingerprint is invalid.");
+                }
+                executableSha256 = NativeCompatibilityJson.ReadHash(entry["executableSha256"]);
+            }
+            else
+            {
+                packageFullName = NativeCompatibilityJson.ReadString(entry["packageFullName"]);
+                var imageSizeElement = entry["imageSize"];
+                if (packageFullName != $"Microsoft.ForteBaseGame_{version}_x64__8wekyb3d8bbwe" ||
+                    imageSizeElement.ValueKind != JsonValueKind.Number || !imageSizeElement.TryGetUInt32(out imageSize) ||
+                    imageSize is < 4096 or > 1024 * 1024 * 1024)
+                {
+                    throw new FormatException("The cached Store fingerprint is invalid.");
+                }
             }
 
             var revision = NativeCompatibilityJson.ReadInt32(entry["revision"]);
@@ -583,11 +715,12 @@ public sealed class NativeCompatibilityCatalog
                 throw new FormatException("The cached acceptance record is invalid.");
             }
 
-            var record = new CacheRecord(version, length, NativeCompatibilityJson.ReadHash(entry["executableSha256"]),
+            var record = new CacheRecord(version, length, executableSha256,
                 revision, NativeCompatibilityJson.ReadHash(entry["envelopeSha256"]),
                 NativeCompatibilityJson.ReadHash(entry["payloadSha256"]), NativeCompatibilityJson.ReadHash(entry["keyId"]),
-                acceptedUtc);
-            if (!records.TryAdd(Fingerprint(record.GameVersion, record.ExecutableLength, record.ExecutableSha256), record))
+                acceptedUtc, packageFullName, imageSize);
+            var fingerprint = packageFullName is null ? Fingerprint(version, length, executableSha256) : StoreFingerprint(packageFullName, imageSize);
+            if (!records.TryAdd(fingerprint, record))
             {
                 throw new FormatException("The cache ledger has duplicate game fingerprints.");
             }
@@ -598,21 +731,43 @@ public sealed class NativeCompatibilityCatalog
 
     private static byte[] EncodeLedger(IReadOnlyDictionary<string, CacheRecord> records)
     {
-        var bytes = JsonSerializer.SerializeToUtf8Bytes(new
+        var format = records.Values.Any(record => record.StorePackageFullName is not null) ? 2 : 1;
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
         {
-            format = 1,
-            entries = records.OrderBy(pair => pair.Key, StringComparer.Ordinal).Select(pair => new
+            writer.WriteStartObject();
+            writer.WriteNumber("format", format);
+            writer.WriteStartArray("entries");
+            foreach (var pair in records.OrderBy(pair => pair.Key, StringComparer.Ordinal))
             {
-                gameVersion = pair.Value.GameVersion,
-                executableLength = pair.Value.ExecutableLength,
-                executableSha256 = pair.Value.ExecutableSha256,
-                revision = pair.Value.Revision,
-                envelopeSha256 = pair.Value.EnvelopeSha256,
-                payloadSha256 = pair.Value.PayloadSha256,
-                keyId = pair.Value.KeyId,
-                acceptedUtc = pair.Value.AcceptedUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)
-            })
-        });
+                var record = pair.Value;
+                writer.WriteStartObject();
+                if (format == 2)
+                {
+                    writer.WriteString("kind", record.StorePackageFullName is null ? "steam" : "store");
+                }
+                writer.WriteString("gameVersion", record.GameVersion);
+                if (record.StorePackageFullName is null)
+                {
+                    writer.WriteNumber("executableLength", record.ExecutableLength);
+                    writer.WriteString("executableSha256", record.ExecutableSha256);
+                }
+                else
+                {
+                    writer.WriteString("packageFullName", record.StorePackageFullName);
+                    writer.WriteNumber("imageSize", record.StoreImageSize);
+                }
+                writer.WriteNumber("revision", record.Revision);
+                writer.WriteString("envelopeSha256", record.EnvelopeSha256);
+                writer.WriteString("payloadSha256", record.PayloadSha256);
+                writer.WriteString("keyId", record.KeyId);
+                writer.WriteString("acceptedUtc", record.AcceptedUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture));
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+        var bytes = stream.ToArray();
         if (bytes.Length > MaximumLedgerBytes)
         {
             throw new IOException("The compatibility acceptance ledger exceeds its size limit.");
@@ -623,8 +778,7 @@ public sealed class NativeCompatibilityCatalog
 
     private bool IsBlocked(CatalogSnapshot snapshot, string fingerprint) =>
         snapshot.Issues.ContainsKey(fingerprint) && snapshot.Records.TryGetValue(fingerprint, out var record) &&
-        (!_builtIn.Matches(record.GameVersion, record.ExecutableLength, record.ExecutableSha256) ||
-         record.Revision > _builtIn.Revision);
+        (!_builtIns.TryGetValue(fingerprint, out var builtIn) || record.Revision > builtIn.Revision);
 
     private static FrozenDictionary<string, byte[]> CopyTrustedKeys(IReadOnlyDictionary<string, byte[]> keys)
     {
@@ -688,13 +842,21 @@ public sealed class NativeCompatibilityCatalog
                 ? "The built-in pack and verified offline compatibility cache are ready."
                 : "The trusted built-in compatibility pack is ready; no signed packs are installed.");
 
-    private string EnvelopePath(CacheRecord record) =>
-        Path.Combine(_cacheDirectory!, record.EnvelopeSha256 + ".pack.json");
+    private string EnvelopePath(string envelopeSha256) =>
+        Path.Combine(_cacheDirectory!, envelopeSha256 + ".pack.json");
+
+    internal static string Fingerprint(NativeHudCompatibilityPack pack) => pack.StoreIdentity is null
+        ? Fingerprint(pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256)
+        : StoreFingerprint(pack.StoreIdentity.PackageFullName, pack.ImageSize);
 
     private static string Fingerprint(string? version, long length, string? sha256) =>
         Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
-            (version?.Trim() ?? string.Empty) + "\n" + length.ToString(CultureInfo.InvariantCulture) + "\n" +
+            "steam\n" + (version?.Trim() ?? string.Empty) + "\n" + length.ToString(CultureInfo.InvariantCulture) + "\n" +
             (sha256?.Trim().ToUpperInvariant() ?? string.Empty))));
+
+    private static string StoreFingerprint(string? packageFullName, uint imageSize) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(
+            "store\n" + (packageFullName ?? string.Empty) + "\n" + imageSize.ToString(CultureInfo.InvariantCulture))));
 
     private static byte[] ReadBounded(string path, int maximumBytes)
     {
@@ -754,7 +916,9 @@ public sealed class NativeCompatibilityCatalog
         string EnvelopeSha256,
         string PayloadSha256,
         string KeyId,
-        DateTimeOffset AcceptedUtc);
+        DateTimeOffset AcceptedUtc,
+        string? StorePackageFullName,
+        uint StoreImageSize);
 
     private sealed class CatalogSnapshot
     {

--- a/src/Wisp.App/NativeCompatibility/NativeCompatibilityRuntime.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeCompatibilityRuntime.cs
@@ -6,15 +6,18 @@ namespace Wisp.App;
 internal static class NativeCompatibilityRuntime
 {
     // Release-owned trust roots, never keys supplied by a downloaded pack or a user-writable cache.
-    // No publisher has been configured yet. The verified embedded map works without network access.
-    internal static Uri? PublisherEndpoint => null;
+    // Embedded maps remain available offline; only this publisher can authorize downloaded maps.
+    internal static Uri? PublisherEndpoint => new("https://wispoverlay.com/compatibility/latest.json");
     private static readonly FrozenDictionary<string, byte[]> PublisherKeys =
-        new Dictionary<string, byte[]>(StringComparer.Ordinal).ToFrozenDictionary();
+        new Dictionary<string, byte[]>(StringComparer.Ordinal)
+        {
+            ["49D5F074A1A837F8E4A8EC5D4D3780443DDB5B045F11075DFC449327D7BAEB20"] = Convert.FromBase64String("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErxpSYYP+zgnYr5Pe4LRvPZykE23Ql6Ga0EIFuWW16j8LwpjuaXg2UGGbaEqZGRbMJG2QNzV9iAAjLEHsMYxMiw==")
+        }.ToFrozenDictionary();
     private static readonly Lazy<NativeCompatibilityCatalog> DefaultCatalog = new(() => new(
         NativeHudBuildContract.BuiltIn,
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Wisp", "NativeCompatibility"),
-        PublisherKeys));
+        PublisherKeys, NativeHudBuildContract.AdditionalBuiltIns));
 
     public static NativeCompatibilityCatalog Catalog => DefaultCatalog.Value;
     public static NativeCompatibilityUpdateClient CreateUpdateClient() => new(PublisherEndpoint, Catalog);

--- a/src/Wisp.App/NativeCompatibility/NativeStorePackageIdentity.cs
+++ b/src/Wisp.App/NativeCompatibility/NativeStorePackageIdentity.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
@@ -7,7 +8,8 @@ namespace Wisp.App;
 // Package provenance is separate from the Store pack's bounded image guards, not a file hash.
 internal readonly record struct NativeStorePackageIdentity(string PackageFullName, string ExecutablePath)
 {
-    internal const string SupportedPackageFullName = "Microsoft.ForteBaseGame_3.430.771.0_x64__8wekyb3d8bbwe";
+    private const string PackagePrefix = "Microsoft.ForteBaseGame_";
+    private const string PackageSuffix = "_x64__8wekyb3d8bbwe";
     internal const int StoreOrigin = 3;
     private const int InsufficientBuffer = 122;
     private const uint MaximumPackageNameCharacters = 512;
@@ -30,7 +32,7 @@ internal readonly record struct NativeStorePackageIdentity(string PackageFullNam
             // No-package and unavailable API results are ordinary nonmatches; Steam still uses its file fingerprint.
             if (!TryReadString((ref uint length, char[]? buffer) => api.GetFullName(handle, ref length, buffer),
                     MaximumPackageNameCharacters, out var name) ||
-                !string.Equals(name, SupportedPackageFullName, StringComparison.Ordinal) ||
+                !IsGamePackageFamily(name) ||
                 api.GetOrigin(name, out var origin) != 0 || origin != StoreOrigin ||
                 !TryReadString((ref uint length, char[]? buffer) => api.GetPath(name, 0, ref length, buffer),
                     MaximumPathCharacters, out var originalPath) ||
@@ -54,7 +56,7 @@ internal readonly record struct NativeStorePackageIdentity(string PackageFullNam
         string? executablePath, out NativeStorePackageIdentity identity)
     {
         identity = default;
-        if (!string.Equals(packageFullName, SupportedPackageFullName, StringComparison.Ordinal) ||
+        if (!IsGamePackageFamily(packageFullName) ||
             origin != StoreOrigin || string.IsNullOrWhiteSpace(originalPackagePath) ||
             string.IsNullOrWhiteSpace(effectivePackagePath) || string.IsNullOrWhiteSpace(executablePath))
         {
@@ -66,20 +68,35 @@ internal readonly record struct NativeStorePackageIdentity(string PackageFullNam
             var original = NativeHudFingerprintCache.NormalizePath(originalPackagePath);
             var effective = NativeHudFingerprintCache.NormalizePath(effectivePackagePath);
             var executable = NativeHudFingerprintCache.NormalizePath(executablePath);
-            // This reviewed build uses the same original/effective directory; do not accept an unverified projection.
+            // A versioned pack does not authorize an unverified installation projection.
             if (original != effective ||
                 executable != NativeHudFingerprintCache.NormalizePath(Path.Combine(effective, "ForzaHorizon6.exe")))
             {
                 return false;
             }
 
-            identity = new NativeStorePackageIdentity(SupportedPackageFullName, executable);
+            identity = new NativeStorePackageIdentity(packageFullName!, executable);
             return true;
         }
         catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
         {
             return false;
         }
+    }
+
+    // Package-family provenance is only the first gate; the factory still requires an exact trusted build map.
+    private static bool IsGamePackageFamily(string? name)
+    {
+        if (name is null || name.Length < PackagePrefix.Length + PackageSuffix.Length + 7 ||
+            name.Length > PackagePrefix.Length + PackageSuffix.Length + 23 ||
+            !name.StartsWith(PackagePrefix, StringComparison.Ordinal) || !name.EndsWith(PackageSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var parts = name[PackagePrefix.Length..^PackageSuffix.Length].Split('.');
+        return parts.Length == 4 && parts.All(part => part.Length is >= 1 and <= 5 &&
+            part.All(char.IsAsciiDigit) && ushort.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out _));
     }
 
     internal static bool MatchesExecutableFileAlias(string expectedPath, string observedPath) =>

--- a/src/Wisp.App/NativeCompatibility/fh6-6.440.853.0.json
+++ b/src/Wisp.App/NativeCompatibility/fh6-6.440.853.0.json
@@ -1,0 +1,209 @@
+{
+  "schemaVersion": 3,
+  "readerVersion": 3,
+  "id": "fh6-steam-6.440.853.0-x64",
+  "revision": 1,
+  "gameVersion": "6.440.853.0",
+  "executableLength": 184055768,
+  "executableSha256": "FEC4A63CDEAD26F6528564F0E33C3D7FD02CD887337ED6E1AEACA79EB2843FCD",
+  "imageSize": 188497920,
+  "sourceVectorRva": 176882448,
+  "thresholdRva": 104738444,
+  "leadVtableRva": 113448576,
+  "expectedThresholdBits": 1036831949,
+  "fields": {
+    "sourceProvider": 30528,
+    "sourceCarOrdinal": 29708,
+    "providerRpm": 432,
+    "providerSimRedlineAngularVelocity": 584,
+    "providerTachometerMaximumAngularVelocity": 588,
+    "localPlayerFlag": 5220,
+    "localPlayerProviderFlag": 49968,
+    "stmState": 5168,
+    "absState": 5172,
+    "stmAvailable": 6068,
+    "tcrAvailable": 6069,
+    "absAvailable": 6070,
+    "lcAvailable": 6071,
+    "lcPrimary": 5356,
+    "lcMode": 8060,
+    "lcSecondary": 49696,
+    "tcrSecondary": 49696,
+    "tcrPrimary": 49700,
+    "tcrTertiary": 49704,
+    "tcrWheelValues": 49864,
+    "firstWheelPointer": 2976,
+    "secondWheelPointer": 2984,
+    "thirdWheelPointer": 2992,
+    "wheelId": 1440
+  },
+  "gameplayVisibility": {
+    "uiServiceRva": 177071928,
+    "uiServiceVtableRva": 113377512,
+    "dependencyVtableRva": 113297664,
+    "transitionManagerVtableRva": 113297552,
+    "hudPageVtableRva": 117906368,
+    "serviceDependencyOffset": 160,
+    "rootTransitionManagerOffset": 56,
+    "managerOwnerOffset": 192,
+    "managerCurrentPageOffset": 144,
+    "managerStateOffset": 104,
+    "pageTransitionManagerOffset": 656,
+    "pageUiVisibleOffset": 964
+  },
+  "nativeGauge": {
+    "registryGlobalRva": 176708104,
+    "registryKeyHash": 14601433220641418792,
+    "registryWrapperVtableRva": 111414448,
+    "registryContextVtableRva": 115300960,
+    "registryContextControlVtableRva": 111417592,
+    "registryContextOffset": 8,
+    "registryContextControlOffset": 16,
+    "registrySentinelOffset": 504,
+    "registryCountOffset": 512,
+    "registryBucketsOffset": 520,
+    "registryBucketsEndOffset": 528,
+    "registryBucketsCapacityOffset": 536,
+    "registryMaskOffset": 544,
+    "registryBucketCountOffset": 552,
+    "registryBucketStride": 16,
+    "registryBucketBoundaryOffset": 0,
+    "registryBucketNodeOffset": 8,
+    "registryNodeNextOffset": 8,
+    "registryNodeHashOffset": 16,
+    "registryNodeObjectOffset": 24,
+    "registryNodeControlOffset": 32,
+    "sharedControlObjectOffset": 16,
+    "hudVtableRva": 115336920,
+    "hudControlVtableRva": 110203968,
+    "hudSubobjectOffset": 48,
+    "hudSubobjectPointerOffset": 304,
+    "hudSubobjectVtableRva": 115337000,
+    "hudSubobjectSlotZeroTargetRva": 11447088,
+    "hudSubobjectSlotZeroPrologueHex": "488D4170C3",
+    "hudTypeVectorOffset": 112,
+    "hudTypeVectorMaximumCount": 64,
+    "hudTypeVectorBeginOffset": 0,
+    "hudTypeVectorEndOffset": 8,
+    "hudTypeVectorCapacityOffset": 16,
+    "hudTypeVectorEntryStride": 32,
+    "hudTypeTokenRva": 179289192,
+    "hudTypeTokenOffset": 0,
+    "hudTypeInstancesBeginOffset": 8,
+    "hudTypeInstancesEndOffset": 16,
+    "hudTypeInstancesCapacityOffset": 24,
+    "hudTypeInstanceCount": 1,
+    "hudTypeInstanceStride": 16,
+    "hudTypeInstanceObjectOffset": 0,
+    "hudTypeInstanceControlOffset": 8,
+    "outerControlVtableRva": 115319176,
+    "outerPrimaryVtableRva": 117118472,
+    "outerSecondaryVtableRva": 117118760,
+    "outerSecondaryOffset": 8,
+    "outerHudBackReferenceOffset": 16,
+    "outerHudControlBackReferenceOffset": 24,
+    "outerChildOffset": 56,
+    "outerSourceOffset": 64,
+    "outerPowerFillOffset": 112,
+    "outerRegenFillOffset": 136,
+    "childlessRegenPowerRatioBits": 1050253722,
+    "childVtableRva": 114222456,
+    "childModeOffset": 228,
+    "childAngleOffset": 244,
+    "childBlurOffset": 248,
+    "childSpeedDigitOneOffset": 252,
+    "childSpeedDigitTenOffset": 256,
+    "childSpeedDigitHundredOffset": 260,
+    "childSpeedLessOrEqualOneOffset": 264,
+    "childSpeedLessTenOffset": 265,
+    "childSpeedLessHundredOffset": 266,
+    "childHeadlightsOnOffset": 268,
+    "childGearOffset": 272,
+    "childGearPreviousOffset": 276,
+    "childGearNextOffset": 280,
+    "childRegenOffset": 304,
+    "childPowerOffset": 308,
+    "childGearGaugeStateOffset": 312,
+    "childUseDriveFor1Offset": 316,
+    "childRatioOffset": 320,
+    "childSpeedUnitObjectOffset": 360,
+    "childMaximumTachometerOffset": 368,
+    "childElectricMaximumSpeedOffset": 392,
+    "speedUnitEnumOffset": 4,
+    "speedUnitMphValue": 22,
+    "speedUnitKphValue": 23,
+    "providerPowerLimitFirstOffset": 9136,
+    "providerPowerLimitSecondOffset": 9148,
+    "providerPowerNumeratorOffset": 504,
+    "providerPowerDenominatorOffset": 2696,
+    "providerRegenTargetOffset": 5160,
+    "providerPowerDenominatorScaleBits": 1008981770,
+    "providerRegenScaleBits": 3214934016,
+    "providerRegenUpperBaseBits": 1048576000,
+    "providerElectricSpeedOffset": 5356,
+    "requiredProviderVtableSlots": [
+      {
+        "offset": 664,
+        "targetRva": 52076768
+      },
+      {
+        "offset": 856,
+        "targetRva": 52087632
+      },
+      {
+        "offset": 1464,
+        "targetRva": 52102592
+      },
+      {
+        "offset": 1824,
+        "targetRva": 52087136
+      },
+      {
+        "offset": 1944,
+        "targetRva": 52096832
+      },
+      {
+        "offset": 3624,
+        "targetRva": 52102352
+      }
+    ]
+  },
+  "requiredVtableSlots": [
+    {
+      "offset": 528,
+      "targetRva": 52087680
+    },
+    {
+      "offset": 680,
+      "targetRva": 52106368
+    },
+    {
+      "offset": 688,
+      "targetRva": 52102672
+    },
+    {
+      "offset": 696,
+      "targetRva": 52075840
+    },
+    {
+      "offset": 1664,
+      "targetRva": 52087664
+    },
+    {
+      "offset": 4184,
+      "targetRva": 52104848
+    },
+    {
+      "offset": 4192,
+      "targetRva": 52073920
+    },
+    {
+      "offset": 4200,
+      "targetRva": 52089728
+    },
+    {
+      "offset": 4216,
+      "targetRva": 52089872
+    }
+  ]
+}

--- a/src/Wisp.App/NativeHudBuildContract.cs
+++ b/src/Wisp.App/NativeHudBuildContract.cs
@@ -7,7 +7,10 @@ public static class NativeHudBuildContract
     // Embedded packs are trusted with the application. External packs must pass
     // the signed catalog before the process reader can select them.
     public static NativeHudCompatibilityPack BuiltIn { get; } = LoadBuiltIn();
+    internal static NativeHudCompatibilityPack PreviousSteamBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.PreviousSteam.json");
     internal static NativeHudCompatibilityPack StoreBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.Store.json");
+    internal static IReadOnlyList<NativeHudCompatibilityPack> AdditionalBuiltIns { get; } =
+        Array.AsReadOnly(new[] { PreviousSteamBuiltIn, StoreBuiltIn });
 
     public static string SupportedVersion => BuiltIn.GameVersion;
     public static long SupportedExecutableLength => BuiltIn.ExecutableLength;

--- a/src/Wisp.App/NativeHudProcessMemory.cs
+++ b/src/Wisp.App/NativeHudProcessMemory.cs
@@ -211,8 +211,7 @@ public sealed class NativeHudProcessMemoryFactory : INativeHudProcessMemoryFacto
         ref NativeAssistProviderStatus status)
     {
         memory = null;
-        var pack = NativeHudBuildContract.StoreBuiltIn;
-        if (identity.ImageSize != pack.ImageSize || pack.StoreIdentity is not { } storeBuild)
+        if (!NativeHudProcessMemory.IsValidModuleRange(identity.ModuleBase, identity.ImageSize))
         {
             return false;
         }
@@ -220,9 +219,17 @@ public sealed class NativeHudProcessMemoryFactory : INativeHudProcessMemoryFacto
         SafeProcessHandle? handle = NativeHudProcessMemory.OpenReadOnly(identity.ProcessId);
         try
         {
-            if (handle.IsInvalid || !NativeStorePackageIdentity.TryRead(handle, identity.ExecutablePath, out var package) ||
-                package.PackageFullName != storeBuild.PackageFullName)
+            if (handle.IsInvalid || !NativeStorePackageIdentity.TryRead(handle, identity.ExecutablePath, out var package))
             {
+                return false;
+            }
+
+            var pack = _catalog.FindStore(package.PackageFullName, identity.ImageSize);
+            if (pack?.StoreIdentity is not { } storeBuild)
+            {
+                status = NativeAssistProviderStatus.UnsupportedBuild;
+                SetStatus(_catalog.GetStoreUnavailableReason(package.PackageFullName, identity.ImageSize)
+                    ?? "No trusted exact compatibility pack for this Xbox/Store FH6 build");
                 return false;
             }
 
@@ -230,14 +237,15 @@ public sealed class NativeHudProcessMemoryFactory : INativeHudProcessMemoryFacto
             if (!storeBuild.MatchesImage(candidate, identity.ModuleBase))
             {
                 status = NativeAssistProviderStatus.UnsupportedBuild;
-                SetStatus("The Xbox/Store FH6 image does not match the bundled reader guards");
+                SetStatus("The Xbox/Store FH6 image does not match the verified compatibility pack reader guards");
                 return false;
             }
 
             process.Refresh();
             if (CaptureIdentity(process) != identity || !NativeHudProcessMemory.HandleMatchesIdentity(handle, identity, allowStoreFileAlias: true) ||
                 !NativeStorePackageIdentity.TryRead(handle, identity.ExecutablePath, out var currentPackage) ||
-                currentPackage != package || !storeBuild.MatchesImage(candidate, identity.ModuleBase))
+                currentPackage != package || !storeBuild.MatchesImage(candidate, identity.ModuleBase) ||
+                !ReferenceEquals(pack, _catalog.FindStore(package.PackageFullName, identity.ImageSize)))
             {
                 status = NativeAssistProviderStatus.ReadFailure;
                 SetStatus("The Xbox/Store FH6 identity changed during attachment");

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,23 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.1.2",
+            "September 7, 2026",
+            "COMPATIBILITY HOTFIX",
+            "Support for Steam FH6 6.440.853.0 and signed compatibility updates for future reviewed builds.",
+            true,
+            [
+                Group("Compatibility",
+                    "Adds a separate Native HUD map for Steam FH6 build 6.440.853.0, retaining Steam 6.430.771.0 and Xbox app / Microsoft Store 3.430.771.0 support.",
+                    "Enables background checks and manual import of signed compatibility maps. Verified maps can be delivered without reinstalling Wisp and remain available offline.",
+                    "Retains exact build identity, read-only access, and menu visibility checks. Native layouts that change beyond the supported reader still require an application update.")
+            ]),
+        new(
             "1.1.1",
             "September 6, 2026",
             "COMPATIBILITY HOTFIX",
             "Xbox app and Microsoft Store editions of Forza Horizon 6 on Windows are now supported.",
-            true,
+            false,
             [
                 Group("Compatibility",
                     "Adds a separate Native HUD compatibility path for Xbox app and Microsoft Store FH6 build 3.430.771.0. Other Store builds remain unsupported.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.1.1</Version>
-    <FileVersion>1.1.1.0</FileVersion>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <Version>1.1.2</Version>
+    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />
@@ -23,7 +23,8 @@
   <ItemGroup>
     <Resource Include="Assets\Wisp-logo.png" />
     <Resource Include="Assets\Native\**\*.png" />
-    <EmbeddedResource Include="NativeCompatibility\fh6-6.430.771.0.json" LogicalName="Wisp.NativeCompatibility.BuiltIn.json" />
+    <EmbeddedResource Include="NativeCompatibility\fh6-6.440.853.0.json" LogicalName="Wisp.NativeCompatibility.BuiltIn.json" />
+    <EmbeddedResource Include="NativeCompatibility\fh6-6.430.771.0.json" LogicalName="Wisp.NativeCompatibility.PreviousSteam.json" />
     <EmbeddedResource Include="NativeCompatibility\fh6-store-3.430.771.0.json" LogicalName="Wisp.NativeCompatibility.Store.json" />
     <Resource Include="Shaders\*.ps" />
     <None Include="Shaders\*.hlsl" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.1.1.0" name="Wisp.App" />
+  <assemblyIdentity version="1.1.2.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.1.1</Version>
-    <FileVersion>1.1.1.0</FileVersion>
-    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <Version>1.1.2</Version>
+    <FileVersion>1.1.2.0</FileVersion>
+    <AssemblyVersion>1.1.2.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -21,9 +21,9 @@ public sealed class ApplicationVersionInfoTests
     [Fact]
     public void CurrentVersionLabelsShareTheAssemblyVersion()
     {
-        Assert.Equal("1.1.1", ApplicationVersionInfo.DisplayVersion);
-        Assert.EndsWith(" 1.1.1", ApplicationVersionInfo.FooterText);
-        Assert.Contains("current 1.1.1 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.Equal("1.1.2", ApplicationVersionInfo.DisplayVersion);
+        Assert.EndsWith(" 1.1.2", ApplicationVersionInfo.FooterText);
+        Assert.Contains("current 1.1.2 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
         Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
     }
 }

--- a/tests/Wisp.App.Tests/NativeCompatibilityCatalogTests.cs
+++ b/tests/Wisp.App.Tests/NativeCompatibilityCatalogTests.cs
@@ -91,7 +91,8 @@ public sealed class NativeCompatibilityCatalogTests
 
         Assert.Equal(NativeCompatibilityInstallCode.UntrustedPublisher, result.Code);
         Assert.Equal(0, catalog.Generation);
-        Assert.Null(NativeCompatibilityRuntime.PublisherEndpoint);
+        Assert.Equal(new Uri("https://wispoverlay.com/compatibility/latest.json"), NativeCompatibilityRuntime.PublisherEndpoint);
+        Assert.True(NativeCompatibilityRuntime.Catalog.HasTrustedPublishers);
     }
 
     [Fact]
@@ -481,15 +482,16 @@ public sealed class NativeCompatibilityCatalogTests
     public void ImportedPackMustSupersedeBuiltInRevisionForTheSameFingerprint()
     {
         using var fixture = new Fixture();
-        var catalog = fixture.Catalog();
+        var builtIn = NativeHudCompatibilityPack.Parse(Bytes(fixture.Pack(3, sameAsBuiltIn: true)));
+        var catalog = new NativeCompatibilityCatalog(builtIn, null, fixture.Keys);
 
         Assert.Equal(NativeCompatibilityInstallCode.RevisionConflict,
             catalog.Install(fixture.Envelope(fixture.Pack(
-                NativeHudBuildContract.BuiltIn.Revision, sameAsBuiltIn: true)), fixture.Now).Code);
+                builtIn.Revision, sameAsBuiltIn: true)), fixture.Now).Code);
         Assert.Equal(NativeCompatibilityInstallCode.RollbackRejected,
             catalog.Install(fixture.Envelope(fixture.Pack(
-                NativeHudBuildContract.BuiltIn.Revision - 1, sameAsBuiltIn: true)), fixture.Now).Code);
-        Assert.Same(NativeHudBuildContract.BuiltIn, Find(catalog, NativeHudBuildContract.BuiltIn));
+                builtIn.Revision - 1, sameAsBuiltIn: true)), fixture.Now).Code);
+        Assert.Same(builtIn, Find(catalog, builtIn));
         Assert.Equal(0, catalog.Generation);
     }
 
@@ -786,8 +788,311 @@ public sealed class NativeCompatibilityCatalogTests
         Assert.Same(NativeHudBuildContract.BuiltIn, Find(catalog, NativeHudBuildContract.BuiltIn));
     }
 
+    [Fact]
+    public void BundleInstallsBothStoresInOneGenerationAndReloadsOffline()
+    {
+        using var fixture = new Fixture();
+        var bytes = fixture.Bundle(fixture.Pack(), fixture.StorePack());
+        var verified = NativeCompatibilityEnvelope.Verify(bytes, fixture.Keys, fixture.Now);
+        Assert.Equal(2, verified.Packs.Count);
+        Assert.Same(verified.Packs[0], verified.Pack);
+        Assert.Throws<NotSupportedException>(() => ((IList<NativeHudCompatibilityPack>)verified.Packs).Clear());
+        var catalog = fixture.Catalog(persistent: true);
+
+        var result = catalog.Install(bytes, fixture.Now);
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.Packs.Count);
+        Assert.Same(result.Packs[0], result.Pack);
+        Assert.Equal(1, catalog.Generation);
+        Assert.All(result.Packs, pack => Assert.Same(pack, Find(catalog, pack)));
+        Assert.Equal(NativeCompatibilityInstallCode.AlreadyInstalled, catalog.Install(bytes, fixture.Now).Code);
+        Assert.Equal(1, catalog.Generation);
+        var reloaded = fixture.Catalog(persistent: true);
+        Assert.False(reloaded.CacheLoadHadErrors);
+        Assert.All(result.Packs, pack => Assert.Equal(pack.Revision, Find(reloaded, pack)!.Revision));
+        Assert.Single(Directory.EnumerateFiles(fixture.CacheDirectory, "*.pack.json"));
+        Assert.Equal(2, JsonNode.Parse(File.ReadAllBytes(fixture.LedgerPath))!["format"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void LegacyStoreEnvelopeRequiresPinnedSignatureAndUsesSeparateExactIdentity()
+    {
+        using var fixture = new Fixture();
+        var store = NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack()));
+        var bytes = fixture.Envelope(fixture.StorePack());
+        var catalog = fixture.Catalog(persistent: true);
+        Assert.True(catalog.Install(bytes, fixture.Now).Success);
+        Assert.NotNull(Find(fixture.Catalog(persistent: true), store));
+        Assert.Null(catalog.Find(store.GameVersion, 0, string.Empty));
+        Assert.Null(catalog.FindStore(store.StoreIdentity!.PackageFullName, store.ImageSize + 1));
+        Assert.Null(catalog.FindStore(store.StoreIdentity.PackageFullName.ToLowerInvariant(), store.ImageSize));
+        Assert.Null(catalog.FindStore(" " + store.StoreIdentity.PackageFullName, store.ImageSize));
+        Assert.Null(catalog.FindStore(null, 0));
+        var untrusted = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null, new Dictionary<string, byte[]>());
+        Assert.Equal(NativeCompatibilityInstallCode.UntrustedPublisher, untrusted.Install(bytes, fixture.Now).Code);
+        Assert.Null(Find(untrusted, store));
+    }
+
+    [Theory]
+    [InlineData("empty")]
+    [InlineData("too-many")]
+    [InlineData("duplicate")]
+    [InlineData("duplicate-revision")]
+    [InlineData("malformed-member")]
+    [InlineData("unknown-field")]
+    [InlineData("single-pack-field")]
+    public void InvalidBundleCannotInstallEvenItsValidFirstMember(string mutation)
+    {
+        using var fixture = new Fixture();
+        var payload = fixture.BundlePayload(fixture.Pack(), fixture.StorePack());
+        var members = payload["packs"]!.AsArray();
+        switch (mutation)
+        {
+            case "empty": members.Clear(); break;
+            case "too-many":
+                while (members.Count <= NativeCompatibilityEnvelope.MaximumPacks) members.Add(fixture.Pack());
+                break;
+            case "duplicate": members.Add(members[0]!.DeepClone()); break;
+            case "duplicate-revision": members.Add(fixture.Pack(9)); break;
+            case "malformed-member": members[1]!["imageSize"] = 0; break;
+            case "unknown-field": payload["extra"] = true; break;
+            case "single-pack-field": payload["pack"] = fixture.Pack(); break;
+        }
+        var catalog = fixture.Catalog(persistent: true);
+        var result = catalog.Install(fixture.SignRaw(Bytes(payload)), fixture.Now);
+        Assert.Equal(NativeCompatibilityInstallCode.InvalidEnvelope, result.Code);
+        Assert.Equal(0, catalog.Generation);
+        Assert.Null(Find(catalog, fixture.ParsePack()));
+        Assert.False(File.Exists(fixture.LedgerPath));
+        Assert.Empty(Directory.EnumerateFiles(fixture.CacheDirectory, "*.pack.json"));
+    }
+
+    [Fact]
+    public void ChangingOnlySecondBundleMemberWithoutResigningRejectsEverything()
+    {
+        using var fixture = new Fixture();
+        var outer = JsonNode.Parse(fixture.Bundle(fixture.Pack(), fixture.StorePack()))!.AsObject();
+        var payload = JsonNode.Parse(Convert.FromBase64String(outer["payload"]!.GetValue<string>()))!;
+        payload["packs"]![1]!["revision"] = 99;
+        outer["payload"] = Convert.ToBase64String(Bytes(payload));
+        var catalog = fixture.Catalog();
+        Assert.Equal(NativeCompatibilityInstallCode.InvalidSignature, catalog.Install(Bytes(outer), fixture.Now).Code);
+        Assert.Null(Find(catalog, fixture.ParsePack()));
+        Assert.Equal(0, catalog.Generation);
+    }
+
+    [Theory]
+    [InlineData(1, NativeCompatibilityInstallCode.RollbackRejected)]
+    [InlineData(2, NativeCompatibilityInstallCode.RevisionConflict)]
+    public void OneBundleMemberBelowItsFloorRejectsTheWholeTransaction(int storeRevision, NativeCompatibilityInstallCode expected)
+    {
+        using var fixture = new Fixture();
+        var catalog = fixture.Catalog(persistent: true);
+        Assert.True(catalog.Install(fixture.Bundle(fixture.Pack(2), fixture.StorePack(2)), fixture.Now).Success);
+        var ledger = File.ReadAllBytes(fixture.LedgerPath);
+        var result = catalog.Install(fixture.Bundle(fixture.Pack(3), fixture.StorePack(storeRevision)), fixture.Now);
+        Assert.Equal(expected, result.Code);
+        Assert.Equal(1, catalog.Generation);
+        Assert.Equal(ledger, File.ReadAllBytes(fixture.LedgerPath));
+        Assert.Equal(2, Find(catalog, fixture.ParsePack())!.Revision);
+        Assert.Single(Directory.EnumerateFiles(fixture.CacheDirectory, "*.pack.json"));
+    }
+
+    [Fact]
+    public void FailedBundleLedgerReplacementKeepsBothPriorMembersAndReceipts()
+    {
+        using var fixture = new Fixture();
+        var catalog = fixture.Catalog(persistent: true);
+        Assert.True(catalog.Install(fixture.Bundle(fixture.Pack(2), fixture.StorePack(2)), fixture.Now).Success);
+        var ledger = File.ReadAllBytes(fixture.LedgerPath);
+        using (var held = new FileStream(fixture.LedgerPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            var result = catalog.Install(fixture.Bundle(fixture.Pack(3), fixture.StorePack(3)), fixture.Now);
+            Assert.Equal(NativeCompatibilityInstallCode.CacheWriteFailed, result.Code);
+        }
+        Assert.Equal(ledger, File.ReadAllBytes(fixture.LedgerPath));
+        Assert.Equal(1, catalog.Generation);
+        foreach (var current in new[] { catalog, fixture.Catalog(persistent: true) })
+        {
+            Assert.Equal(2, Find(current, fixture.ParsePack())!.Revision);
+            Assert.Equal(2, Find(current, NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack())))!.Revision);
+        }
+    }
+
+    [Fact]
+    public void MixedLedgerUpgradeRetainsLegacyReceiptAndExpiredBundleRemainsUsableOffline()
+    {
+        using var fixture = new Fixture();
+        var accepted = fixture.Now.AddDays(-3);
+        var catalog = fixture.Catalog(persistent: true);
+        Assert.True(catalog.Install(fixture.Envelope(issued: accepted.AddHours(-1), expires: accepted.AddHours(1)), accepted).Success);
+        Assert.Equal(1, JsonNode.Parse(File.ReadAllBytes(fixture.LedgerPath))!["format"]!.GetValue<int>());
+        var payload = fixture.BundlePayload(fixture.StorePack());
+        payload["issuedUtc"] = Utc(accepted.AddHours(-1));
+        payload["expiresUtc"] = Utc(accepted.AddHours(1));
+        var bytes = fixture.SignRaw(Bytes(payload));
+        Assert.True(catalog.Install(bytes, accepted).Success);
+        var reloaded = fixture.Catalog(persistent: true);
+        Assert.False(reloaded.CacheLoadHadErrors);
+        Assert.NotNull(Find(reloaded, fixture.ParsePack()));
+        Assert.NotNull(Find(reloaded, NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack()))));
+        Assert.Equal(NativeCompatibilityInstallCode.Expired, reloaded.Install(bytes, fixture.Now).Code);
+    }
+
+    [Theory]
+    [InlineData("package")]
+    [InlineData("version")]
+    [InlineData("size")]
+    [InlineData("kind")]
+    [InlineData("steam-fields")]
+    [InlineData("missing-kind")]
+    [InlineData("duplicate")]
+    public void StoreReceiptIdentityIsStrictAndMustMatchResignedContent(string mutation)
+    {
+        using var fixture = new Fixture();
+        var store = NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack()));
+        Assert.True(fixture.Catalog(persistent: true).Install(fixture.Envelope(fixture.StorePack()), fixture.Now).Success);
+        var ledger = JsonNode.Parse(File.ReadAllBytes(fixture.LedgerPath))!.AsObject();
+        var entry = ledger["entries"]![0]!.AsObject();
+        switch (mutation)
+        {
+            case "package": entry["packageFullName"] = "Untrusted.ForteBaseGame_3.430.772.0_x64__8wekyb3d8bbwe"; break;
+            case "version": entry["gameVersion"] = "3.430.773.0"; entry["packageFullName"] = "Microsoft.ForteBaseGame_3.430.773.0_x64__8wekyb3d8bbwe"; break;
+            case "size": entry["imageSize"] = store.ImageSize + 4096; break;
+            case "kind": entry["kind"] = "steam"; break;
+            case "steam-fields": entry["executableSha256"] = new string('0', 64); break;
+            case "missing-kind": entry.Remove("kind"); break;
+            case "duplicate": ledger["entries"]!.AsArray().Add(entry.DeepClone()); break;
+        }
+        File.WriteAllBytes(fixture.LedgerPath, Bytes(ledger));
+        var reloaded = fixture.Catalog(persistent: true);
+        Assert.True(reloaded.CacheLoadHadErrors);
+        Assert.Null(Find(reloaded, store));
+        Assert.Null(reloaded.FindStore(entry["packageFullName"]!.GetValue<string>(), entry["imageSize"]!.GetValue<uint>()));
+        Assert.Same(NativeHudBuildContract.BuiltIn, Find(reloaded, NativeHudBuildContract.BuiltIn));
+    }
+
+    [Fact]
+    public void CorruptOrRevokedBundleBlocksBothHigherRevisionsIncludingStoreBuiltIn()
+    {
+        using var fixture = new Fixture();
+        var store = NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack(1)));
+        var bytes = fixture.Bundle(fixture.Pack(fixture.NextRevision, sameAsBuiltIn: true), fixture.StorePack(2));
+        var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, fixture.CacheDirectory, fixture.Keys, [store]);
+        Assert.True(catalog.Install(bytes, fixture.Now).Success);
+        var revoked = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, fixture.CacheDirectory, new Dictionary<string, byte[]>(), [store]);
+        Assert.Null(Find(revoked, store));
+        Assert.Null(Find(revoked, NativeHudBuildContract.BuiltIn));
+        File.WriteAllText(fixture.EnvelopePath(bytes), "{}");
+        var corrupt = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, fixture.CacheDirectory, fixture.Keys, [store]);
+        Assert.Null(Find(corrupt, store));
+        Assert.NotNull(corrupt.GetStoreUnavailableReason(store.StoreIdentity!.PackageFullName, store.ImageSize));
+        Assert.Null(Find(corrupt, NativeHudBuildContract.BuiltIn));
+        Assert.Equal(2, corrupt.Diagnostics.Count);
+    }
+
+    [Fact]
+    public void AdditionalBuiltInsAreCopiedBoundedExactAndHaveIndependentRevisionFloors()
+    {
+        using var fixture = new Fixture();
+        var olderSteam = fixture.ParsePack();
+        var store = NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack(2)));
+        var source = new List<NativeHudCompatibilityPack> { olderSteam, store };
+        var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null, fixture.Keys, source);
+        source.Clear();
+        Assert.Same(NativeHudBuildContract.BuiltIn, Find(catalog, NativeHudBuildContract.BuiltIn));
+        Assert.Same(olderSteam, Find(catalog, olderSteam));
+        Assert.Same(store, Find(catalog, store));
+        Assert.Null(catalog.Find(store.GameVersion, 0, string.Empty));
+        Assert.Null(catalog.FindStore(olderSteam.GameVersion, olderSteam.ImageSize));
+        Assert.Equal(NativeCompatibilityInstallCode.RevisionConflict, catalog.Install(fixture.Envelope(fixture.StorePack(2)), fixture.Now).Code);
+        Assert.Equal(NativeCompatibilityInstallCode.RollbackRejected, catalog.Install(fixture.Envelope(fixture.Pack(1)), fixture.Now).Code);
+        Assert.Throws<ArgumentException>(() => new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null, fixture.Keys, [olderSteam, olderSteam]));
+        Assert.Throws<ArgumentException>(() => new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null, fixture.Keys, [NativeHudBuildContract.BuiltIn]));
+    }
+
+    [Fact]
+    public void BundleKeepsNewerEmbeddedMemberWhileInstallingAnotherBuild()
+    {
+        using var fixture = new Fixture();
+        var newer = NativeHudCompatibilityPack.Parse(Bytes(fixture.Pack(5)));
+        var catalog = new NativeCompatibilityCatalog(newer, fixture.CacheDirectory, fixture.Keys);
+        var result = catalog.Install(fixture.Bundle(fixture.Pack(2), fixture.StorePack()), fixture.Now);
+        Assert.True(result.Success);
+        Assert.True(result.Changed);
+        Assert.Same(newer, result.Pack);
+        Assert.Same(newer, result.Packs[0]);
+        Assert.Same(newer, Find(catalog, newer));
+        Assert.NotNull(Find(catalog, result.Packs[1]));
+        Assert.Single(JsonNode.Parse(File.ReadAllBytes(fixture.LedgerPath))!["entries"]!.AsArray());
+        Assert.Equal(NativeCompatibilityInstallCode.RollbackRejected, catalog.Install(fixture.Envelope(fixture.Pack(2)), fixture.Now).Code);
+    }
+
+    [Fact]
+    public void BundleEntirelyCoveredByEmbeddedMapsIsNoOpWithoutReceipts()
+    {
+        using var fixture = new Fixture();
+        var newer = NativeHudCompatibilityPack.Parse(Bytes(fixture.Pack(5)));
+        var store = NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack(2)));
+        var catalog = new NativeCompatibilityCatalog(newer, fixture.CacheDirectory, fixture.Keys, [store]);
+        var result = catalog.Install(fixture.Bundle(fixture.Pack(2), fixture.StorePack(2)), fixture.Now);
+        Assert.Equal(NativeCompatibilityInstallCode.AlreadyInstalled, result.Code);
+        Assert.False(result.Changed);
+        Assert.Equal(0, catalog.Generation);
+        Assert.Same(newer, result.Packs[0]);
+        Assert.Same(store, result.Packs[1]);
+        Assert.False(File.Exists(fixture.LedgerPath));
+        Assert.Empty(Directory.EnumerateFiles(fixture.CacheDirectory, "*.pack.json"));
+    }
+
+    [Fact]
+    public void NewerEmbeddedMapCannotLetBundleBypassAcceptedRevisionFloor()
+    {
+        using var fixture = new Fixture();
+        Assert.True(fixture.Catalog(persistent: true).Install(fixture.Envelope(fixture.Pack(3)), fixture.Now).Success);
+        var newer = NativeHudCompatibilityPack.Parse(Bytes(fixture.Pack(5)));
+        var catalog = new NativeCompatibilityCatalog(newer, fixture.CacheDirectory, fixture.Keys);
+        var ledger = File.ReadAllBytes(fixture.LedgerPath);
+        Assert.Equal(NativeCompatibilityInstallCode.RollbackRejected,
+            catalog.Install(fixture.Bundle(fixture.StorePack(), fixture.Pack(2)), fixture.Now).Code);
+        Assert.Equal(ledger, File.ReadAllBytes(fixture.LedgerPath));
+        Assert.Null(Find(catalog, NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack()))));
+        Assert.Same(newer, Find(catalog, newer));
+    }
+
+    [Fact]
+    public void EightMemberBundleIsAcceptedButCapacityFailureNeverPartiallyInstalls()
+    {
+        using var fixture = new Fixture();
+        var catalog = fixture.Catalog();
+        for (var offset = 0; offset < NativeCompatibilityCatalog.MaximumCachedPacks - 8; offset += 8)
+        {
+            var members = Enumerable.Range(offset, 8).Select(index =>
+            {
+                var pack = fixture.Pack(1);
+                pack["executableSha256"] = index.ToString("X64", CultureInfo.InvariantCulture);
+                return pack;
+            }).ToArray();
+            Assert.True(catalog.Install(fixture.Bundle(members), fixture.Now).Success);
+        }
+        for (var index = 120; index < 127; index++)
+        {
+            var pack = fixture.Pack(1);
+            pack["executableSha256"] = index.ToString("X64", CultureInfo.InvariantCulture);
+            Assert.True(catalog.Install(fixture.Envelope(pack), fixture.Now).Success);
+        }
+        var generation = catalog.Generation;
+        Assert.Equal(NativeCompatibilityInstallCode.CatalogFull,
+            catalog.Install(fixture.Bundle(fixture.Pack(), fixture.StorePack()), fixture.Now).Code);
+        Assert.Equal(generation, catalog.Generation);
+        Assert.Null(Find(catalog, fixture.ParsePack()));
+        Assert.Null(Find(catalog, NativeHudCompatibilityPack.Parse(Bytes(fixture.StorePack()))));
+    }
+
     private static NativeHudCompatibilityPack? Find(NativeCompatibilityCatalog catalog, NativeHudCompatibilityPack pack) =>
-        catalog.Find(pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256);
+        pack.StoreIdentity is null ? catalog.Find(pack.GameVersion, pack.ExecutableLength, pack.ExecutableSha256)
+            : catalog.FindStore(pack.StoreIdentity.PackageFullName, pack.ImageSize);
 
     private static byte[] Bytes(JsonNode value) => JsonSerializer.SerializeToUtf8Bytes(value);
     private static string Utc(DateTimeOffset value) => value.UtcDateTime.ToString("O", CultureInfo.InvariantCulture);
@@ -835,6 +1140,27 @@ public sealed class NativeCompatibilityCatalogTests
         }
 
         public NativeHudCompatibilityPack ParsePack() => NativeHudCompatibilityPack.Parse(Bytes(Pack()));
+
+        public JsonObject StorePack(int revision = 2)
+        {
+            using var stream = typeof(NativeHudBuildContract).Assembly.GetManifestResourceStream("Wisp.NativeCompatibility.Store.json")!;
+            var pack = JsonNode.Parse(stream)!.AsObject();
+            pack["gameVersion"] = "3.430.772.0";
+            pack["revision"] = revision;
+            pack["storeIdentity"]!["packageFullName"] = "Microsoft.ForteBaseGame_3.430.772.0_x64__8wekyb3d8bbwe";
+            return pack;
+        }
+
+        public JsonObject BundlePayload(params JsonObject[] packs) => new()
+        {
+            ["format"] = 2,
+            ["purpose"] = "wisp-native-hud-compatibility",
+            ["issuedUtc"] = Utc(Now.AddMinutes(-1)),
+            ["expiresUtc"] = Utc(Now.AddDays(1)),
+            ["packs"] = new JsonArray(packs.Select(pack => pack.DeepClone()).ToArray())
+        };
+
+        public byte[] Bundle(params JsonObject[] packs) => SignRaw(Bytes(BundlePayload(packs)));
 
         public JsonObject Payload(JsonObject? pack = null, DateTimeOffset? issued = null, DateTimeOffset? expires = null) => new()
         {

--- a/tests/Wisp.App.Tests/NativeGaugeCompatibilityPackTests.cs
+++ b/tests/Wisp.App.Tests/NativeGaugeCompatibilityPackTests.cs
@@ -8,7 +8,7 @@ namespace Wisp.App.Tests;
 
 public sealed class NativeGaugeCompatibilityPackTests
 {
-    private const uint ImageSize = 188_293_120;
+    private static uint ImageSize => NativeHudBuildContract.BuiltIn.ImageSize;
 
     private static readonly string[] DataRvaProperties =
     [
@@ -28,7 +28,8 @@ public sealed class NativeGaugeCompatibilityPackTests
 
         Assert.Equal(3, pack.SchemaVersion);
         Assert.Equal(3, pack.ReaderVersion);
-        Assert.Equal(5, pack.Revision);
+        Assert.Equal("6.440.853.0", pack.GameVersion);
+        Assert.Equal(1, pack.Revision);
         foreach (var property in typeof(NativeGaugeLayout).GetProperties()
                      .Where(property => property.PropertyType == typeof(ulong)))
         {
@@ -40,8 +41,8 @@ public sealed class NativeGaugeCompatibilityPackTests
 
         Assert.Equal("488D4170C3", layout.HudSubobjectSlotZeroPrologueHex);
         Assert.Equal(6, layout.RequiredProviderVtableSlots.Count);
-        Assert.Equal(0x01F12AD0UL, layout.RequiredProviderVtableSlots[0x0298]);
-        Assert.Equal(0x01F18F00UL, layout.RequiredProviderVtableSlots[0x0E28]);
+        Assert.Equal(0x031AA0E0UL, layout.RequiredProviderVtableSlots[0x0298]);
+        Assert.Equal(0x031B04D0UL, layout.RequiredProviderVtableSlots[0x0E28]);
         Assert.Equal(64UL, layout.HudTypeVectorMaximumCount);
         Assert.Equal(1UL, layout.HudTypeInstanceCount);
         Assert.Equal(0x10UL, layout.SharedControlObjectOffset);
@@ -379,13 +380,21 @@ public sealed class NativeGaugeCompatibilityPackTests
     [InlineData("offset", "672")]
     [InlineData("offset", "665")]
     [InlineData("targetRva", "0")]
-    [InlineData("targetRva", "188293120")]
     [InlineData("targetRva", "-1")]
     [InlineData("targetRva", "null")]
     public void InvalidNativeGaugeProviderGuardsAreRejected(string propertyName, string rawJson)
     {
         var document = BuiltInDocument();
         document["nativeGauge"]!["requiredProviderVtableSlots"]![0]![propertyName] = JsonNode.Parse(rawJson);
+
+        Assert.Throws<FormatException>(() => Parse(document));
+    }
+
+    [Fact]
+    public void NativeGaugeProviderTargetMustStayInsideTheImage()
+    {
+        var document = BuiltInDocument();
+        document["nativeGauge"]!["requiredProviderVtableSlots"]![0]!["targetRva"] = ImageSize;
 
         Assert.Throws<FormatException>(() => Parse(document));
     }

--- a/tests/Wisp.App.Tests/NativeHudCompatibilityPackTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudCompatibilityPackTests.cs
@@ -84,7 +84,7 @@ public sealed class NativeHudCompatibilityPackTests
     }
 
     [Fact]
-    public void BundledPackPreservesTheGeneratedCurrentReaderContract()
+    public void PreviousBundledPackPreservesItsGeneratedReaderContract()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
         while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Wisp.sln")))

--- a/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
@@ -34,18 +34,35 @@ public sealed class NativeHudMemoryResolverTests
     }
 
     [Fact]
-    public void UpdatedBuildIsAcceptedAndPreviousAddressMapIsRejected()
+    public void UpdatedBuildRequiresItsOwnExactFingerprintAndAddressMap()
     {
         Assert.True(NativeHudBuildContract.Matches(
-            "6.430.771.0", 183_853_016,
-            "B62B5EC1933B2D11A6B80941AE0D2B38C4A5AAEFDD880E487453D178081D7B44"));
+            "6.440.853.0", 184_055_768,
+            "FEC4A63CDEAD26F6528564F0E33C3D7FD02CD887337ED6E1AEACA79EB2843FCD"));
         Assert.False(NativeHudBuildContract.Matches(
             "6.420.696.0", 183_790_552,
             "8B2F8B6AACE53B89DDCFE45CF3F8C199E9A1817B715C4C2C1B512B6BB7A1EEF0"));
-        Assert.Equal(0x0A8D9A60UL, NativeHudBuildContract.SourceVectorRva);
-        Assert.Equal(0x063C9984UL, NativeHudBuildContract.ThresholdRva);
-        Assert.Equal(0x0678A940UL, NativeHudBuildContract.LeadVtableRva);
+        Assert.Equal(0x0A8B0310UL, NativeHudBuildContract.SourceVectorRva);
+        Assert.Equal(0x063E2E8CUL, NativeHudBuildContract.ThresholdRva);
+        Assert.Equal(0x06C31680UL, NativeHudBuildContract.LeadVtableRva);
         Assert.Equal(9, NativeHudBuildContract.RequiredVtableSlots.Count);
+    }
+
+    [Fact]
+    public void ProductionCatalogRetainsPreviousSteamAndStoreContractsOffline()
+    {
+        var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null,
+            new Dictionary<string, byte[]>(), NativeHudBuildContract.AdditionalBuiltIns);
+        var previous = NativeHudBuildContract.PreviousSteamBuiltIn;
+        var store = NativeHudBuildContract.StoreBuiltIn;
+
+        Assert.Equal("6.430.771.0", previous.GameVersion);
+        Assert.Same(previous, catalog.Find(previous.GameVersion, previous.ExecutableLength, previous.ExecutableSha256));
+        Assert.Same(store, catalog.FindStore(store.StoreIdentity!.PackageFullName, store.ImageSize));
+        Assert.Null(catalog.Find(previous.GameVersion, NativeHudBuildContract.SupportedExecutableLength,
+            NativeHudBuildContract.SupportedSha256));
+        Assert.Null(catalog.FindStore(store.StoreIdentity.PackageFullName, NativeHudBuildContract.BuiltIn.ImageSize));
+        Assert.False(catalog.HasTrustedPublishers);
     }
 
     [Fact]

--- a/tests/Wisp.App.Tests/NativeHudStoreBuildIdentityTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudStoreBuildIdentityTests.cs
@@ -9,6 +9,7 @@ namespace Wisp.App.Tests;
 public sealed class NativeHudStoreBuildIdentityTests
 {
     private const string StoreVersion = "3.430.771.0";
+    private const string KnownPackageFullName = "Microsoft.ForteBaseGame_3.430.771.0_x64__8wekyb3d8bbwe";
     private const uint ImageSize = 0x5000;
     private const uint Timestamp = 1787153332;
     private const int Pe = 0x80;
@@ -22,7 +23,7 @@ public sealed class NativeHudStoreBuildIdentityTests
         var identity = ParseIdentity(IdentityDocument(memory));
 
         Assert.True(identity.MatchesImage(memory, Module));
-        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(KnownPackageFullName, identity.PackageFullName);
         Assert.Equal(Timestamp, identity.TimeDateStamp);
         Assert.Equal(ImageSize, identity.ImageSize);
         Assert.Equal(new[] { (Module, 4096), (Module + 0x1100, 32), (Module + 0x1200, 64) }, memory.Reads);
@@ -269,7 +270,7 @@ public sealed class NativeHudStoreBuildIdentityTests
     }
 
     [Fact]
-    public void EvenTrustedSignedEnvelopeCannotSupplyAStorePack()
+    public void StoreEnvelopeRequiresAPinnedPublisherAndPreservesItsImageGuards()
     {
         var now = new DateTimeOffset(2026, 9, 6, 12, 0, 0, TimeSpan.Zero);
         using var key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -292,10 +293,18 @@ public sealed class NativeHudStoreBuildIdentityTests
             ["payload"] = Convert.ToBase64String(payload),
             ["signature"] = Convert.ToBase64String(signature)
         });
+        var verified = NativeCompatibilityEnvelope.Verify(envelope, new Dictionary<string, byte[]> { [keyId] = publicKey }, now);
+        Assert.Single(verified.Packs);
+        Assert.NotNull(verified.Pack.StoreIdentity);
+        Assert.Equal(KnownPackageFullName, verified.Pack.StoreIdentity.PackageFullName);
+        var memory = new Memory();
+        BinaryPrimitives.WriteUInt32LittleEndian(memory.Bytes.AsSpan(Pe + 80), verified.Pack.ImageSize);
+        Assert.True(verified.Pack.StoreIdentity.MatchesImage(memory, Module));
+        memory.Bytes[0x1100] ^= 1;
+        Assert.False(verified.Pack.StoreIdentity.MatchesImage(memory, Module));
         var exception = Assert.Throws<NativeCompatibilityEnvelopeException>(() => NativeCompatibilityEnvelope.Verify(
-            envelope, new Dictionary<string, byte[]> { [keyId] = publicKey }, now));
-        Assert.Equal(NativeCompatibilityInstallCode.InvalidEnvelope, exception.Code);
-        Assert.Contains("application release", exception.Message, StringComparison.Ordinal);
+            envelope, new Dictionary<string, byte[]>(), now));
+        Assert.Equal(NativeCompatibilityInstallCode.UntrustedPublisher, exception.Code);
     }
 
     private static JsonObject StorePackDocument()
@@ -324,7 +333,7 @@ public sealed class NativeHudStoreBuildIdentityTests
 
     private static JsonObject IdentityDocument(Memory memory) => new()
     {
-        ["packageFullName"] = NativeStorePackageIdentity.SupportedPackageFullName,
+        ["packageFullName"] = KnownPackageFullName,
         ["timeDateStamp"] = Timestamp,
         ["codeGuards"] = new JsonArray(Guard(memory, 0x1100, 32), Guard(memory, 0x1200, 64))
     };

--- a/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
+++ b/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
@@ -6,6 +6,7 @@ namespace Wisp.App.Tests;
 
 public sealed class NativeStorePackageIdentityTests
 {
+    private const string KnownPackageFullName = "Microsoft.ForteBaseGame_3.430.771.0_x64__8wekyb3d8bbwe";
     private const string PackagePath = @"C:\Games\Forza\Content";
     private const string ExecutablePath = PackagePath + @"\ForzaHorizon6.exe";
 
@@ -13,7 +14,7 @@ public sealed class NativeStorePackageIdentityTests
     public void ExactStorePackageAndExecutableMatch()
     {
         Assert.True(Validate(ExecutablePath, out var identity));
-        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(KnownPackageFullName, identity.PackageFullName);
         Assert.Equal(ExecutablePath.ToUpperInvariant(), identity.ExecutablePath);
     }
 
@@ -42,15 +43,34 @@ public sealed class NativeStorePackageIdentityTests
     }
 
     [Theory]
-    [InlineData("Microsoft.ForteBaseGame_3.430.772.0_x64__8wekyb3d8bbwe")]
-    [InlineData("Microsoft.ForteBaseGame_6.430.771.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.65536_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.-1_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.0.1_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.0 _x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.430.772.0_x64__8wekyb3d8bbwe_extra")]
     [InlineData("Microsoft.ForteBaseGame_3.430.771.0_x86__8wekyb3d8bbwe")]
     [InlineData("Microsoft.ForteBaseGame_3.430.771.0_x64__otherpublisher")]
     [InlineData("Microsoft.OtherGame_3.430.771.0_x64__8wekyb3d8bbwe")]
     [InlineData("")]
     [InlineData(null)]
-    public void OtherPackageOrBuildIsRejected(string? name) => Assert.False(
+    public void OtherPackageOrMalformedVersionIsRejected(string? name) => Assert.False(
         NativeStorePackageIdentity.TryValidate(name, 3, PackagePath, PackagePath, ExecutablePath, out _));
+
+    [Theory]
+    [InlineData("Microsoft.ForteBaseGame_3.440.853.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_6.430.771.0_x64__8wekyb3d8bbwe")]
+    public void NewPackageVersionStillRequiresItsOwnTrustedBuildContract(string fullName)
+    {
+        using var handle = new SafeProcessHandle(new IntPtr(42), ownsHandle: false);
+        var api = new FakePackageApi { FullName = fullName };
+        Assert.True(NativeStorePackageIdentity.TryRead(handle, ExecutablePath, api, out var identity));
+        Assert.Equal(fullName, identity.PackageFullName);
+
+        var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null,
+            new Dictionary<string, byte[]>(), NativeHudBuildContract.AdditionalBuiltIns);
+        Assert.Null(catalog.FindStore(identity.PackageFullName, NativeHudBuildContract.StoreBuiltIn.ImageSize));
+    }
 
     [Theory]
     [InlineData(0)]
@@ -62,7 +82,7 @@ public sealed class NativeStorePackageIdentityTests
     [InlineData(-1)]
     [InlineData(int.MaxValue)]
     public void NonStoreOriginsAreRejected(int origin) => Assert.False(
-        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+        NativeStorePackageIdentity.TryValidate(KnownPackageFullName,
             origin, PackagePath, PackagePath, ExecutablePath, out _));
 
     [Theory]
@@ -73,7 +93,7 @@ public sealed class NativeStorePackageIdentityTests
     [InlineData(@"C:\Games\Other\Content", PackagePath)]
     [InlineData(PackagePath, @"C:\Games\Other\Content")]
     public void UnavailableOrUnverifiedPackagePathsAreRejected(string? original, string? effective) => Assert.False(
-        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+        NativeStorePackageIdentity.TryValidate(KnownPackageFullName,
             3, original, effective, ExecutablePath, out _));
 
     [Fact]
@@ -82,7 +102,7 @@ public sealed class NativeStorePackageIdentityTests
         using var handle = new SafeProcessHandle(new IntPtr(42), ownsHandle: false);
         var api = new FakePackageApi();
         Assert.True(NativeStorePackageIdentity.TryRead(handle, ExecutablePath, api, out var identity));
-        Assert.Equal(NativeStorePackageIdentity.SupportedPackageFullName, identity.PackageFullName);
+        Assert.Equal(KnownPackageFullName, identity.PackageFullName);
         Assert.Equal(new[] { 0, 0, 2, 2 }, api.PathTypes);
         Assert.Equal(2, api.NameCalls);
     }
@@ -125,7 +145,7 @@ public sealed class NativeStorePackageIdentityTests
     }
 
     private static bool Validate(string? path, out NativeStorePackageIdentity identity) =>
-        NativeStorePackageIdentity.TryValidate(NativeStorePackageIdentity.SupportedPackageFullName,
+        NativeStorePackageIdentity.TryValidate(KnownPackageFullName,
             3, PackagePath, PackagePath, path, out identity);
 
     [Fact]
@@ -258,6 +278,7 @@ public sealed class NativeStorePackageIdentityTests
 
     private sealed class FakePackageApi : NativeStorePackageIdentity.IPackageApi
     {
+        internal string FullName { get; init; } = KnownPackageFullName;
         internal string Fault { get; init; } = "";
         internal int NameCalls { get; private set; }
         internal List<int> PathTypes { get; } = [];
@@ -279,7 +300,7 @@ public sealed class NativeStorePackageIdentityTests
                 if (Fault == "name-growth") { length++; return 0; }
             }
 
-            var result = Copy(NativeStorePackageIdentity.SupportedPackageFullName, ref length, buffer);
+            var result = Copy(FullName, ref length, buffer);
             if (buffer is not null && Fault == "name-no-terminator") buffer[^1] = 'x';
             if (buffer is not null && Fault == "name-interior-null") buffer[3] = '\0';
             return result;
@@ -287,12 +308,14 @@ public sealed class NativeStorePackageIdentityTests
 
         public int GetOrigin(string fullName, out int origin)
         {
+            Assert.Equal(FullName, fullName);
             origin = 3;
             return Fault == "origin-error" ? 5 : 0;
         }
 
         public int GetPath(string fullName, int pathType, ref uint length, char[]? buffer)
         {
+            Assert.Equal(FullName, fullName);
             PathTypes.Add(pathType);
             if (Fault == "original-error" && pathType == 0 || Fault == "effective-error" && pathType == 2) return 15707;
             if (Fault == "path-large" && buffer is null) { length = uint.MaxValue; return 122; }

--- a/tests/Wisp.App.Tests/ReleaseContentTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseContentTests.cs
@@ -82,8 +82,8 @@ public sealed class ReleaseContentTests
         Assert.Equal(0x0248UL, contract.Fields.ProviderSimRedlineAngularVelocity);
         Assert.Equal(0x024CUL, contract.Fields.ProviderTachometerMaximumAngularVelocity);
         Assert.Contains("TryValidateTachometerState", resolver, StringComparison.Ordinal);
-        Assert.Equal(0x01F15590UL, contract.RequiredVtableSlots[0x0210]);
-        Assert.Equal(0x01F15580UL, contract.RequiredVtableSlots[0x0680]);
+        Assert.Equal(0x031ACB80UL, contract.RequiredVtableSlots[0x0210]);
+        Assert.Equal(0x031ACB70UL, contract.RequiredVtableSlots[0x0680]);
         Assert.Contains("NativeAssistAssetSelector.FileName", digital, StringComparison.Ordinal);
         Assert.Contains("NativeAssistAssetSelector.FileName", analogue, StringComparison.Ordinal);
         Assert.Contains("\"On_glow\"", assistSelector, StringComparison.Ordinal);

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));
@@ -20,12 +20,24 @@ public sealed class ReleaseNotesCatalogTests
     }
 
     [Fact]
-    public void CurrentStoreCompatibilityEntryIdentifiesTheSupportedPcBuild()
+    public void CurrentCompatibilityEntryIdentifiesTheUpdatedGameBuild()
     {
         var entry = ReleaseNotesCatalog.Entries[0];
-        Assert.Equal("1.1.1", entry.Version);
+        Assert.Equal("1.1.2", entry.Version);
         Assert.Equal("COMPATIBILITY HOTFIX", entry.Label);
         Assert.True(entry.IsCurrent);
+        Assert.Contains("6.440.853.0", entry.Summary, StringComparison.Ordinal);
+        var text = string.Join(' ', entry.Groups.SelectMany(group => group.Items));
+        Assert.Contains("6.440.853.0", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HistoricalStoreCompatibilityEntryIdentifiesTheSupportedPcBuild()
+    {
+        var entry = ReleaseNotesCatalog.Entries.Single(entry => entry.Version == "1.1.1");
+        Assert.Equal("1.1.1", entry.Version);
+        Assert.Equal("COMPATIBILITY HOTFIX", entry.Label);
+        Assert.False(entry.IsCurrent);
         var text = string.Join(' ', entry.Groups.SelectMany(group => group.Items));
         Assert.Contains("3.430.771.0", text, StringComparison.Ordinal);
         Assert.Contains("Xbox app and Microsoft Store", text, StringComparison.Ordinal);

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -366,8 +366,8 @@ public sealed class WpfStyleRuntimeTests
                 }
                 Assert.Equal(controller.ViewModel.NativeCompatibilityUpdates,
                     Assert.IsType<TextBlock>(mainWindow.FindName("CompatibilityStatusText")).Text);
-                Assert.False(Assert.IsType<Button>(mainWindow.FindName("CompatibilityCheckButton")).IsEnabled);
-                Assert.False(Assert.IsType<Button>(mainWindow.FindName("CompatibilityImportButton")).IsEnabled);
+                Assert.True(Assert.IsType<Button>(mainWindow.FindName("CompatibilityCheckButton")).IsEnabled);
+                Assert.True(Assert.IsType<Button>(mainWindow.FindName("CompatibilityImportButton")).IsEnabled);
                 mainWindow.Close();
                 gForceWindow.Close();
                 controller.DisposeAsync().AsTask().GetAwaiter().GetResult();

--- a/tools/Sign-CompatibilityBundle.ps1
+++ b/tools/Sign-CompatibilityBundle.ps1
@@ -1,0 +1,147 @@
+#Requires -Version 7.4
+[CmdletBinding(DefaultParameterSetName = 'Sign')]
+param(
+    [Parameter(Mandatory)][string]$KeyFile,
+    [Parameter(Mandatory, ParameterSetName = 'Initialize')][switch]$InitializeKey,
+    [Parameter(Mandatory, ParameterSetName = 'Initialize')][string]$PublicKeyOutput,
+    [Parameter(Mandatory, ParameterSetName = 'Sign')][string[]]$Pack,
+    [Parameter(Mandatory, ParameterSetName = 'Sign')][string]$Output,
+    [Parameter(Mandatory, ParameterSetName = 'Sign')][switch]$Reviewed,
+    [Parameter(ParameterSetName = 'Sign')][ValidateRange(1, 365)][int]$ValidityDays = 90
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $IsWindows) {
+    throw 'This signing key is protected for its owning Windows user.'
+}
+Add-Type -AssemblyName System.Security.Cryptography.ProtectedData
+if (-not ('WispCompatibilitySigningKey' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Security.Cryptography;
+public static class WispCompatibilitySigningKey
+{
+    public static void Import(ECDsa key, byte[] bytes)
+    {
+        key.ImportPkcs8PrivateKey(bytes, out int consumed);
+        if (consumed != bytes.Length || key.KeySize != 256 ||
+            key.ExportParameters(false).Curve.Oid.Value != "1.2.840.10045.3.1.7")
+            throw new CryptographicException("The publisher key is not ECDSA P-256.");
+    }
+}
+'@
+}
+$utf8 = [Text.UTF8Encoding]::new($false)
+$entropy = [Text.Encoding]::ASCII.GetBytes('Wisp.NativeHud.Compatibility/publisher-key/v1')
+$privateBytes = $null
+$key = $null
+
+function Write-NewBytes([string]$Path, [byte[]]$Bytes) {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    $parent = [IO.Path]::GetDirectoryName($fullPath)
+    [void][IO.Directory]::CreateDirectory($parent)
+    $stream = [IO.FileStream]::new($fullPath, [IO.FileMode]::CreateNew,
+        [IO.FileAccess]::Write, [IO.FileShare]::None)
+    try { $stream.Write($Bytes, 0, $Bytes.Length); $stream.Flush($true) }
+    finally { $stream.Dispose() }
+}
+
+try {
+    if ($InitializeKey) {
+        if ((Test-Path -LiteralPath $KeyFile) -or (Test-Path -LiteralPath $PublicKeyOutput)) {
+            throw 'Key initialization refuses to replace an existing file.'
+        }
+        $key = [Security.Cryptography.ECDsa]::Create([Security.Cryptography.ECCurve+NamedCurves]::nistP256)
+        $privateBytes = $key.ExportPkcs8PrivateKey()
+        $protected = [Security.Cryptography.ProtectedData]::Protect($privateBytes, $entropy,
+            [Security.Cryptography.DataProtectionScope]::CurrentUser)
+        $publicBytes = $key.ExportSubjectPublicKeyInfo()
+        $publicRecord = [ordered]@{
+            format = 1
+            algorithm = 'ECDSA-P256-SHA256-P1363'
+            keyId = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($publicBytes))
+            subjectPublicKeyInfo = [Convert]::ToBase64String($publicBytes)
+        }
+        Write-NewBytes $KeyFile $protected
+        Write-NewBytes $PublicKeyOutput $utf8.GetBytes(($publicRecord | ConvertTo-Json -Compress))
+        [pscustomobject]@{ initialized = $true; keyId = $publicRecord.keyId; plaintextPrivateKeyWritten = $false }
+        return
+    }
+
+    if (-not $Reviewed) { throw 'Only reviewed compatibility packs may be signed.' }
+    if ($Pack.Count -lt 1 -or $Pack.Count -gt 8) { throw 'A bundle must contain between one and eight reviewed packs.' }
+    if (Test-Path -LiteralPath $Output) { throw 'Signing refuses to replace an existing output.' }
+    $protectedFile = Get-Item -LiteralPath $KeyFile
+    if ($protectedFile.Length -lt 1 -or $protectedFile.Length -gt 16384 -or
+        ($protectedFile.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw 'The publisher key file is invalid.'
+    }
+    $privateBytes = [Security.Cryptography.ProtectedData]::Unprotect(
+        [IO.File]::ReadAllBytes($protectedFile.FullName), $entropy,
+        [Security.Cryptography.DataProtectionScope]::CurrentUser)
+    $key = [Security.Cryptography.ECDsa]::Create()
+    [WispCompatibilitySigningKey]::Import($key, $privateBytes)
+
+    $packs = [Collections.Generic.List[object]]::new()
+    $identities = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($path in $Pack) {
+        $file = Get-Item -LiteralPath $path
+        if ($file.Length -lt 1 -or $file.Length -gt 65536 -or
+            ($file.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            throw 'A compatibility pack is not a bounded regular file.'
+        }
+        $value = [IO.File]::ReadAllText($file.FullName) | ConvertFrom-Json -AsHashtable
+        if ($value.schemaVersion -notin @(1, 2, 3, 4) -or $value.revision -lt 1 -or
+            $value.gameVersion -notmatch '^\d{1,5}\.\d{1,5}\.\d{1,5}\.\d{1,5}$') {
+            throw 'A compatibility pack has invalid release metadata.'
+        }
+        $identity = if ($value.schemaVersion -eq 4) {
+            'store:' + $value.storeIdentity.packageFullName + ':' + $value.imageSize
+        } else {
+            'steam:' + $value.gameVersion + ':' + $value.executableLength + ':' + $value.executableSha256
+        }
+        if (-not $identities.Add($identity)) { throw 'A bundle cannot contain duplicate build identities.' }
+        $packs.Add($value)
+    }
+
+    $issued = [DateTime]::UtcNow
+    $payload = [ordered]@{
+        format = 2
+        purpose = 'wisp-native-hud-compatibility'
+        issuedUtc = $issued.ToString('O')
+        expiresUtc = $issued.AddDays($ValidityDays).ToString('O')
+        packs = $packs.ToArray()
+    }
+    $payloadBytes = $utf8.GetBytes(($payload | ConvertTo-Json -Depth 32 -Compress))
+    if ($payloadBytes.Length -gt 98304) { throw 'The compatibility bundle exceeds the signed payload limit.' }
+    $prefix = [Text.Encoding]::ASCII.GetBytes("Wisp.NativeHud.Compatibility/v1`0")
+    $inputBytes = [byte[]]::new($prefix.Length + $payloadBytes.Length)
+    [Array]::Copy($prefix, 0, $inputBytes, 0, $prefix.Length)
+    [Array]::Copy($payloadBytes, 0, $inputBytes, $prefix.Length, $payloadBytes.Length)
+    $signature = $key.SignData($inputBytes, [Security.Cryptography.HashAlgorithmName]::SHA256,
+        [Security.Cryptography.DSASignatureFormat]::IeeeP1363FixedFieldConcatenation)
+    if (-not $key.VerifyData($inputBytes, $signature, [Security.Cryptography.HashAlgorithmName]::SHA256,
+        [Security.Cryptography.DSASignatureFormat]::IeeeP1363FixedFieldConcatenation)) {
+        throw 'The generated compatibility signature failed verification.'
+    }
+    $publicBytes = $key.ExportSubjectPublicKeyInfo()
+    $envelope = [ordered]@{
+        format = 1
+        keyId = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($publicBytes))
+        payload = [Convert]::ToBase64String($payloadBytes)
+        signature = [Convert]::ToBase64String($signature)
+    }
+    $envelopeBytes = $utf8.GetBytes(($envelope | ConvertTo-Json -Compress))
+    if ($envelopeBytes.Length -gt 131072) { throw 'The signed envelope exceeds the download limit.' }
+    Write-NewBytes $Output $envelopeBytes
+    [pscustomobject]@{
+        signed = $true
+        packs = $packs.Count
+        sha256 = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($envelopeBytes))
+        published = $false
+    }
+}
+finally {
+    if ($null -ne $privateBytes) { [Array]::Clear($privateBytes, 0, $privateBytes.Length) }
+    if ($null -ne $key) { $key.Dispose() }
+}


### PR DESCRIPTION
## Purpose

Restore the HUD on Steam FH6 6.440.853.0 and harden compatibility-map delivery for future reviewed updates. Addresses #46; close that report only after the public release is verified.

## Root cause and solution

The game update changed its executable identity and native memory locations. Wisp 1.1.1 rejected the unknown build, leaving gameplay visibility unavailable and hiding the overlays even when UDP reached the dashboard.

Add a separately verified map for the new Steam binary, retain the previous Steam and Store maps, and enable the existing pinned-signature update path. Bounded multi-build bundles install atomically with revision floors and offline verification. Store selection uses the actual versioned Windows package while retaining exact trusted-map, origin, path, loaded-image, and reader guards. No renderer, scheduling, smoothing, or telemetry changes are included.

## Validation

- Official local installer build passed: audited locked restore, formatting, 2,791 .NET tests, 75 Python audit tests, update-helper smoke test, and both real-installer validators.
- Exact binary audit passed. A bounded live ownership check resolved the new HUD token; actual candidate readers returned native needle, redline, and gameplay visibility throughout all 45 initialized service observations.
- Real publisher-key integration passed signed-bundle acceptance, tamper rejection, atomic persistence, offline reload, idempotence, and revoked-key handling. The exact initial publisher asset matches all three embedded maps.

- [x] Approved scope and verified compatibility benefit.
- [x] Contributor-rights terms reviewed; source changes are authorized.
- [x] Regression coverage and changelog updated; complete local Release tests pass.
- [x] No credentials, private keys, game binaries, private captures, machine-specific paths, or generated release output committed.
- [x] Native HUD assets unchanged.

## Outstanding validation

Required GitHub checks and public artifact verification run before publication/issue closure. The live check covered a parked combustion car with explicitly native-derived input; it does not independently prove UDP correlation, every assist/menu transition, electric-car behavior, or a fix for the separate intermittent focus-lag issue #30.
