### PR TITLE
Restore updated Store HUD and add boost vacuum in Wisp 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.1.3 - 2026-09-08
+
+- Add the reviewed native HUD map for Xbox app / Microsoft Store FH6 `3.440.853.0` on Windows PC, retaining Store `3.430.771.0` and the existing Steam maps.
+- Retain the signed compatibility-map update path from 1.1.2, including exact Store identity checks, atomic installation, and offline reuse for reviewed maps within the supported reader.
+- Add an optional **Show vacuum pressure** toggle in Appearance > Boost, using negative pressure reported by FH6.
+- Let the existing boost-gauge visibility toggle show a stationary zero gauge on naturally aspirated cars. Electric vehicles never show it. Require positive boost before enabling pressure readings, so vacuum alone does not identify forced induction; after detection, the option follows negative telemetry at idle and cruise.
+- Support vacuum in Digital and Analogue gauges, attached and detached layouts, and the Appearance preview in PSI or bar.
+- Extend the enabled gauge range to -20 through 70 PSI or -1 through 5 bar, with a zero marker on the Digital rail.
+- Keep the option off by default and save it with settings and HUD profiles. Existing settings and profiles leave vacuum disabled.
+- Check for application updates every time Wisp opens and every 24 hours while it remains running, when automatic checks are enabled. A recent check from a previous launch no longer suppresses the startup check.
+- Preserve an available-update banner if a later automatic refresh fails. Downloads and installation still require confirmation.
+
 ## 1.1.2 - 2026-09-07
 
 - Add the native compatibility map for Steam FH6 `6.440.853.0`, retaining the previous Steam and Store maps.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
+## New in Wisp 1.1.3
+
+Adds native HUD support for Xbox app / Microsoft Store FH6 `3.440.853.0` on
+Windows PC. Previous Store and Steam maps remain available offline. Signed map
+updates introduced in 1.1.2 continue to support future reviewed builds within the
+existing reader; changed native layouts may still require an application update.
+
+Enable **Show vacuum pressure** in Appearance > Boost to display negative pressure
+reported by FH6. Digital and Analogue gauges support PSI and bar, including
+attached and detached layouts. The option starts off and saves with your settings
+and HUD profiles. Leave the boost gauge enabled even when you do not know a
+tune's induction setup: naturally aspirated cars show a stationary zero gauge,
+and pressure starts working once positive boost is detected. Electric vehicles
+never show the boost gauge. Vacuum requires positive boost to have been detected
+for the current car/session.
+
+Automatic application-update checks now run whenever Wisp opens and every 24
+hours while it stays open, including while waiting in the tray. An available
+update banner remains visible if a later automatic check fails.
+
+[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.1.3 release notes](docs/releases/Wisp-1.1.3-release-notes.md)
+
 ## New in Wisp 1.1.2
 
 Adds support for Steam FH6 `6.440.853.0` and signed compatibility-map updates for
@@ -234,8 +257,9 @@ installer is unsigned, so Windows may show an unfamiliar-publisher warning.
 
 ## Application updates
 
-Wisp checks for updates at startup by default, at most once every 24 hours.
-Turn off **Automatically check once daily** in **Extras** to disable those checks.
+Wisp checks for updates whenever it opens and every 24 hours while it remains
+running, including while waiting in the tray.
+Turn off **Automatically check on open and daily** in **Extras** to disable those checks.
 You can also select **Check for updates** there to check immediately. Automatic
 checks discover releases; they never download or install an update without your
 confirmation.

--- a/docs/BOOST-GAUGE.md
+++ b/docs/BOOST-GAUGE.md
@@ -6,14 +6,18 @@ It does not estimate pressure from throttle, RPM, speed, or gear.
 
 ## Availability
 
-The gauge remains hidden until the current car produces a non-zero boost-channel
-sample. FH6 reports vacuum on supported forced-induction cars before positive
-boost, so Wisp can identify the car before the driver builds pressure. Electric
-cars and cars whose boost channel remains at zero do not show the gauge. The
-availability state resets when the car changes.
+The existing gauge visibility toggle controls the gauge on combustion cars.
+Naturally aspirated cars show a stationary zero gauge, so you can leave it
+enabled without knowing whether a tune has forced induction. Electric cars
+never show the boost gauge.
 
-Vacuum is used only for availability. The visible readout and gauge position
-start at zero and do not show a negative pressure value. Choose PSI or bar for
+Pressure readings begin once the current car produces at least 0.5 PSI of
+positive boost. Vacuum alone does not identify forced induction. Detection
+resets when the car changes or the HUD session resets.
+
+Enable **Show vacuum pressure** to display negative telemetry after positive
+boost is detected. The option is off by default and saves with settings and HUD
+profiles. With it off, negative readings clamp to zero. Choose PSI or bar for
 both layouts and the Appearance preview; FH6 telemetry remains in PSI internally.
 
 ## Digital layout
@@ -26,12 +30,16 @@ The rail can use the custom three-point gauge gradient or the neutral stock
 tachometer material. The pressure readout has its own color toggle, so the number
 can remain white while the rail uses the gradient.
 
+With vacuum enabled, the rail includes a zero marker between negative and
+positive pressure.
+
 ## Analogue layout
 
 Analogue mode uses a circular 0 to 70 PSI gauge with numbered 10 PSI intervals
 and intermediate 5 PSI ticks, or a 0 to 5 bar scale with numbered 1 bar intervals.
 The center readout shows whole PSI or bar to one decimal place. The needle and
 readout use the Native HUD's existing typography, materials, and motion style.
+With vacuum enabled, the scale extends to -20 PSI or -1 bar.
 
 The readout color can follow the needle position or remain white. The Analogue
 gauge also has independent size and attached-placement controls.
@@ -55,6 +63,7 @@ Open **Appearance > Boost gauge** to change:
 - gauge visibility;
 - attached or detached Analogue placement;
 - PSI or bar;
+- vacuum pressure after positive boost is detected;
 - Analogue pressure-number color;
 - Digital pressure-number color;
 - Digital stock-material mode.

--- a/docs/releases/Wisp-1.1.3-release-notes.md
+++ b/docs/releases/Wisp-1.1.3-release-notes.md
@@ -1,0 +1,33 @@
+# Wisp 1.1.3
+
+Adds Xbox app / Microsoft Store FH6 `3.440.853.0` support on Windows PC and
+optional vacuum pressure for boost gauges, and fixes automatic update checks.
+
+- Includes a reviewed native HUD compatibility map for the updated Store build.
+  Previous Store `3.430.771.0` and existing Steam maps remain available offline.
+- Retains signed compatibility-map updates introduced in 1.1.2, with exact
+  package and code checks, atomic installation, and offline reuse. Future reviewed
+  maps within the supported reader can be delivered without reinstalling Wisp;
+  changes to native layouts can still require an application update.
+
+- Enable **Show vacuum pressure** in Appearance > Boost to show negative pressure
+  reported by FH6. The option is off by default. Pressure readings first require
+  positive boost from the current car/session; vacuum alone does not enable them.
+- Keep the boost gauge enabled even if you do not know whether a tune has forced
+  induction. Naturally aspirated cars show a stationary zero gauge. Electric
+  vehicles never show the boost gauge.
+- Supports Digital and Analogue gauges, attached and detached layouts, and the
+  Appearance preview in PSI or bar.
+- Uses a -20 to 70 PSI or -1 to 5 bar scale when enabled. The Digital rail marks
+  zero between vacuum and positive boost.
+- Saves the option with Wisp settings and HUD profiles. Existing settings and
+  profiles leave vacuum disabled.
+
+- With automatic checks enabled, Wisp checks for application updates whenever
+  it opens and every 24 hours while it remains running, including in the tray.
+  A recent check from an earlier launch no longer suppresses the startup check.
+- An available-update banner stays visible if a later automatic refresh fails.
+  Downloads and installation still require confirmation.
+
+The installer is `Wisp-Setup-1.1.3.exe`. Install over your current Wisp version
+to retain completed setup, HUD preferences, profiles, and tire calibration.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,6 +1,6 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.1.2"
-#define MyAppDisplayVersion "1.1.2"
+#define MyAppVersion "1.1.3"
+#define MyAppDisplayVersion "1.1.3"
 #define MyAppPublisher "Wisp"
 #define MyAppExeName "Wisp.exe"
 

--- a/src/Wisp.App/App.xaml.cs
+++ b/src/Wisp.App/App.xaml.cs
@@ -104,6 +104,7 @@ public partial class App : Application
         ConfigureStartupCompanion();
         if (launchMode == StartupLaunchMode.WaitForForza && _startupTray is { IsAvailable: true })
         {
+            _controller.BeginStartupApplicationUpdateCheck();
             await SuspendRuntimeAsync();
             return;
         }
@@ -321,6 +322,7 @@ public partial class App : Application
                     window.Activate();
                 }
             }
+            _controller.BeginStartupApplicationUpdateCheck();
             if (_runtimeActive)
             {
                 return;
@@ -331,7 +333,6 @@ public partial class App : Application
                 await _controller.StartAsync();
                 _runtimeActive = true;
                 _startupTray?.SetWaiting(false);
-                _controller.BeginStartupApplicationUpdateCheck();
             }
             catch (Exception exception) when (exception is ArgumentOutOfRangeException or System.Net.Sockets.SocketException)
             {

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -38,11 +38,13 @@ public sealed class AppController : IAsyncDisposable
     private readonly NativeCompatibilityUpdateClient _compatibilityUpdates = NativeCompatibilityRuntime.CreateUpdateClient();
     private readonly CancellationTokenSource _compatibilityLifetime = new();
     private readonly WispUpdateClient _applicationUpdates = WispUpdateClient.CreateDefault();
+    private readonly Func<Version, CancellationToken, Task<UpdateRelease?>> _checkForApplicationUpdate;
     private readonly CancellationTokenSource _applicationUpdateLifetime = new();
     private readonly Dictionary<int, CalibrationPersistenceIdentity> _capturedCalibrationProfiles;
     private readonly Dispatcher _dispatcher;
     private readonly DispatcherTimer _uiTimer;
     private readonly DispatcherTimer _settingsSaveTimer;
+    private readonly DispatcherTimer _applicationUpdateTimer;
     private TelemetryFreshness _freshness = new(TelemetryTimeout);
     private VehicleState? _lastFreshnessState;
     private VehicleState? _lastProcessedState;
@@ -109,12 +111,14 @@ public sealed class AppController : IAsyncDisposable
         AppSettings settings,
         Action<AppSettings> saveSettings,
         IStartupRegistrationService startupRegistrationService,
-        Action<AppSettings>? saveCompletedSetup = null)
+        Action<AppSettings>? saveCompletedSetup = null,
+        Func<Version, CancellationToken, Task<UpdateRelease?>>? checkForApplicationUpdate = null)
     {
         Settings = settings;
         _saveSettings = saveSettings ?? throw new ArgumentNullException(nameof(saveSettings));
         _saveCompletedSetup = saveCompletedSetup ?? _saveSettings;
         _startupRegistrationService = startupRegistrationService;
+        _checkForApplicationUpdate = checkForApplicationUpdate ?? _applicationUpdates.CheckForUpdateAsync;
         SetupTelemetry = new SetupTelemetryTest(new SetupTelemetrySource(_receiver));
         _calibration.ImportSnapshots(settings.Calibrations);
         _capturedCalibrationProfiles = CalibrationPersistenceIdentity.Capture(_calibration);
@@ -167,6 +171,11 @@ public sealed class AppController : IAsyncDisposable
             _settingsSaveTimer.Stop();
             SaveSettings();
         };
+        _applicationUpdateTimer = new DispatcherTimer(DispatcherPriority.Background, _dispatcher)
+        {
+            Interval = ApplicationUpdateCheckPolicy.MinimumInterval
+        };
+        _applicationUpdateTimer.Tick += OnApplicationUpdateTimer;
         if (_debugLog.IsEnabled && settings.DebugLoggingExpiresAtUtc is { } expiresAtUtc)
         {
             _debugHealthMonitor.Start(expiresAtUtc);
@@ -427,17 +436,22 @@ public sealed class AppController : IAsyncDisposable
 
     public void BeginStartupApplicationUpdateCheck()
     {
-        if (_disposed || Settings.RequiresSetup ||
-            !ApplicationUpdateCheckPolicy.IsDue(
-                Settings.AutomaticApplicationUpdateChecks,
-                Settings.LastApplicationUpdateCheckUtc,
-                DateTimeOffset.UtcNow))
+        if (_disposed || Settings.RequiresSetup || !Settings.AutomaticApplicationUpdateChecks)
         {
+            _applicationUpdateTimer.Stop();
             return;
         }
 
+        // Opening Wisp is an explicit check opportunity even when a previous
+        // process checked recently. The timer also survives companion suspension.
+        if (!_applicationUpdateTimer.IsEnabled)
+        {
+            _applicationUpdateTimer.Start();
+        }
         _ = CheckApplicationUpdateAvailabilityAsync(automatic: true);
     }
+
+    private void OnApplicationUpdateTimer(object? sender, EventArgs e) => BeginStartupApplicationUpdateCheck();
 
     public async Task<ApplicationUpdateDetails?> GetAvailableApplicationUpdateDetailsAsync()
     {
@@ -469,35 +483,45 @@ public sealed class AppController : IAsyncDisposable
 
         try
         {
+            _applicationUpdateTimer.Stop();
+            if (Settings.AutomaticApplicationUpdateChecks && !Settings.RequiresSetup)
+            {
+                _applicationUpdateTimer.Start();
+            }
             Settings.LastApplicationUpdateCheckUtc = DateTimeOffset.UtcNow;
             SaveSettings();
-            ViewModel.UpdateApplicationUpdateStatus(
-                "Checking the latest Wisp release…",
-                "Checking…",
-                canCheck: false);
+            if (!automatic || !TryShowPendingApplicationUpdate(canCheck: false))
+            {
+                ViewModel.UpdateApplicationUpdateStatus(
+                    automatic && _availableApplicationRelease is not null
+                        ? ViewModel.ApplicationUpdateStatus
+                        : "Checking the latest Wisp release…",
+                    "Checking…",
+                    canCheck: false,
+                    isUpdateAvailable: automatic && _availableApplicationRelease is not null);
+            }
 
             var installedVersion = CurrentApplicationVersion();
-            var release = await _applicationUpdates.CheckForUpdateAsync(
+            var release = await _checkForApplicationUpdate(
                 installedVersion,
                 _applicationUpdateLifetime.Token);
+            _availableApplicationRelease = release;
+            if (automatic && TryShowPendingApplicationUpdate())
+            {
+                return release;
+            }
             if (release is null)
             {
-                _availableApplicationRelease = null;
                 ViewModel.UpdateApplicationUpdateStatus(
                     Settings.AutomaticApplicationUpdateChecks
-                        ? $"Wisp {ApplicationVersionInfo.Format(installedVersion)} is current. Automatic checks run once daily."
+                        ? $"Wisp {ApplicationVersionInfo.Format(installedVersion)} is current. Automatic checks run on open and every 24 hours."
                         : $"Wisp {ApplicationVersionInfo.Format(installedVersion)} is current.",
                     "Check again",
                     canCheck: true);
                 return null;
             }
 
-            _availableApplicationRelease = release;
-            ViewModel.UpdateApplicationUpdateStatus(
-                $"Wisp {ApplicationVersionInfo.Format(release.Version)} is available. The installer will download only after you confirm.",
-                "Update",
-                canCheck: true,
-                isUpdateAvailable: true);
+            ShowAvailableApplicationUpdate(release);
             return release;
         }
         catch (OperationCanceledException) when (_applicationUpdateLifetime.IsCancellationRequested)
@@ -536,7 +560,15 @@ public sealed class AppController : IAsyncDisposable
         }
         catch (UpdateSecurityException)
         {
-            if (automatic)
+            if (automatic && TryShowPendingApplicationUpdate())
+            {
+                return null;
+            }
+            if (automatic && _availableApplicationRelease is { } available)
+            {
+                ShowAvailableApplicationUpdate(available);
+            }
+            else if (automatic)
             {
                 ViewModel.UpdateApplicationUpdateStatus(
                     "The latest release could not be verified. No update was downloaded.",
@@ -558,11 +590,45 @@ public sealed class AppController : IAsyncDisposable
         }
     }
 
-    private void RestoreAutomaticApplicationUpdateStatus() =>
+    private void ShowAvailableApplicationUpdate(UpdateRelease release) =>
         ViewModel.UpdateApplicationUpdateStatus(
-            "Automatic update checks are enabled. Wisp will try again after the daily interval.",
+            $"Wisp {ApplicationVersionInfo.Format(release.Version)} is available. The installer will download only after you confirm.",
+            "Update",
+            canCheck: true,
+            isUpdateAvailable: true);
+
+    private bool TryShowPendingApplicationUpdate(bool canCheck = true)
+    {
+        if (_pendingInstaller is not { } pending || !File.Exists(pending.StagedPath))
+        {
+            return false;
+        }
+        ViewModel.UpdateApplicationUpdateStatus(
+            $"Wisp {ApplicationVersionInfo.Format(pending.Version)} is verified and ready to install.",
+            "Install update",
+            canCheck,
+            isUpdateAvailable: true);
+        return true;
+    }
+
+    private void RestoreAutomaticApplicationUpdateStatus()
+    {
+        if (TryShowPendingApplicationUpdate())
+        {
+            return;
+        }
+        if (_availableApplicationRelease is { } available)
+        {
+            ShowAvailableApplicationUpdate(available);
+            return;
+        }
+        ViewModel.UpdateApplicationUpdateStatus(
+            Settings.AutomaticApplicationUpdateChecks
+                ? "Automatic update checks are enabled. Wisp will try again when opened or after 24 hours."
+                : "Automatic update checks are off. You can still check manually.",
             "Check now",
             canCheck: true);
+    }
 
     public async Task<VerifiedInstaller?> PrepareApplicationUpdateAsync()
     {
@@ -823,6 +889,7 @@ public sealed class AppController : IAsyncDisposable
             Settings.BoostGaugeColorNumber = ViewModel.BoostGaugeColorNumber;
             Settings.DigitalBoostGaugeColorNumber = ViewModel.DigitalBoostGaugeColorNumber;
             Settings.DigitalBoostGaugeStockColors = ViewModel.DigitalBoostGaugeStockColors;
+            Settings.ShowBoostVacuum = ViewModel.ShowBoostVacuum;
             Settings.BoostPressureUnit = ViewModel.SelectedBoostPressureUnit;
             Settings.BoostGaugeScale = Math.Clamp(ViewModel.BoostGaugeScale, 0.5, 2.0);
             Settings.TireTemperatureGaugeEnabled = ViewModel.TireTemperatureGaugeEnabled;
@@ -874,11 +941,15 @@ public sealed class AppController : IAsyncDisposable
 
             if (previousAutomaticApplicationUpdateChecks != Settings.AutomaticApplicationUpdateChecks)
             {
+                if (!Settings.AutomaticApplicationUpdateChecks)
+                {
+                    _applicationUpdateTimer.Stop();
+                }
                 if (_availableApplicationRelease is null && _pendingInstaller is null)
                 {
                     ViewModel.UpdateApplicationUpdateStatus(
                         Settings.AutomaticApplicationUpdateChecks
-                            ? "Automatic update checks are enabled. Wisp checks at most once daily."
+                            ? "Automatic update checks are enabled. Wisp checks on open and every 24 hours."
                             : "Automatic update checks are off. You can still check manually.",
                         "Check now",
                         canCheck: true);
@@ -1295,6 +1366,7 @@ public sealed class AppController : IAsyncDisposable
         ViewModel.BoostGaugeColorNumber = Settings.BoostGaugeColorNumber;
         ViewModel.DigitalBoostGaugeColorNumber = Settings.DigitalBoostGaugeColorNumber;
         ViewModel.DigitalBoostGaugeStockColors = Settings.DigitalBoostGaugeStockColors;
+        ViewModel.ShowBoostVacuum = Settings.ShowBoostVacuum;
         ViewModel.UseBarBoostPressure = Settings.BoostPressureUnit == BoostPressureUnit.Bar;
         ViewModel.BoostGaugeScale = Settings.BoostGaugeScale;
         ViewModel.TireTemperatureGaugeEnabled = Settings.TireTemperatureGaugeEnabled;
@@ -1722,6 +1794,7 @@ public sealed class AppController : IAsyncDisposable
         _applicationUpdateLifetime.Cancel();
         _compatibilityUpdates.Dispose();
         _applicationUpdates.Dispose();
+        _applicationUpdateTimer.Stop();
         _uiTimer.Stop();
         SetCompositionRenderingEnabled(false);
         _manualOverlayHidden = false;

--- a/src/Wisp.App/AppSettings.cs
+++ b/src/Wisp.App/AppSettings.cs
@@ -61,6 +61,7 @@ public sealed class AppSettings
     public bool BoostGaugeColorNumber { get; set; }
     public bool DigitalBoostGaugeColorNumber { get; set; }
     public bool DigitalBoostGaugeStockColors { get; set; }
+    public bool ShowBoostVacuum { get; set; }
     public BoostPressureUnit BoostPressureUnit { get; set; } = BoostPressureUnit.Psi;
     public double BoostGaugeScale { get; set; } = 1.0;
     public bool TireTemperatureGaugeEnabled { get; set; } = true;

--- a/src/Wisp.App/ApplicationUpdateCheckPolicy.cs
+++ b/src/Wisp.App/ApplicationUpdateCheckPolicy.cs
@@ -3,11 +3,4 @@ namespace Wisp.App;
 internal static class ApplicationUpdateCheckPolicy
 {
     internal static readonly TimeSpan MinimumInterval = TimeSpan.FromHours(24);
-
-    internal static bool IsDue(
-        bool automaticChecksEnabled,
-        DateTimeOffset? lastCheckUtc,
-        DateTimeOffset nowUtc) =>
-        automaticChecksEnabled &&
-        (lastCheckUtc is null || nowUtc >= lastCheckUtc.Value + MinimumInterval);
 }

--- a/src/Wisp.App/BoostDisplayModel.cs
+++ b/src/Wisp.App/BoostDisplayModel.cs
@@ -5,7 +5,8 @@ public readonly record struct BoostDisplay(
     double PressurePsi,
     double LearnedPeakPsi,
     double Fraction,
-    double ScaleMaximumPsi)
+    double ScaleMaximumPsi,
+    double ScaleMinimumPsi = 0)
 {
     public static BoostDisplay Unavailable => new(false, 0, 0, 0, 70);
 }
@@ -18,7 +19,9 @@ public sealed class BoostDisplayModel
     private bool _forcedInduction;
     private double _peakPsi;
 
-    public BoostDisplay Calculate(int carOrdinal, bool isElectric, double pressurePsi)
+    internal bool HasDetectedBoost => _forcedInduction;
+
+    public BoostDisplay Calculate(int carOrdinal, bool isElectric, double pressurePsi, bool showVacuum = false)
     {
         if (carOrdinal != _carOrdinal)
         {
@@ -39,28 +42,29 @@ public sealed class BoostDisplayModel
             return BoostDisplay.Unavailable;
         }
 
-        // FH6 reports vacuum on forced-induction cars before they make positive
-        // boost. Accepting that first non-zero sample lets the gauge appear with
-        // the speedometer while a zero-only naturally aspirated car stays gated.
-        if (Math.Abs(pressurePsi) >= ActivityThresholdPsi)
+        // Vacuum alone does not identify forced induction. Require positive
+        // boost before retaining vacuum readings for this car/session.
+        if (pressurePsi >= ActivityThresholdPsi)
         {
             _forcedInduction = true;
         }
 
         if (!_forcedInduction)
         {
-            return BoostDisplay.Unavailable;
+            return new BoostDisplay(true, 0, 0, 0, GaugeMaximumPsi,
+                BoostPressureUnits.AnalogMinimum(BoostPressureUnit.Psi, showVacuum));
         }
 
-        var displayedPressure = Math.Max(0, pressurePsi);
-        _peakPsi = Math.Max(_peakPsi, displayedPressure);
+        var displayedPressure = showVacuum ? pressurePsi : Math.Max(0, pressurePsi);
+        _peakPsi = Math.Max(_peakPsi, Math.Max(0, pressurePsi));
         var denominator = Math.Max(_peakPsi, 5);
         return new BoostDisplay(
             true,
             displayedPressure,
             _peakPsi,
             Math.Clamp(displayedPressure / denominator, 0, 1),
-            GaugeMaximumPsi);
+            GaugeMaximumPsi,
+            BoostPressureUnits.AnalogMinimum(BoostPressureUnit.Psi, showVacuum));
     }
 
     public void Reset()

--- a/src/Wisp.App/BoostGaugeVisuals.cs
+++ b/src/Wisp.App/BoostGaugeVisuals.cs
@@ -46,6 +46,8 @@ public abstract class BoostVisualBase : Grid
 
     protected double DisplayPressure => BoostPressureUnits.FromPsi(Display.PressurePsi, PressureUnit);
 
+    protected bool ShowsVacuum => Display.ScaleMinimumPsi < 0;
+
     protected string PressureSymbol => BoostPressureUnits.Symbol(PressureUnit);
 
     protected Brush NumberBrush()
@@ -200,7 +202,9 @@ public sealed class DigitalBoostRailView : BoostVisualBase
         var trackBrush = new SolidColorBrush(Color.FromArgb(54, 236, 239, 244));
         var outline = new Pen(new SolidColorBrush(Color.FromArgb(168, 238, 241, 246)), 1.0);
 
-        var fraction = Math.Clamp(Display.Fraction, 0, 1);
+        var fraction = ShowsVacuum
+            ? BoostPressureUnits.GaugeFraction(Display.PressurePsi, PressureUnit, showVacuum: true)
+            : Math.Clamp(Display.Fraction, 0, 1);
         _stockGaugeMaterial.UpdateGaugeParameters(fraction, 1);
         _stockGaugeMaterial.Visibility = UseStockColors ? Visibility.Visible : Visibility.Collapsed;
 
@@ -241,6 +245,15 @@ public sealed class DigitalBoostRailView : BoostVisualBase
             }
 
             dc.DrawGeometry(null, outline, track);
+        }
+
+        if (ShowsVacuum)
+        {
+            var zero = leftTop + (rightTop - leftTop) *
+                BoostPressureUnits.GaugeFraction(0, PressureUnit, showVacuum: true);
+            var zeroPen = new Pen(Brushes.WhiteSmoke, 1);
+            dc.DrawLine(zeroPen, new Point(zero, top - 3), new Point(zero, top - 1));
+            dc.DrawLine(zeroPen, new Point(zero - endRake, bottom + 1), new Point(zero - endRake, bottom + 3));
         }
 
         // Float the connector symmetrically between the rails. Its -0.2 rake
@@ -290,7 +303,6 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
 {
     private const double StartAngle = 110;
     private const double SweepAngle = 260;
-    private const double MaximumPsi = 70;
     private readonly NativeAnalogNeedleVisual _needleMaterial;
     private readonly RotateTransform _needleRotation = new();
 
@@ -348,25 +360,26 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
         DrawArc(dc, center, radius, StartAngle, SweepAngle, trackPen);
 
         var maximum = BoostPressureUnits.AnalogMaximum(PressureUnit);
-        var gaugeFraction = Math.Clamp(DisplayPressure / maximum, 0, 1);
-        if (gaugeFraction > 0)
+        var minimum = BoostPressureUnits.AnalogMinimum(PressureUnit, ShowsVacuum);
+        var range = maximum - minimum;
+        var gaugeFraction = BoostPressureUnits.GaugeFraction(Display.PressurePsi, PressureUnit, ShowsVacuum);
+        var zeroFraction = BoostPressureUnits.GaugeFraction(0, PressureUnit, ShowsVacuum);
+        if (gaugeFraction != zeroFraction)
         {
-            var maximumPsi = BoostPressureUnits.AnalogMaximumPsi(PressureUnit);
-            DrawActiveArc(dc, center, radius, gaugeFraction, maximumPsi);
+            DrawActiveArc(dc, center, radius, gaugeFraction, zeroFraction, minimum, maximum);
         }
 
-        const double minimum = 0;
         var majorInterval = PressureUnit == BoostPressureUnit.Bar ? 1 : 10;
-        var minorInterval = majorInterval / 2;
-        var majorCount = (int)(maximum / majorInterval);
+        var minorInterval = majorInterval / 2d;
+        var majorCount = (int)(range / majorInterval);
         for (var index = 0; index <= majorCount; index++)
         {
             var pressure = minimum + index * majorInterval;
-            var angle = StartAngle + SweepAngle * (pressure / maximum);
+            var angle = StartAngle + SweepAngle * ((pressure - minimum) / range);
             DrawTick(dc, center, radius, angle, 7, 1.4, pressure.ToString("0", CultureInfo.InvariantCulture));
             if (index < majorCount)
             {
-                DrawTick(dc, center, radius, angle + SweepAngle * (minorInterval / maximum), 3.5, 0.8, null);
+                DrawTick(dc, center, radius, angle + SweepAngle * (minorInterval / range), 3.5, 0.8, null);
             }
         }
 
@@ -388,17 +401,22 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
         Point center,
         double radius,
         double gaugeFraction,
-        double maximumPsi)
+        double zeroFraction,
+        double minimum,
+        double maximum)
     {
-        var segmentCount = Math.Max(1, (int)Math.Ceiling(SweepAngle * gaugeFraction / 3));
+        var arcStart = Math.Min(gaugeFraction, zeroFraction);
+        var arcLength = Math.Abs(gaugeFraction - zeroFraction);
+        var segmentCount = Math.Max(1, (int)Math.Ceiling(SweepAngle * arcLength / 3));
         var learnedScale = Math.Max(Display.LearnedPeakPsi, 5);
         for (var index = 0; index < segmentCount; index++)
         {
-            var startFraction = gaugeFraction * index / segmentCount;
-            var endFraction = gaugeFraction * (index + 1) / segmentCount;
+            var startFraction = arcStart + arcLength * index / segmentCount;
+            var endFraction = arcStart + arcLength * (index + 1) / segmentCount;
             var start = StartAngle + (SweepAngle * startFraction);
             var sweep = (SweepAngle * (endFraction - startFraction)) + 0.35;
-            var pressure = maximumPsi * endFraction;
+            var pressure = minimum + (maximum - minimum) * endFraction;
+            if (PressureUnit == BoostPressureUnit.Bar) pressure *= BoostPressureUnits.PsiPerBar;
             var colorFraction = Math.Clamp(pressure / learnedScale, 0, 1);
             var arc = ArcGeometry(center, radius, start, sweep);
             dc.DrawGeometry(null, new Pen(new SolidColorBrush(PaletteColor(colorFraction, 58)), 8), arc);
@@ -420,20 +438,20 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
 
     private void DrawNativeBoostDigits(DrawingContext dc, Point center)
     {
-        var digits = PressureUnit == BoostPressureUnit.Bar
-            ? Math.Clamp(DisplayPressure, 0, 5).ToString("0.0", CultureInfo.InvariantCulture)
-            : Math.Clamp(
-                    (int)Math.Round(DisplayPressure, MidpointRounding.AwayFromZero),
-                    0,
-                    (int)MaximumPsi)
-                .ToString("00", CultureInfo.InvariantCulture);
+        var pressure = ShowsVacuum
+            ? Display.PressurePsi
+            : Math.Clamp(Display.PressurePsi, 0, BoostPressureUnits.AnalogMaximumPsi(PressureUnit));
+        var digits = BoostPressureUnits.FormatValue(pressure, PressureUnit, padPsi: true);
         var tint = NumberColor();
         const double height = 28;
         const double width = 18;
         const double dotWidth = 4;
+        const double minusWidth = 8;
         const double gap = -1;
-        var totalWidth = digits.Sum(character => character == '.' ? dotWidth : width) +
+        var totalWidth = digits.Sum(character => character == '.' ? dotWidth : character == '-' ? minusWidth : width) +
                          gap * (digits.Length - 1);
+        var scale = Math.Min(1, 44 / totalWidth);
+        if (scale < 1) dc.PushTransform(new ScaleTransform(scale, scale, center.X, center.Y));
         var left = center.X - totalWidth / 2;
         foreach (var digit in digits)
         {
@@ -444,6 +462,13 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
                 left += dotWidth + gap;
                 continue;
             }
+            if (digit == '-')
+            {
+                dc.DrawLine(new Pen(new SolidColorBrush(tint), 2),
+                    new Point(left + 1, center.Y), new Point(left + minusWidth - 1, center.Y));
+                left += minusWidth + gap;
+                continue;
+            }
             var image = NativeAssetCache.GetTinted(
                 NativeGaugeMode.Analogue,
                 $"HUD_Dial_Speed_Analogue_{digit}.png",
@@ -451,6 +476,7 @@ public sealed class AnalogBoostGaugeView : BoostVisualBase
             dc.DrawImage(image, new Rect(left, center.Y - height / 2, width, height));
             left += width + gap;
         }
+        if (scale < 1) dc.Pop();
     }
 
     private void DrawTick(DrawingContext dc, Point center, double radius, double angle,

--- a/src/Wisp.App/BoostPressureUnits.cs
+++ b/src/Wisp.App/BoostPressureUnits.cs
@@ -12,13 +12,28 @@ public static class BoostPressureUnits
     public static string Symbol(BoostPressureUnit unit) =>
         unit == BoostPressureUnit.Bar ? "BAR" : "PSI";
 
-    public static string FormatValue(double pressurePsi, BoostPressureUnit unit) =>
-        FromPsi(pressurePsi, unit).ToString(
-            unit == BoostPressureUnit.Bar ? "0.0" : "0",
+    public static string FormatValue(double pressurePsi, BoostPressureUnit unit, bool padPsi = false)
+    {
+        var pressure = FromPsi(pressurePsi, unit);
+        var value = pressure.ToString(
+            unit == BoostPressureUnit.Bar ? "0.0" : padPsi && pressure >= 0 ? "00" : "0",
             CultureInfo.InvariantCulture);
+        return value is "-0" or "-0.0"
+            ? unit == BoostPressureUnit.Bar ? "0.0" : padPsi ? "00" : "0"
+            : value;
+    }
 
     public static double AnalogMaximum(BoostPressureUnit unit) =>
         unit == BoostPressureUnit.Bar ? 5 : 70;
+
+    public static double AnalogMinimum(BoostPressureUnit unit, bool showVacuum) =>
+        showVacuum ? (unit == BoostPressureUnit.Bar ? -1 : -20) : 0;
+
+    public static double GaugeFraction(double pressurePsi, BoostPressureUnit unit, bool showVacuum)
+    {
+        var minimum = AnalogMinimum(unit, showVacuum);
+        return Math.Clamp((FromPsi(pressurePsi, unit) - minimum) / (AnalogMaximum(unit) - minimum), 0, 1);
+    }
 
     public static double AnalogMaximumPsi(BoostPressureUnit unit) =>
         unit == BoostPressureUnit.Bar ? AnalogMaximum(unit) * PsiPerBar : AnalogMaximum(unit);

--- a/src/Wisp.App/DiagnosticsViewModel.cs
+++ b/src/Wisp.App/DiagnosticsViewModel.cs
@@ -65,6 +65,8 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     private bool _boostGaugeColorNumber;
     private bool _digitalBoostGaugeColorNumber;
     private bool _digitalBoostGaugeStockColors;
+    private bool _showBoostVacuum;
+    private double _lastBoostPressurePsi;
     private bool _useBarBoostPressure;
     private double _boostGaugeScale;
     private BoostDisplay _boostDisplay = BoostDisplay.Unavailable;
@@ -104,7 +106,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     private string _dashboardPeakPower = "—";
     private string _dashboardPeakTorque = "—";
     private string _dashboardTopSpeed = "—";
-    private string _applicationUpdateStatus = "Wisp checks for updates once daily. Downloads always require confirmation.";
+    private string _applicationUpdateStatus = "Wisp checks for updates on open and every 24 hours. Downloads always require confirmation.";
     private string _applicationUpdateAction = "Check for updates";
     private bool _canCheckApplicationUpdate = true;
     private bool _isApplicationUpdateAvailable;
@@ -127,6 +129,7 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         _boostGaugeColorNumber = settings.BoostGaugeColorNumber;
         _digitalBoostGaugeColorNumber = settings.DigitalBoostGaugeColorNumber;
         _digitalBoostGaugeStockColors = settings.DigitalBoostGaugeStockColors;
+        _showBoostVacuum = settings.ShowBoostVacuum;
         _useBarBoostPressure = settings.BoostPressureUnit == BoostPressureUnit.Bar;
         _boostGaugeScale = settings.BoostGaugeScale;
         _tireTemperatureGaugeEnabled = settings.TireTemperatureGaugeEnabled;
@@ -305,7 +308,10 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         : HudPreviewSample.Caption;
     public BoostDisplay PreviewBoostDisplay => BoostDisplay.IsAvailable
         ? BoostDisplay
-        : HudPreviewSample.Boost;
+        : HudPreviewSample.Boost with
+        {
+            ScaleMinimumPsi = BoostPressureUnits.AnalogMinimum(BoostPressureUnit.Psi, ShowBoostVacuum)
+        };
     public TireTemperatureDisplay PreviewTireTemperatureDisplay => TireTemperatureDisplay.IsAvailable
         ? TireTemperatureDisplay
         : HudPreviewSample.TireTemperature;
@@ -479,6 +485,28 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     public bool BoostGaugeColorNumber { get => _boostGaugeColorNumber; set => Set(ref _boostGaugeColorNumber, value); }
     public bool DigitalBoostGaugeColorNumber { get => _digitalBoostGaugeColorNumber; set => Set(ref _digitalBoostGaugeColorNumber, value); }
     public bool DigitalBoostGaugeStockColors { get => _digitalBoostGaugeStockColors; set => Set(ref _digitalBoostGaugeStockColors, value); }
+    public bool ShowBoostVacuum
+    {
+        get => _showBoostVacuum;
+        set
+        {
+            if (!Set(ref _showBoostVacuum, value)) return;
+            if (BoostDisplay.IsAvailable)
+            {
+                BoostDisplay = BoostDisplay with
+                {
+                    PressurePsi = _boostDisplayModel.HasDetectedBoost
+                        ? value ? _lastBoostPressurePsi : Math.Max(0, _lastBoostPressurePsi)
+                        : 0,
+                    ScaleMinimumPsi = BoostPressureUnits.AnalogMinimum(BoostPressureUnit.Psi, value)
+                };
+            }
+            else
+            {
+                OnPropertyChanged(nameof(PreviewBoostDisplay));
+            }
+        }
+    }
     public bool UseBarBoostPressure
     {
         get => _useBarBoostPressure;
@@ -699,10 +727,12 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         HudSpeed = speed.IsAvailable
             ? displayedSpeed.ToString(CultureInfo.InvariantCulture)
             : "—";
+        _lastBoostPressurePsi = state.BoostPressurePsi;
         BoostDisplay = _boostDisplayModel.Calculate(
             state.CarOrdinal,
             state.IsElectric,
-            state.BoostPressurePsi);
+            state.BoostPressurePsi,
+            ShowBoostVacuum);
         TireTemperatureDisplay = _tireTemperatureDisplayModel.Calculate(
             state.CarOrdinal,
             state.TireTemperatureFahrenheit);

--- a/src/Wisp.App/HudPreset.cs
+++ b/src/Wisp.App/HudPreset.cs
@@ -29,6 +29,7 @@ public sealed class HudPreset
     public bool BoostGaugeColorNumber { get; set; }
     public bool DigitalBoostGaugeColorNumber { get; set; }
     public bool DigitalBoostGaugeStockColors { get; set; }
+    public bool ShowBoostVacuum { get; set; }
     public BoostPressureUnit BoostPressureUnit { get; set; } = Wisp.App.BoostPressureUnit.Psi;
     public double BoostGaugeScale { get; set; } = 1;
     public bool TireTemperatureGaugeEnabled { get; set; } = true;
@@ -91,6 +92,7 @@ public sealed class HudPreset
             BoostGaugeColorNumber = settings.BoostGaugeColorNumber,
             DigitalBoostGaugeColorNumber = settings.DigitalBoostGaugeColorNumber,
             DigitalBoostGaugeStockColors = settings.DigitalBoostGaugeStockColors,
+            ShowBoostVacuum = settings.ShowBoostVacuum,
             BoostPressureUnit = settings.BoostPressureUnit,
             BoostGaugeScale = settings.BoostGaugeScale,
             TireTemperatureGaugeEnabled = settings.TireTemperatureGaugeEnabled,
@@ -136,6 +138,7 @@ public sealed class HudPreset
         settings.BoostGaugeColorNumber = BoostGaugeColorNumber;
         settings.DigitalBoostGaugeColorNumber = DigitalBoostGaugeColorNumber;
         settings.DigitalBoostGaugeStockColors = DigitalBoostGaugeStockColors;
+        settings.ShowBoostVacuum = ShowBoostVacuum;
         settings.BoostPressureUnit = BoostPressureUnit;
         settings.BoostGaugeScale = BoostGaugeScale;
         settings.TireTemperatureGaugeEnabled = TireTemperatureGaugeEnabled;

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -840,6 +840,14 @@
                                                           AutomationProperties.Name="Use the stock tachometer material on the digital boost rail"
                                                           Style="{StaticResource ToggleSwitchStyle}" Margin="0,14,0,0"
                                                           Checked="Option_Changed" Unchecked="Option_Changed" />
+                                                <CheckBox Content="Show vacuum pressure"
+                                                          IsChecked="{Binding ShowBoostVacuum}"
+                                                          AutomationProperties.Name="Show vacuum pressure"
+                                                          Style="{StaticResource ToggleSwitchStyle}" Margin="0,14,0,0"
+                                                          Checked="Option_Changed" Unchecked="Option_Changed" />
+                                                <TextBlock Text="Show vacuum at idle and cruise after positive boost is detected."
+                                                           TextWrapping="Wrap" Foreground="{DynamicResource FaintBrush}"
+                                                           FontSize="11" Margin="54,4,0,0" />
                                                 <CheckBox Content="Display boost pressure in bar"
                                                           IsChecked="{Binding UseBarBoostPressure}"
                                                           AutomationProperties.Name="Display boost pressure in bar"
@@ -1646,12 +1654,12 @@
                                                 <TextBlock Text="Immutable GitHub release assets are checked for an exact version, size, and SHA-256 match before installation."
                                                            Foreground="{DynamicResource FaintBrush}" FontSize="11" LineHeight="16"
                                                            TextWrapping="Wrap" Margin="0,8,0,0" />
-                                                <CheckBox Content="Automatically check once daily"
+                                                <CheckBox Content="Automatically check on open and daily"
                                                           IsChecked="{Binding AutomaticApplicationUpdateChecks}"
                                                           Style="{StaticResource ToggleSwitchStyle}"
                                                           Checked="Option_Changed" Unchecked="Option_Changed"
                                                           Margin="0,16,0,0"
-                                                          AutomationProperties.Name="Automatically check for Wisp updates once daily" />
+                                                          AutomationProperties.Name="Automatically check for Wisp updates on open and every 24 hours" />
                                             </StackPanel>
                                             <StackPanel Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center">
                                                 <Border Background="{DynamicResource RaisedBrush}" CornerRadius="6" Padding="9,4"

--- a/src/Wisp.App/NativeCompatibility/fh6-store-3.440.853.0.json
+++ b/src/Wisp.App/NativeCompatibility/fh6-store-3.440.853.0.json
@@ -1,0 +1,233 @@
+{
+  "schemaVersion": 4,
+  "readerVersion": 4,
+  "id": "fh6-store-3.440.853.0-x64",
+  "revision": 1,
+  "gameVersion": "3.440.853.0",
+  "imageSize": 188420096,
+  "sourceVectorRva": 176851648,
+  "thresholdRva": 104664348,
+  "leadVtableRva": 113373952,
+  "expectedThresholdBits": 1036831949,
+  "fields": {
+    "sourceProvider": 30528,
+    "sourceCarOrdinal": 29708,
+    "providerRpm": 432,
+    "providerSimRedlineAngularVelocity": 584,
+    "providerTachometerMaximumAngularVelocity": 588,
+    "localPlayerFlag": 5220,
+    "localPlayerProviderFlag": 49968,
+    "stmState": 5168,
+    "absState": 5172,
+    "stmAvailable": 6068,
+    "tcrAvailable": 6069,
+    "absAvailable": 6070,
+    "lcAvailable": 6071,
+    "lcPrimary": 5356,
+    "lcMode": 8060,
+    "lcSecondary": 49696,
+    "tcrSecondary": 49696,
+    "tcrPrimary": 49700,
+    "tcrTertiary": 49704,
+    "tcrWheelValues": 49864,
+    "firstWheelPointer": 2976,
+    "secondWheelPointer": 2984,
+    "thirdWheelPointer": 2992,
+    "wheelId": 1440
+  },
+  "gameplayVisibility": {
+    "uiServiceRva": 177040344,
+    "uiServiceVtableRva": 113302872,
+    "dependencyVtableRva": 113223016,
+    "transitionManagerVtableRva": 113222904,
+    "hudPageVtableRva": 117837272,
+    "serviceDependencyOffset": 160,
+    "rootTransitionManagerOffset": 56,
+    "managerOwnerOffset": 192,
+    "managerCurrentPageOffset": 144,
+    "managerStateOffset": 104,
+    "pageTransitionManagerOffset": 656,
+    "pageUiVisibleOffset": 964
+  },
+  "nativeGauge": {
+    "registryGlobalRva": 176679640,
+    "registryKeyHash": 14601433220641418792,
+    "registryWrapperVtableRva": 111340336,
+    "registryContextVtableRva": 115232096,
+    "registryContextControlVtableRva": 111343480,
+    "registryContextOffset": 8,
+    "registryContextControlOffset": 16,
+    "registrySentinelOffset": 504,
+    "registryCountOffset": 512,
+    "registryBucketsOffset": 520,
+    "registryBucketsEndOffset": 528,
+    "registryBucketsCapacityOffset": 536,
+    "registryMaskOffset": 544,
+    "registryBucketCountOffset": 552,
+    "registryBucketStride": 16,
+    "registryBucketBoundaryOffset": 0,
+    "registryBucketNodeOffset": 8,
+    "registryNodeNextOffset": 8,
+    "registryNodeHashOffset": 16,
+    "registryNodeObjectOffset": 24,
+    "registryNodeControlOffset": 32,
+    "sharedControlObjectOffset": 16,
+    "hudVtableRva": 115268056,
+    "hudControlVtableRva": 110129712,
+    "hudSubobjectOffset": 48,
+    "hudSubobjectPointerOffset": 304,
+    "hudSubobjectVtableRva": 115268136,
+    "hudSubobjectSlotZeroTargetRva": 10957008,
+    "hudSubobjectSlotZeroPrologueHex": "488D4170C3",
+    "hudTypeVectorOffset": 112,
+    "hudTypeVectorMaximumCount": 64,
+    "hudTypeVectorBeginOffset": 0,
+    "hudTypeVectorEndOffset": 8,
+    "hudTypeVectorCapacityOffset": 16,
+    "hudTypeVectorEntryStride": 32,
+    "hudTypeTokenRva": 179254232,
+    "hudTypeTokenOffset": 0,
+    "hudTypeInstancesBeginOffset": 8,
+    "hudTypeInstancesEndOffset": 16,
+    "hudTypeInstancesCapacityOffset": 24,
+    "hudTypeInstanceCount": 1,
+    "hudTypeInstanceStride": 16,
+    "hudTypeInstanceObjectOffset": 0,
+    "hudTypeInstanceControlOffset": 8,
+    "outerControlVtableRva": 115250312,
+    "outerPrimaryVtableRva": 117049464,
+    "outerSecondaryVtableRva": 117049752,
+    "outerSecondaryOffset": 8,
+    "outerHudBackReferenceOffset": 16,
+    "outerHudControlBackReferenceOffset": 24,
+    "outerChildOffset": 56,
+    "outerSourceOffset": 64,
+    "outerPowerFillOffset": 112,
+    "outerRegenFillOffset": 136,
+    "childlessRegenPowerRatioBits": 1050253722,
+    "childVtableRva": 114153128,
+    "childModeOffset": 228,
+    "childAngleOffset": 244,
+    "childBlurOffset": 248,
+    "childSpeedDigitOneOffset": 252,
+    "childSpeedDigitTenOffset": 256,
+    "childSpeedDigitHundredOffset": 260,
+    "childSpeedLessOrEqualOneOffset": 264,
+    "childSpeedLessTenOffset": 265,
+    "childSpeedLessHundredOffset": 266,
+    "childHeadlightsOnOffset": 268,
+    "childGearOffset": 272,
+    "childGearPreviousOffset": 276,
+    "childGearNextOffset": 280,
+    "childRegenOffset": 304,
+    "childPowerOffset": 308,
+    "childGearGaugeStateOffset": 312,
+    "childUseDriveFor1Offset": 316,
+    "childRatioOffset": 320,
+    "childSpeedUnitObjectOffset": 360,
+    "childMaximumTachometerOffset": 368,
+    "childElectricMaximumSpeedOffset": 392,
+    "speedUnitEnumOffset": 4,
+    "speedUnitMphValue": 22,
+    "speedUnitKphValue": 23,
+    "providerPowerLimitFirstOffset": 9136,
+    "providerPowerLimitSecondOffset": 9148,
+    "providerPowerNumeratorOffset": 504,
+    "providerPowerDenominatorOffset": 2696,
+    "providerRegenTargetOffset": 5160,
+    "providerPowerDenominatorScaleBits": 1008981770,
+    "providerRegenScaleBits": 3214934016,
+    "providerRegenUpperBaseBits": 1048576000,
+    "providerElectricSpeedOffset": 5356,
+    "requiredProviderVtableSlots": [
+      {
+        "offset": 664,
+        "targetRva": 51557296
+      },
+      {
+        "offset": 856,
+        "targetRva": 51568160
+      },
+      {
+        "offset": 1464,
+        "targetRva": 51583120
+      },
+      {
+        "offset": 1824,
+        "targetRva": 51567664
+      },
+      {
+        "offset": 1944,
+        "targetRva": 51577360
+      },
+      {
+        "offset": 3624,
+        "targetRva": 51582880
+      }
+    ]
+  },
+  "requiredVtableSlots": [
+    {
+      "offset": 528,
+      "targetRva": 51568208
+    },
+    {
+      "offset": 680,
+      "targetRva": 51586896
+    },
+    {
+      "offset": 688,
+      "targetRva": 51583200
+    },
+    {
+      "offset": 696,
+      "targetRva": 51556368
+    },
+    {
+      "offset": 1664,
+      "targetRva": 51568192
+    },
+    {
+      "offset": 4184,
+      "targetRva": 51585376
+    },
+    {
+      "offset": 4192,
+      "targetRva": 51554448
+    },
+    {
+      "offset": 4200,
+      "targetRva": 51570256
+    },
+    {
+      "offset": 4216,
+      "targetRva": 51570400
+    }
+  ],
+  "storeIdentity": {
+    "packageFullName": "Microsoft.ForteBaseGame_3.440.853.0_x64__8wekyb3d8bbwe",
+    "timeDateStamp": 1788432457,
+    "codeGuards": [
+      {
+        "rva": 102985910,
+        "length": 75,
+        "sha256": "100B1A4FFB835FFBA5DAEB52FDCD79C0C8C4A9ECBD623BB273470769EDBDB4D7"
+      },
+      {
+        "rva": 22556256,
+        "length": 66,
+        "sha256": "F74FA91DA7206766C6444DBADA2604C3E1EF19FDCF9D55F935BFAF6FEED7867F"
+      },
+      {
+        "rva": 5698062,
+        "length": 126,
+        "sha256": "994D51581128BEFD019656150934D66FF8678132D8F078F70E79B3E9DCBDF328"
+      },
+      {
+        "rva": 50267711,
+        "length": 67,
+        "sha256": "96B6ED2BB5106F084603288896D88BC2E758BF29F858FCAEA4725E356DDAA4FE"
+      }
+    ]
+  }
+}

--- a/src/Wisp.App/NativeHudBuildContract.cs
+++ b/src/Wisp.App/NativeHudBuildContract.cs
@@ -9,8 +9,9 @@ public static class NativeHudBuildContract
     public static NativeHudCompatibilityPack BuiltIn { get; } = LoadBuiltIn();
     internal static NativeHudCompatibilityPack PreviousSteamBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.PreviousSteam.json");
     internal static NativeHudCompatibilityPack StoreBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.Store.json");
+    internal static NativeHudCompatibilityPack PreviousStoreBuiltIn { get; } = LoadBuiltIn("Wisp.NativeCompatibility.PreviousStore.json");
     internal static IReadOnlyList<NativeHudCompatibilityPack> AdditionalBuiltIns { get; } =
-        Array.AsReadOnly(new[] { PreviousSteamBuiltIn, StoreBuiltIn });
+        Array.AsReadOnly(new[] { PreviousSteamBuiltIn, StoreBuiltIn, PreviousStoreBuiltIn });
 
     public static string SupportedVersion => BuiltIn.GameVersion;
     public static long SupportedExecutableLength => BuiltIn.ExecutableLength;

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,31 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.1.3",
+            "September 8, 2026",
+            "COMPATIBILITY HOTFIX",
+            "Xbox app / Microsoft Store FH6 3.440.853.0 support, optional boost vacuum pressure, and reliable automatic update checks.",
+            true,
+            [
+                Group("Compatibility",
+                    "Adds a reviewed Native HUD map for Xbox app / Microsoft Store FH6 3.440.853.0 on Windows PC, retaining Store 3.430.771.0 and existing Steam maps.",
+                    "Retains signed compatibility-map updates introduced in 1.1.2, with exact identity checks, atomic installation, and offline reuse. Future reviewed maps within the supported reader can be delivered without reinstalling Wisp; changed native layouts may still require an application update."),
+                Group("Boost gauges",
+                    "Adds Show vacuum pressure in Appearance > Boost. It displays negative pressure reported by FH6 and is off by default.",
+                    "The existing boost-gauge toggle can show a stationary zero gauge on naturally aspirated cars, so you can leave it enabled without knowing a tune's induction setup. Electric vehicles never show the gauge.",
+                    "Requires positive boost before enabling pressure readings for a car. After detection, the vacuum option follows negative pressure at idle and cruise.",
+                    "Supports PSI and bar in attached and detached Digital and Analogue gauges and the Appearance preview. Enabled scales run from -20 to 70 PSI or -1 to 5 bar, with a zero marker on the Digital rail.",
+                    "Saves the option with settings and HUD profiles. Existing settings and profiles leave vacuum disabled."),
+                Group("Application updates",
+                    "Checks for updates whenever Wisp opens and every 24 hours while it remains running, including while waiting in the tray, when automatic checks are enabled.",
+                    "Keeps an available-update banner visible if a later automatic refresh fails. Downloads and installation still require confirmation.")
+            ]),
+        new(
             "1.1.2",
             "September 7, 2026",
             "COMPATIBILITY HOTFIX",
             "Support for Steam FH6 6.440.853.0 and signed compatibility updates for future reviewed builds.",
-            true,
+            false,
             [
                 Group("Compatibility",
                     "Adds a separate Native HUD map for Steam FH6 build 6.440.853.0, retaining Steam 6.430.771.0 and Xbox app / Microsoft Store 3.430.771.0 support.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.1.2</Version>
-    <FileVersion>1.1.2.0</FileVersion>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <Version>1.1.3</Version>
+    <FileVersion>1.1.3.0</FileVersion>
+    <AssemblyVersion>1.1.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />
@@ -25,7 +25,8 @@
     <Resource Include="Assets\Native\**\*.png" />
     <EmbeddedResource Include="NativeCompatibility\fh6-6.440.853.0.json" LogicalName="Wisp.NativeCompatibility.BuiltIn.json" />
     <EmbeddedResource Include="NativeCompatibility\fh6-6.430.771.0.json" LogicalName="Wisp.NativeCompatibility.PreviousSteam.json" />
-    <EmbeddedResource Include="NativeCompatibility\fh6-store-3.430.771.0.json" LogicalName="Wisp.NativeCompatibility.Store.json" />
+    <EmbeddedResource Include="NativeCompatibility\fh6-store-3.440.853.0.json" LogicalName="Wisp.NativeCompatibility.Store.json" />
+    <EmbeddedResource Include="NativeCompatibility\fh6-store-3.430.771.0.json" LogicalName="Wisp.NativeCompatibility.PreviousStore.json" />
     <Resource Include="Shaders\*.ps" />
     <None Include="Shaders\*.hlsl" />
     <Content Include="Assets\Native\ASSET-MANIFEST.csv" CopyToOutputDirectory="PreserveNewest" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.1.2.0" name="Wisp.App" />
+  <assemblyIdentity version="1.1.3.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.1.2</Version>
-    <FileVersion>1.1.2.0</FileVersion>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
+    <Version>1.1.3</Version>
+    <FileVersion>1.1.3.0</FileVersion>
+    <AssemblyVersion>1.1.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/AppControllerOptionsTests.cs
+++ b/tests/Wisp.App.Tests/AppControllerOptionsTests.cs
@@ -99,6 +99,7 @@ public sealed class AppControllerOptionsTests
                 controller.ViewModel.BoostGaugeColorNumber = true;
                 controller.ViewModel.DigitalBoostGaugeColorNumber = true;
                 controller.ViewModel.DigitalBoostGaugeStockColors = true;
+                controller.ViewModel.ShowBoostVacuum = true;
                 controller.ViewModel.UseBarBoostPressure = true;
                 controller.ViewModel.TireTemperatureGaugeEnabled = false;
                 controller.ViewModel.TireTemperatureGaugeAttached = false;
@@ -133,6 +134,7 @@ public sealed class AppControllerOptionsTests
                 Assert.True(settings.BoostGaugeColorNumber);
                 Assert.True(settings.DigitalBoostGaugeColorNumber);
                 Assert.True(settings.DigitalBoostGaugeStockColors);
+                Assert.True(settings.ShowBoostVacuum);
                 Assert.Equal(BoostPressureUnit.Bar, settings.BoostPressureUnit);
                 Assert.False(settings.TireTemperatureGaugeEnabled);
                 Assert.False(settings.TireTemperatureGaugeAttached);

--- a/tests/Wisp.App.Tests/ApplicationUpdateCheckPolicyTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationUpdateCheckPolicyTests.cs
@@ -1,32 +1,336 @@
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using Wisp.Update;
 using Xunit;
 
 namespace Wisp.App.Tests;
 
 public sealed class ApplicationUpdateCheckPolicyTests
 {
-    private static readonly DateTimeOffset Now = new(2026, 9, 4, 12, 0, 0, TimeSpan.Zero);
-
-    [Fact]
-    public void DisabledAutomaticChecksNeverRun()
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(24)]
+    public async Task EveryOpenChecksDespiteRecentOrFuturePersistedTimestamp(int previousCheckHours)
     {
-        Assert.False(ApplicationUpdateCheckPolicy.IsDue(false, null, Now));
+        var settings = CompletedSettings();
+        settings.LastApplicationUpdateCheckUtc = DateTimeOffset.UtcNow.AddHours(previousCheckHours);
+        var checks = 0;
+        await using var controller = Controller(settings, (_, _) => { checks++; return Task.FromResult<UpdateRelease?>(null); });
+        controller.BeginStartupApplicationUpdateCheck();
+        Assert.Equal(1, checks);
+        controller.BeginStartupApplicationUpdateCheck();
+        Assert.Equal(2, checks);
+        Assert.True(Timer(controller).IsEnabled);
+        Assert.Equal(TimeSpan.FromHours(24), Timer(controller).Interval);
     }
 
     [Fact]
-    public void FirstAutomaticCheckRuns()
+    public async Task DailyTimerSurvivesCompanionSuspensionWithoutStartingTelemetry()
     {
-        Assert.True(ApplicationUpdateCheckPolicy.IsDue(true, null, Now));
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => { checks++; return Task.FromResult<UpdateRelease?>(null); });
+        controller.BeginStartupApplicationUpdateCheck();
+        await controller.SuspendForForzaAsync();
+        Assert.True(Timer(controller).IsEnabled);
+        FireDailyTimer(controller);
+        Assert.Equal(2, checks);
+        Assert.True(Timer(controller).IsEnabled);
+        Assert.False(controller.SetupTelemetry.IsRunning);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task DisabledChecksOrIncompleteSetupDoNotScheduleRequests(bool enabled, bool setupComplete)
+    {
+        var settings = setupComplete ? CompletedSettings() : new AppSettings();
+        settings.AutomaticApplicationUpdateChecks = enabled;
+        var checks = 0;
+        await using var controller = Controller(settings, (_, _) => { checks++; return Task.FromResult<UpdateRelease?>(null); });
+        controller.BeginStartupApplicationUpdateCheck();
+        FireDailyTimer(controller);
+        Assert.Equal(0, checks);
+        Assert.False(Timer(controller).IsEnabled);
     }
 
     [Fact]
-    public void CheckInsideDailyWindowDoesNotRun()
+    public async Task DisableReenableAndDisposeControlTheTimerAndRequests()
     {
-        Assert.False(ApplicationUpdateCheckPolicy.IsDue(true, Now.AddHours(-23), Now));
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => { checks++; return Task.FromResult<UpdateRelease?>(null); });
+        controller.BeginStartupApplicationUpdateCheck();
+        controller.ViewModel.AutomaticApplicationUpdateChecks = false;
+        controller.ApplyViewOptions();
+        FireDailyTimer(controller);
+        Assert.Equal(1, checks);
+        Assert.False(Timer(controller).IsEnabled);
+        controller.ViewModel.AutomaticApplicationUpdateChecks = true;
+        controller.ApplyViewOptions();
+        Assert.Equal(2, checks);
+        Assert.True(Timer(controller).IsEnabled);
+        await controller.DisposeAsync();
+        controller.BeginStartupApplicationUpdateCheck();
+        FireDailyTimer(controller);
+        Assert.Equal(2, checks);
+        Assert.False(Timer(controller).IsEnabled);
     }
 
     [Fact]
-    public void CheckRunsWhenDailyWindowExpires()
+    public async Task OverlappingOpensAndTimerRequestsDoNotDuplicateTheCheck()
     {
-        Assert.True(ApplicationUpdateCheckPolicy.IsDue(true, Now.AddHours(-24), Now));
+        var response = new TaskCompletionSource<UpdateRelease?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => { checks++; return response.Task; });
+        controller.BeginStartupApplicationUpdateCheck();
+        controller.BeginStartupApplicationUpdateCheck();
+        FireDailyTimer(controller);
+        Assert.Equal(1, checks);
+        Assert.False(controller.ViewModel.CanCheckApplicationUpdate);
+        response.SetResult(Release());
+        await WaitForCheckAsync(controller);
+        Assert.True(controller.ViewModel.IsApplicationUpdateAvailable);
+    }
+
+    [Theory]
+    [InlineData("http")]
+    [InlineData("timeout")]
+    [InlineData("verification")]
+    public async Task AutomaticRefreshFailureKeepsTheKnownRelease(string failure)
+    {
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => ++checks == 1
+            ? Task.FromResult<UpdateRelease?>(Release()) : Task.FromException<UpdateRelease?>(Failure(failure)));
+        controller.BeginStartupApplicationUpdateCheck();
+        FireDailyTimer(controller);
+        Assert.Equal(2, checks);
+        Assert.True(controller.ViewModel.IsApplicationUpdateAvailable);
+        Assert.True(controller.ViewModel.CanCheckApplicationUpdate);
+        Assert.Equal("Update", controller.ViewModel.ApplicationUpdateAction);
+        Assert.Equal("1.2.3", (await controller.GetAvailableApplicationUpdateDetailsAsync())!.Version);
+        Assert.Equal(2, checks);
+    }
+
+    [Fact]
+    public async Task AutomaticRefreshKeepsBannerWhilePendingAndClearsOnlyAfterVerifiedNoUpdate()
+    {
+        var response = new TaskCompletionSource<UpdateRelease?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => ++checks == 1
+            ? Task.FromResult<UpdateRelease?>(Release()) : response.Task);
+        controller.BeginStartupApplicationUpdateCheck();
+        FireDailyTimer(controller);
+        Assert.True(controller.ViewModel.IsApplicationUpdateAvailable);
+        Assert.False(controller.ViewModel.CanCheckApplicationUpdate);
+        response.SetResult(null);
+        await WaitForCheckAsync(controller);
+        Assert.False(controller.ViewModel.IsApplicationUpdateAvailable);
+    }
+
+    [Fact]
+    public async Task DisablingAutomaticChecksDuringFailureKeepsTheDisabledStatus()
+    {
+        var response = new TaskCompletionSource<UpdateRelease?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var controller = Controller(CompletedSettings(), (_, _) => response.Task);
+        controller.BeginStartupApplicationUpdateCheck();
+        controller.ViewModel.AutomaticApplicationUpdateChecks = false;
+        controller.ApplyViewOptions();
+        response.SetException(new HttpRequestException());
+        await WaitForCheckAsync(controller);
+        Assert.False(Timer(controller).IsEnabled);
+        Assert.Contains("Automatic update checks are off", controller.ViewModel.ApplicationUpdateStatus);
+        Assert.DoesNotContain("enabled", controller.ViewModel.ApplicationUpdateStatus);
+    }
+
+    [Theory]
+    [InlineData("http")]
+    [InlineData("timeout")]
+    [InlineData("verification")]
+    [InlineData("newer")]
+    [InlineData("current")]
+    public async Task AutomaticRefreshPreservesStagedInstallerVersionActionAndConfirmation(string outcome)
+    {
+        using var staged = new StagedInstallerFixture();
+        var response = new TaskCompletionSource<UpdateRelease?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var checks = 0;
+        await using var controller = Controller(CompletedSettings(), (_, _) => { checks++; return response.Task; });
+        staged.Attach(controller);
+        controller.BeginStartupApplicationUpdateCheck();
+        Assert.True(controller.ViewModel.IsApplicationUpdateAvailable);
+        Assert.Contains("1.2.2", controller.ViewModel.ApplicationUpdateStatus);
+        Assert.Equal("Install update", controller.ViewModel.ApplicationUpdateAction);
+        Assert.False(controller.ViewModel.CanCheckApplicationUpdate);
+        if (outcome == "newer") response.SetResult(Release());
+        else if (outcome == "current") response.SetResult(null);
+        else response.SetException(Failure(outcome));
+        await WaitForCheckAsync(controller);
+        Assert.Equal(1, checks);
+        Assert.True(controller.ViewModel.IsApplicationUpdateAvailable);
+        Assert.Contains("1.2.2", controller.ViewModel.ApplicationUpdateStatus);
+        Assert.DoesNotContain("1.2.3", controller.ViewModel.ApplicationUpdateStatus);
+        Assert.Equal("Install update", controller.ViewModel.ApplicationUpdateAction);
+        var details = await controller.GetAvailableApplicationUpdateDetailsAsync();
+        Assert.Equal("1.2.2", details!.Version);
+        Assert.Equal("Staged release details.", details.ReleaseSummary);
+        Assert.Same(staged.Installer, await controller.PrepareApplicationUpdateAsync());
+        Assert.Equal(new byte[] { 0 }, File.ReadAllBytes(staged.Installer.StagedPath));
+    }
+
+    [Fact]
+    public async Task MissingStagedInstallerDoesNotHideANewlyAvailableRelease()
+    {
+        using var staged = new StagedInstallerFixture();
+        await using var controller = Controller(CompletedSettings(), (_, _) => Task.FromResult<UpdateRelease?>(Release()));
+        staged.Attach(controller);
+        File.Delete(staged.Installer.StagedPath);
+        controller.BeginStartupApplicationUpdateCheck();
+        Assert.Equal("Update", controller.ViewModel.ApplicationUpdateAction);
+        Assert.Contains("1.2.3", controller.ViewModel.ApplicationUpdateStatus);
+        Assert.Equal("1.2.3", (await controller.GetAvailableApplicationUpdateDetailsAsync())!.Version);
+    }
+
+    [Fact]
+    public async Task ManualChecksRemainAvailableWhenAutomaticChecksAreDisabled()
+    {
+        var settings = CompletedSettings();
+        settings.AutomaticApplicationUpdateChecks = false;
+        await using var controller = Controller(settings, (_, _) => Task.FromResult<UpdateRelease?>(Release()));
+        Assert.Equal("1.2.3", (await controller.GetAvailableApplicationUpdateDetailsAsync())!.Version);
+        Assert.False(Timer(controller).IsEnabled);
+    }
+
+    [Fact]
+    public void AppRoutesIntentionalOpensAndWaitingStartupToOneCheckWithoutUdpDependency()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Wisp.sln"))) directory = directory.Parent;
+        Assert.NotNull(directory);
+        var source = File.ReadAllText(Path.Combine(directory!.FullName, "src", "Wisp.App", "App.xaml.cs"));
+        var waitingStart = source.IndexOf("if (launchMode == StartupLaunchMode.WaitForForza", StringComparison.Ordinal);
+        var waitingEnd = source.IndexOf("// A failed tray creation", waitingStart, StringComparison.Ordinal);
+        Assert.Contains("_controller.BeginStartupApplicationUpdateCheck();", source[waitingStart..waitingEnd]);
+        var runtimeStart = source.IndexOf("private async Task StartRuntimeAsync", StringComparison.Ordinal);
+        var runtimeEnd = source.IndexOf("private void OnControlPanelClosing", runtimeStart, StringComparison.Ordinal);
+        var runtime = source[runtimeStart..runtimeEnd];
+        var check = runtime.IndexOf("_controller.BeginStartupApplicationUpdateCheck();", StringComparison.Ordinal);
+        Assert.True(check >= 0 && check < runtime.IndexOf("if (_runtimeActive)", StringComparison.Ordinal));
+        Assert.True(check < runtime.IndexOf("await _controller.StartAsync();", StringComparison.Ordinal));
+        Assert.Equal(2, source.Split("_controller.BeginStartupApplicationUpdateCheck();", StringSplitOptions.None).Length - 1);
+        var restoreStart = source.IndexOf("private void RestoreControlPanel()", StringComparison.Ordinal);
+        var restoreEnd = source.IndexOf("private void OnStartupOptionsChanged", restoreStart, StringComparison.Ordinal);
+        Assert.Contains("StartRuntimeAsync(showControlPanel: true", source[restoreStart..restoreEnd]);
+        Assert.Contains("StartRuntimeAsync(showControlPanel: false", source[restoreStart..restoreEnd]);
+    }
+
+    internal static void AssertBannerOnCurrentDispatcher()
+    {
+        var checks = 0;
+        var controller = Controller(CompletedSettings(), (_, _) => ++checks == 1
+            ? Task.FromResult<UpdateRelease?>(Release()) : Task.FromException<UpdateRelease?>(new HttpRequestException()));
+        var application = Application.Current;
+        var shutdownMode = application.ShutdownMode;
+        MainWindow? window = null;
+        try
+        {
+            application.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            window = new MainWindow(controller);
+            var banner = Assert.IsType<Border>(window.FindName("DashboardUpdateBanner"));
+            window.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+            Assert.Equal(Visibility.Collapsed, banner.Visibility);
+            controller.BeginStartupApplicationUpdateCheck();
+            window.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+            Assert.Equal(Visibility.Visible, banner.Visibility);
+            FireDailyTimer(controller);
+            window.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+            Assert.Equal(Visibility.Visible, banner.Visibility);
+            var action = Assert.Single(Assert.IsType<Grid>(banner.Child).Children.OfType<Button>());
+            Assert.Equal("Update", action.Content);
+            Assert.True(action.IsEnabled);
+            using var staged = new StagedInstallerFixture();
+            staged.Attach(controller);
+            FireDailyTimer(controller);
+            window.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+            Assert.Equal(Visibility.Visible, banner.Visibility);
+            Assert.Equal("Install update", action.Content);
+            Assert.True(action.IsEnabled);
+            Assert.Contains("1.2.2", controller.ViewModel.ApplicationUpdateStatus);
+        }
+        finally
+        {
+            window?.Close();
+            controller.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            application.ShutdownMode = shutdownMode;
+        }
+    }
+
+    private static AppController Controller(AppSettings settings, Func<Version, CancellationToken, Task<UpdateRelease?>> check) =>
+        new(settings, _ => { }, new NoStartupRegistration(), checkForApplicationUpdate: check);
+    private static DispatcherTimer Timer(AppController controller) => (DispatcherTimer)typeof(AppController)
+        .GetField("_applicationUpdateTimer", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(controller)!;
+    private static void FireDailyTimer(AppController controller) => typeof(AppController)
+        .GetMethod("OnApplicationUpdateTimer", BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(controller, [null, EventArgs.Empty]);
+    private static async Task WaitForCheckAsync(AppController controller)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while ((!controller.ViewModel.CanCheckApplicationUpdate || CheckActive(controller)) && DateTime.UtcNow < deadline) await Task.Delay(10);
+        Assert.True(controller.ViewModel.CanCheckApplicationUpdate);
+        Assert.False(CheckActive(controller));
+    }
+    private static bool CheckActive(AppController controller) => (int)typeof(AppController)
+        .GetField("_applicationUpdateOperation", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(controller)! != 0;
+    private static UpdateRelease Release() => (UpdateRelease)Activator.CreateInstance(typeof(UpdateRelease),
+        BindingFlags.Instance | BindingFlags.NonPublic, binder: null,
+        args: [new SemanticVersion(1, 2, 3), "v1.2.3", "Wisp-Setup-1.2.3.exe", 1L, new string('A', 64),
+            new Uri("https://github.com/Views2k/Wisp/releases/download/v1.2.3/Wisp-Setup-1.2.3.exe"), "Reviewed maintenance update."],
+        culture: null)!;
+    private static Exception Failure(string kind) => kind switch
+    {
+        "http" => new HttpRequestException(),
+        "timeout" => new OperationCanceledException(),
+        _ => new UpdateSecurityException("Unverified fixture response.")
+    };
+    private static AppSettings CompletedSettings()
+    {
+        var settings = new AppSettings { StartWithWindows = false, StartWithForza = false };
+        var now = DateTimeOffset.UtcNow;
+        SetupCompletion.Save(settings, SetupPreferences.FromSettings(settings) with
+        {
+            DataOutConfirmed = true,
+            DisplayModeConfirmed = true,
+            StockHudConfirmed = true
+        }, new SetupTelemetryEvidence(settings.UdpPort, 12, 12, TimeSpan.FromMilliseconds(550), now), _ => { }, now);
+        return settings;
+    }
+    private sealed class NoStartupRegistration : IStartupRegistrationService
+    {
+        public void Apply(bool startWithWindows, bool startWithForza) { }
+    }
+
+    private sealed class StagedInstallerFixture : IDisposable
+    {
+        private readonly string _directory = Path.Combine(Path.GetTempPath(), "Wisp.App.Tests", Guid.NewGuid().ToString("N"));
+        public StagedInstallerFixture()
+        {
+            Directory.CreateDirectory(_directory);
+            var path = Path.Combine(_directory, "staged-installer.fixture");
+            File.WriteAllBytes(path, [0]);
+            Installer = (VerifiedInstaller)Activator.CreateInstance(typeof(VerifiedInstaller),
+                BindingFlags.Instance | BindingFlags.NonPublic, binder: null,
+                args: [path, new SemanticVersion(1, 2, 2), 1L, new string('A', 64)], culture: null)!;
+        }
+        public VerifiedInstaller Installer { get; }
+        public void Attach(AppController controller)
+        {
+            typeof(AppController).GetField("_pendingInstaller", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(controller, Installer);
+            typeof(AppController).GetField("_pendingApplicationUpdateDetails", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(controller, new ApplicationUpdateDetails("1.2.2", "Staged release details."));
+            typeof(AppController).GetField("_availableApplicationRelease", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(controller, null);
+            controller.MarkApplicationUpdateDeferred(Installer);
+        }
+        public void Dispose() => Directory.Delete(_directory, recursive: true);
     }
 }

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -21,9 +21,9 @@ public sealed class ApplicationVersionInfoTests
     [Fact]
     public void CurrentVersionLabelsShareTheAssemblyVersion()
     {
-        Assert.Equal("1.1.2", ApplicationVersionInfo.DisplayVersion);
-        Assert.EndsWith(" 1.1.2", ApplicationVersionInfo.FooterText);
-        Assert.Contains("current 1.1.2 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.Equal("1.1.3", ApplicationVersionInfo.DisplayVersion);
+        Assert.EndsWith(" 1.1.3", ApplicationVersionInfo.FooterText);
+        Assert.Contains("current 1.1.3 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
         Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
     }
 }

--- a/tests/Wisp.App.Tests/BoostDisplayModelTests.cs
+++ b/tests/Wisp.App.Tests/BoostDisplayModelTests.cs
@@ -4,6 +4,45 @@ namespace Wisp.App.Tests;
 
 public sealed class BoostDisplayModelTests
 {
+    [Theory]
+    [InlineData(-2.9465)]
+    [InlineData(-10)]
+    [InlineData(-20)]
+    [InlineData(-35)]
+    public void VacuumOptionPreservesTelemetryWithoutTreatingVacuumAsBoost(double pressure)
+    {
+        var model = new BoostDisplayModel();
+        model.Calculate(3411, false, 24);
+
+        var display = model.Calculate(3411, false, pressure, showVacuum: true);
+
+        Assert.True(display.IsAvailable);
+        Assert.Equal(pressure, display.PressurePsi);
+        Assert.Equal(24, display.LearnedPeakPsi);
+        Assert.Equal(0, display.Fraction);
+        Assert.Equal(-20, display.ScaleMinimumPsi);
+        Assert.Equal(70, display.ScaleMaximumPsi);
+        var disabled = model.Calculate(3411, false, pressure);
+        Assert.Equal(0, disabled.PressurePsi);
+        Assert.Equal(0, disabled.ScaleMinimumPsi);
+        Assert.Equal(24, disabled.LearnedPeakPsi);
+    }
+
+    [Fact]
+    public void VacuumOptionDoesNotInventPressureOrBypassVehicleAvailability()
+    {
+        var model = new BoostDisplayModel();
+        Assert.True(model.Calculate(3411, false, 0, showVacuum: true).IsAvailable);
+        Assert.Equal(0, model.Calculate(3411, false, -10, showVacuum: true).PressurePsi);
+        Assert.Equal(0, model.Calculate(3411, false, 0, showVacuum: true).PressurePsi);
+        Assert.False(model.Calculate(3411, true, -10, showVacuum: true).IsAvailable);
+        Assert.True(model.Calculate(3411, false, 0, showVacuum: true).IsAvailable);
+        Assert.True(model.Calculate(3411, false, 10, showVacuum: true).IsAvailable);
+        Assert.True(model.Calculate(1024, false, 0, showVacuum: true).IsAvailable);
+        Assert.False(model.Calculate(1024, false, double.NaN, showVacuum: true).IsAvailable);
+        Assert.False(model.Calculate(1024, false, double.NegativeInfinity, showVacuum: true).IsAvailable);
+    }
+
     [Fact]
     public void ProvidesFifteenColorPalettesAndOneNeutralStockStyle()
     {
@@ -16,15 +55,21 @@ public sealed class BoostDisplayModelTests
         Assert.Equal(stock.Mid, stock.High);
     }
 
-    [Fact]
-    public void ShowsTheGaugeOnTheFirstManifoldPressureSample()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NaturallyAspiratedVacuumAndThrottleCyclesKeepTheGaugeAvailableAtZero(bool showVacuum)
     {
         var model = new BoostDisplayModel();
 
-        var display = model.Calculate(3411, false, -11);
-
-        Assert.True(display.IsAvailable);
-        Assert.Equal(0, display.PressurePsi);
+        foreach (var pressure in new[] { -15d, -10, -4, 0, 0.1, -15, 0, -15 })
+        {
+            var display = model.Calculate(3411, false, pressure, showVacuum);
+            Assert.True(display.IsAvailable);
+            Assert.Equal(0, display.PressurePsi);
+            Assert.Equal(0, display.LearnedPeakPsi);
+            Assert.Equal(0, display.Fraction);
+        }
     }
 
     [Fact]
@@ -47,16 +92,24 @@ public sealed class BoostDisplayModelTests
     public void ZeroPressureDoesNotIdentifyForcedInduction()
     {
         var model = new BoostDisplayModel();
-        for (var i = 0; i < 20; i++) Assert.False(model.Calculate(22, false, 0).IsAvailable);
+        for (var i = 0; i < 20; i++)
+        {
+            var display = model.Calculate(22, false, 0);
+            Assert.True(display.IsAvailable);
+            Assert.Equal(0, display.PressurePsi);
+            Assert.False(model.HasDetectedBoost);
+        }
     }
 
-    [Fact]
-    public void ElectricVehiclesNeverExposeBoost()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ElectricVehiclesNeverExposeBoost(bool showVacuum)
     {
         var model = new BoostDisplayModel();
 
-        Assert.False(model.Calculate(23, true, 15).IsAvailable);
-        Assert.False(model.Calculate(23, true, -11).IsAvailable);
+        Assert.False(model.Calculate(23, true, 15, showVacuum).IsAvailable);
+        Assert.False(model.Calculate(23, true, -11, showVacuum).IsAvailable);
     }
 
     [Fact]
@@ -67,15 +120,28 @@ public sealed class BoostDisplayModelTests
 
         Assert.False(model.Calculate(23, true, 15).IsAvailable);
         Assert.False(model.Calculate(23, true, 0).IsAvailable);
-        Assert.False(model.Calculate(23, false, 0).IsAvailable);
+        var combustion = model.Calculate(23, false, -15, showVacuum: true);
+        Assert.True(combustion.IsAvailable);
+        Assert.Equal(0, combustion.PressurePsi);
     }
 
     [Fact]
-    public void VacuumMakesTheGaugeAvailableBeforePositiveBoost()
+    public void PositiveBoostEnablesSubsequentVacuumForTheSameCar()
     {
         var model = new BoostDisplayModel();
-        Assert.True(model.Calculate(23, false, -4).IsAvailable);
-        Assert.True(model.Calculate(23, false, 7).IsAvailable);
+        var beforeBoost = model.Calculate(23, false, -15, showVacuum: true);
+        Assert.True(beforeBoost.IsAvailable);
+        Assert.Equal(0, beforeBoost.PressurePsi);
+        Assert.True(model.Calculate(23, false, 7, showVacuum: true).IsAvailable);
+        var vacuum = model.Calculate(23, false, -15, showVacuum: true);
+        Assert.True(vacuum.IsAvailable);
+        Assert.Equal(-15, vacuum.PressurePsi);
+        Assert.Equal(7, vacuum.LearnedPeakPsi);
+
+        model.Reset();
+        var afterReset = model.Calculate(23, false, -15, showVacuum: true);
+        Assert.True(afterReset.IsAvailable);
+        Assert.Equal(0, afterReset.PressurePsi);
     }
 
     [Fact]
@@ -85,6 +151,12 @@ public sealed class BoostDisplayModelTests
         model.Calculate(3411, false, 24);
         Assert.True(model.Calculate(3411, false, 24).IsAvailable);
 
-        Assert.False(model.Calculate(1024, false, 0).IsAvailable);
+        foreach (var pressure in new[] { 0d, -15, 0 })
+        {
+            var display = model.Calculate(1024, false, pressure, showVacuum: true);
+            Assert.True(display.IsAvailable);
+            Assert.Equal(0, display.PressurePsi);
+            Assert.Equal(0, display.LearnedPeakPsi);
+        }
     }
 }

--- a/tests/Wisp.App.Tests/BoostGaugeVisualsTests.cs
+++ b/tests/Wisp.App.Tests/BoostGaugeVisualsTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+internal static class BoostGaugeVisualsTests
+{
+    // Keep shared shader resources on the existing resource-only STA fixture.
+    internal static void AssertOnCurrentDispatcher()
+    {
+        NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(BoostPressureUnit.Psi, -20, 2);
+        NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(BoostPressureUnit.Psi, -200, 3);
+        NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(BoostPressureUnit.Bar, -20, 2);
+        NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(BoostPressureUnit.Psi, -0.1, 2, showsMinus: false);
+        NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(BoostPressureUnit.Bar, -0.1, 2, showsMinus: false);
+        foreach (var unit in new[] { BoostPressureUnit.Psi, BoostPressureUnit.Bar })
+            foreach (var stock in new[] { false, true })
+                DigitalRailPlacesVacuumBelowTheZeroReference(unit, stock);
+    }
+
+    private static void NativeReadoutDrawsAMinusAndFitsSignedTelemetryInsideTheRing(
+        BoostPressureUnit unit, double pressure, int digitCount, bool showsMinus = true)
+    {
+        var model = new BoostDisplayModel();
+        model.Calculate(42, false, 24);
+        var gauge = new AnalogBoostGaugeView
+        {
+            PressureUnit = unit,
+            Display = model.Calculate(42, false, pressure, showVacuum: true)
+        };
+        var drawing = new DrawingGroup();
+        using (var context = drawing.Open())
+        {
+            typeof(AnalogBoostGaugeView).GetMethod("DrawNativeBoostDigits",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+                .Invoke(gauge, [context, new Point(144, 144)]);
+        }
+        var leaves = Flatten(drawing).ToArray();
+        Assert.Equal(digitCount, leaves.OfType<ImageDrawing>().Count());
+        Assert.Equal(showsMinus ? 1 : 0, leaves.OfType<GeometryDrawing>().Count(item => item.Geometry is LineGeometry));
+        Assert.True(drawing.Bounds.Width <= 44.01);
+    }
+
+    private static void DigitalRailPlacesVacuumBelowTheZeroReference(BoostPressureUnit unit, bool stock)
+    {
+        var model = new BoostDisplayModel();
+        model.Calculate(42, false, 24);
+        var rail = new DigitalBoostRailView { PressureUnit = unit, UseStockColors = stock };
+        rail.Measure(new Size(302, 96));
+        rail.Arrange(new Rect(0, 0, 302, 96));
+        var material = Assert.IsType<NativeDigitalGaugeVisual>(Assert.Single(rail.Children.Cast<UIElement>()));
+        var effect = Assert.IsType<DigitalGaugeShaderEffect>(material.Effect);
+        double previous = -1;
+        foreach (var pressure in new[] { -10d, 0, 20 })
+        {
+            rail.Display = model.Calculate(42, false, pressure, showVacuum: true);
+            var drawing = new DrawingGroup();
+            using (var context = drawing.Open())
+            {
+                typeof(DigitalBoostRailView).GetMethod("OnRender", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .Invoke(rail, [context]);
+            }
+            var zero = BoostPressureUnits.GaugeFraction(0, unit, showVacuum: true);
+            var fraction = effect.GaugeParameters.X;
+            Assert.True(fraction > previous);
+            Assert.Equal(Math.Sign(pressure), Math.Sign(fraction - zero));
+            Assert.Equal(stock ? Visibility.Visible : Visibility.Collapsed, material.Visibility);
+            Assert.Contains(Flatten(drawing).OfType<GeometryDrawing>(), item =>
+                item.Geometry is LineGeometry line && line.StartPoint.Y == 55.75 &&
+                Math.Abs(line.StartPoint.X - (9.05 + 283 * zero)) < 0.001);
+            previous = fraction;
+        }
+    }
+
+    private static IEnumerable<Drawing> Flatten(Drawing drawing) => drawing is DrawingGroup group
+        ? group.Children.SelectMany(Flatten)
+        : [drawing];
+}

--- a/tests/Wisp.App.Tests/BoostPressureUnitsTests.cs
+++ b/tests/Wisp.App.Tests/BoostPressureUnitsTests.cs
@@ -8,6 +8,7 @@ public sealed class BoostPressureUnitsTests
     [InlineData(0, 0)]
     [InlineData(14.503773773, 1)]
     [InlineData(29.007547546, 2)]
+    [InlineData(-14.503773773, -1)]
     public void ConvertsPsiToBar(double psi, double expectedBar)
     {
         Assert.Equal(expectedBar, BoostPressureUnits.FromPsi(psi, BoostPressureUnit.Bar), 8);
@@ -18,8 +19,31 @@ public sealed class BoostPressureUnitsTests
     {
         Assert.Equal("24", BoostPressureUnits.FormatValue(24, BoostPressureUnit.Psi));
         Assert.Equal("1.7", BoostPressureUnits.FormatValue(24, BoostPressureUnit.Bar));
+        Assert.Equal("-20", BoostPressureUnits.FormatValue(-20, BoostPressureUnit.Psi));
+        Assert.Equal("-1.4", BoostPressureUnits.FormatValue(-20, BoostPressureUnit.Bar));
         Assert.Equal("PSI", BoostPressureUnits.Symbol(BoostPressureUnit.Psi));
         Assert.Equal("BAR", BoostPressureUnits.Symbol(BoostPressureUnit.Bar));
+    }
+
+    [Theory]
+    [InlineData(-0.1, BoostPressureUnit.Psi, "0")]
+    [InlineData(-0.6, BoostPressureUnit.Psi, "-1")]
+    [InlineData(-0.1, BoostPressureUnit.Bar, "0.0")]
+    [InlineData(-1, BoostPressureUnit.Bar, "-0.1")]
+    public void NearZeroReadoutsDoNotDisplayNegativeZero(double psi, BoostPressureUnit unit, string expected)
+    {
+        Assert.Equal(expected, BoostPressureUnits.FormatValue(psi, unit));
+    }
+
+    [Theory]
+    [InlineData(-0.1, "00")]
+    [InlineData(0, "00")]
+    [InlineData(2.5, "03")]
+    [InlineData(-2.5, "-3")]
+    [InlineData(-20, "-20")]
+    public void AnaloguePsiPaddingPreservesSignedAndRoundedReadouts(double psi, string expected)
+    {
+        Assert.Equal(expected, BoostPressureUnits.FormatValue(psi, BoostPressureUnit.Psi, padPsi: true));
     }
 
     [Fact]
@@ -27,5 +51,22 @@ public sealed class BoostPressureUnitsTests
     {
         Assert.Equal(5, BoostPressureUnits.AnalogMaximum(BoostPressureUnit.Bar));
         Assert.Equal(72.518868865, BoostPressureUnits.AnalogMaximumPsi(BoostPressureUnit.Bar), 8);
+    }
+
+    [Theory]
+    [InlineData(BoostPressureUnit.Psi, -20, -20, 70, 2d / 9)]
+    [InlineData(BoostPressureUnit.Bar, -1, -14.503773773, 72.518868865, 1d / 6)]
+    public void VacuumScaleHasAZeroReferenceBetweenItsEndpoints(
+        BoostPressureUnit unit, double minimum, double minimumPsi, double maximumPsi, double zeroFraction)
+    {
+        Assert.Equal(minimum, BoostPressureUnits.AnalogMinimum(unit, showVacuum: true));
+        Assert.Equal(0, BoostPressureUnits.AnalogMinimum(unit, showVacuum: false));
+        Assert.Equal(0, BoostPressureUnits.GaugeFraction(minimumPsi, unit, showVacuum: true), 8);
+        Assert.Equal(zeroFraction, BoostPressureUnits.GaugeFraction(0, unit, showVacuum: true), 8);
+        Assert.Equal(1, BoostPressureUnits.GaugeFraction(maximumPsi, unit, showVacuum: true), 8);
+        Assert.Equal(0, BoostPressureUnits.GaugeFraction(-200, unit, showVacuum: true));
+        Assert.Equal(1, BoostPressureUnits.GaugeFraction(200, unit, showVacuum: true));
+        Assert.Equal(0, BoostPressureUnits.GaugeFraction(-10, unit, showVacuum: false));
+        Assert.Equal(0.5, BoostPressureUnits.GaugeFraction(maximumPsi / 2, unit, showVacuum: false), 8);
     }
 }

--- a/tests/Wisp.App.Tests/BoostVacuumUiTests.cs
+++ b/tests/Wisp.App.Tests/BoostVacuumUiTests.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using Wisp.Core;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+internal static class BoostVacuumUiTests
+{
+    internal static void AssertOnCurrentDispatcher()
+    {
+        var settings = new AppSettings
+        {
+            StartWithWindows = false,
+            StartWithForza = false,
+            AutomaticApplicationUpdateChecks = false,
+            LayoutMode = HudLayoutMode.Native,
+            NativeGaugeMode = NativeGaugeMode.Analogue,
+            BoostGaugeEnabled = true,
+            BoostGaugeAttached = true
+        };
+        var now = DateTimeOffset.UtcNow;
+        var preferences = SetupPreferences.FromSettings(settings) with
+        {
+            DataOutConfirmed = true,
+            DisplayModeConfirmed = true,
+            StockHudConfirmed = true
+        };
+        SetupCompletion.Save(settings, preferences,
+            new SetupTelemetryEvidence(settings.UdpPort, 12, 12, TimeSpan.FromMilliseconds(550), now), _ => { }, now);
+        string? persisted = null;
+        var controller = new AppController(settings, value => persisted = JsonSerializer.Serialize(value), new NoStartupRegistration());
+        var application = Application.Current;
+        var shutdownMode = application.ShutdownMode;
+        MainWindow? window = null;
+        try
+        {
+            application.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+            window = new MainWindow(controller);
+            window.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.DataBind);
+            var toggle = Assert.Single(Descendants(window).OfType<CheckBox>(), check =>
+                BindingOperations.GetBinding(check, ToggleButton.IsCheckedProperty)?.Path.Path == nameof(DiagnosticsViewModel.ShowBoostVacuum));
+            Assert.False(toggle.IsChecked);
+            // Exercise the authored Checked/Unchecked handlers without showing a window or starting the App.
+            window.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+            foreach (var enabled in new[] { true, false })
+            {
+                persisted = null;
+                toggle.SetCurrentValue(ToggleButton.IsCheckedProperty, enabled);
+                Assert.NotNull(toggle.GetBindingExpression(ToggleButton.IsCheckedProperty));
+                Assert.Equal(enabled, controller.ViewModel.ShowBoostVacuum);
+                Assert.Equal(enabled, settings.ShowBoostVacuum);
+                Assert.True(controller.TrySavePendingSettings());
+                Assert.Equal(enabled, JsonSerializer.Deserialize<AppSettings>(Assert.IsType<string>(persisted))!.ShowBoostVacuum);
+            }
+            AssertStationaryCombustionGaugeVisibility(controller, window, toggle);
+        }
+        finally
+        {
+            try
+            {
+                try { window?.Close(); }
+                finally { controller.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
+            }
+            finally
+            {
+                application.ShutdownMode = shutdownMode;
+            }
+        }
+    }
+
+    private static void AssertStationaryCombustionGaugeVisibility(AppController controller, MainWindow window, CheckBox vacuum)
+    {
+        var enabled = Assert.Single(Descendants(window).OfType<CheckBox>(), check =>
+            BindingOperations.GetBinding(check, ToggleButton.IsCheckedProperty)?.Path.Path == nameof(DiagnosticsViewModel.BoostGaugeEnabled));
+        var overlay = new OverlayWindow(controller);
+        var detached = new BoostGaugeWindow(controller);
+        try
+        {
+            var analog = Assert.IsType<AnalogBoostGaugeView>(overlay.FindName("AttachedAnalogBoost"));
+            var digital = Assert.IsType<DigitalBoostRailView>(overlay.FindName("AttachedDigitalBoost"));
+            var detachedGauge = Assert.Single(Descendants(detached).OfType<AnalogBoostGaugeView>());
+            foreach (var unit in new[] { BoostPressureUnit.Psi, BoostPressureUnit.Bar })
+            {
+                controller.ViewModel.UseBarBoostPressure = unit == BoostPressureUnit.Bar;
+                foreach (var mode in new[] { NativeGaugeMode.Analogue, NativeGaugeMode.Digital })
+                {
+                    controller.ViewModel.NativeGaugeSelectionIndex = (int)mode;
+                    controller.Settings.NativeGaugeMode = mode;
+                    controller.ViewModel.BoostGaugeAttached = true;
+                    controller.Settings.BoostGaugeAttached = true;
+                    overlay.SetElectricPowertrain(false);
+                    overlay.ApplyLayout(HudLayoutMode.Native, mode, 1, 1, 1);
+                    enabled.SetCurrentValue(ToggleButton.IsCheckedProperty, true);
+                    foreach (var pressure in new[] { 0f, -0.2f, -10f, 0f })
+                    {
+                        UpdateBoostTelemetry(controller.ViewModel, isElectric: false, pressure);
+                        // The real Checked/Unchecked handlers must not expose
+                        // negative-only NA telemetry when changing this option.
+                        foreach (var showVacuum in new[] { false, true })
+                        {
+                            vacuum.SetCurrentValue(ToggleButton.IsCheckedProperty, showVacuum);
+                            window.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.DataBind);
+                            Assert.True(controller.ViewModel.BoostDisplay.IsAvailable);
+                            Assert.Equal(0, controller.ViewModel.BoostDisplay.PressurePsi);
+                            Assert.Equal(0, controller.ViewModel.BoostDisplay.LearnedPeakPsi);
+                            Assert.Equal(mode == NativeGaugeMode.Analogue ? Visibility.Visible : Visibility.Collapsed, analog.Visibility);
+                            Assert.Equal(mode == NativeGaugeMode.Digital ? Visibility.Visible : Visibility.Collapsed, digital.Visibility);
+                            Assert.Equal(0, analog.Display.PressurePsi);
+                            Assert.Equal(0, digital.Display.PressurePsi);
+                            Assert.Equal(unit, analog.PressureUnit);
+                            Assert.Equal(unit, digital.PressureUnit);
+                        }
+                    }
+                    enabled.SetCurrentValue(ToggleButton.IsCheckedProperty, false);
+                    Assert.False(controller.Settings.BoostGaugeEnabled);
+                    Assert.Equal(Visibility.Collapsed, analog.Visibility);
+                    Assert.Equal(Visibility.Collapsed, digital.Visibility);
+                    Assert.False(controller.IsDetachedBoostGaugeEnabled);
+                    enabled.SetCurrentValue(ToggleButton.IsCheckedProperty, true);
+                    controller.ViewModel.BoostGaugeAttached = false;
+                    controller.Settings.BoostGaugeAttached = false;
+                    window.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.DataBind);
+                    Assert.Equal(mode == NativeGaugeMode.Analogue, controller.IsDetachedBoostGaugeEnabled);
+                    Assert.True(detachedGauge.Display.IsAvailable);
+                    Assert.Equal(0, detachedGauge.Display.PressurePsi);
+                    Assert.Equal(unit, detachedGauge.PressureUnit);
+                    enabled.SetCurrentValue(ToggleButton.IsCheckedProperty, false);
+                    Assert.False(controller.IsDetachedBoostGaugeEnabled);
+                    enabled.SetCurrentValue(ToggleButton.IsCheckedProperty, true);
+                    UpdateBoostTelemetry(controller.ViewModel, isElectric: true, pressure: -10);
+                    overlay.SetElectricPowertrain(true);
+                    window.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.DataBind);
+                    Assert.True(controller.Settings.BoostGaugeEnabled);
+                    Assert.False(controller.ViewModel.BoostDisplay.IsAvailable);
+                    Assert.False(detachedGauge.Display.IsAvailable);
+                    Assert.False(controller.IsDetachedBoostGaugeEnabled);
+                    Assert.Equal(Visibility.Collapsed, analog.Visibility);
+                    Assert.Equal(Visibility.Collapsed, digital.Visibility);
+                }
+            }
+            // These exercise real control bindings and layout/controller gates;
+            // no test window, live listener or game session is started.
+            Assert.False(overlay.IsVisible);
+            Assert.False(detached.IsVisible);
+        }
+        finally
+        {
+            detached.Close();
+            overlay.Close();
+        }
+    }
+
+    private static void UpdateBoostTelemetry(DiagnosticsViewModel viewModel, bool isElectric, float pressure)
+    {
+        var state = new VehicleState
+        {
+            IsRaceOn = true,
+            GameTimestampMilliseconds = 1,
+            ReceivedAtUtc = DateTimeOffset.UtcNow,
+            CarOrdinal = isElectric ? 102 : 101,
+            NumCylinders = isElectric ? 0 : 12,
+            BoostPressurePsi = pressure,
+            Drivetrain = DrivetrainType.RearWheelDrive,
+            GroundSpeedMetersPerSecond = 0,
+            WheelRotationRadiansPerSecond = default,
+            TireSlipRatio = default,
+            TireSlipAngle = default,
+            NormalizedSuspensionTravel = default,
+            LateralAccelerationMetersPerSecondSquared = 0,
+            LongitudinalAccelerationMetersPerSecondSquared = 0,
+            EngineRpm = isElectric ? 0 : 900,
+            EngineMaximumRpm = 8000,
+            Gear = TransmissionGear.Neutral,
+            Steering = 0,
+            Accelerator = 0,
+            Brake = 0
+        };
+        viewModel.Update(state, new IndicatedSpeed(0, 0, true, false, "Fixture"),
+            new CalibrationResult(null, 0.3, 0.2, 0, true, string.Empty, false), default,
+            TimeSpan.Zero, SpeedUnit.MilesPerHour, 60, refreshDiagnostics: false, updateGForce: false);
+    }
+
+    private static IEnumerable<DependencyObject> Descendants(DependencyObject parent)
+    {
+        foreach (var child in LogicalTreeHelper.GetChildren(parent).OfType<DependencyObject>())
+        {
+            yield return child;
+            foreach (var descendant in Descendants(child)) yield return descendant;
+        }
+    }
+
+    private sealed class NoStartupRegistration : IStartupRegistrationService
+    {
+        public void Apply(bool startWithWindows, bool startWithForza) { }
+    }
+}

--- a/tests/Wisp.App.Tests/DiagnosticsViewModelTests.cs
+++ b/tests/Wisp.App.Tests/DiagnosticsViewModelTests.cs
@@ -6,6 +6,70 @@ namespace Wisp.App.Tests;
 
 public sealed class DiagnosticsViewModelTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BoostVacuumUsesSignedTelemetryWithOrWithoutNativeHudData(bool nativeAvailable)
+    {
+        var viewModel = new DiagnosticsViewModel(new AppSettings());
+        var native = nativeAvailable
+            ? NativeSnapshot(1, 140, 0, System.Diagnostics.Stopwatch.GetTimestamp())
+            : NativeHudSnapshot.Unavailable(carOrdinal: 1);
+        foreach (var pressure in new[] { 12f, -20f })
+        {
+            viewModel.Update(
+                DrivingState() with { NumCylinders = 4, BoostPressurePsi = pressure },
+                new IndicatedSpeed(0, 30, true, false, "Rear"),
+                new CalibrationResult(null, 0.3, 0.2, 0, true, string.Empty, false),
+                native, default, TimeSpan.Zero, SpeedUnit.MilesPerHour, 60,
+                refreshDiagnostics: false, updateGForce: false);
+        }
+
+        Assert.Equal(0, viewModel.BoostDisplay.PressurePsi);
+        viewModel.ShowBoostVacuum = true;
+        Assert.Equal(-20, viewModel.BoostDisplay.PressurePsi);
+        Assert.Equal(-20, viewModel.PreviewBoostDisplay.PressurePsi);
+        Assert.Equal(-20, viewModel.BoostDisplay.ScaleMinimumPsi);
+        viewModel.ShowBoostVacuum = false;
+        Assert.Equal(0, viewModel.BoostDisplay.PressurePsi);
+        Assert.Equal(0, viewModel.BoostDisplay.ScaleMinimumPsi);
+    }
+
+    [Fact]
+    public void NaturallyAspiratedGaugeStaysAvailableAtZeroWhenVacuumIsToggled()
+    {
+        var viewModel = new DiagnosticsViewModel(new AppSettings());
+        foreach (var pressure in new[] { -15f, 0f, -15f })
+        {
+            viewModel.Update(
+                DrivingState() with { NumCylinders = 8, BoostPressurePsi = pressure },
+                new IndicatedSpeed(0, 30, true, false, "Rear"),
+                new CalibrationResult(null, 0.3, 0.2, 0, true, string.Empty, false),
+                NativeHudSnapshot.Unavailable(carOrdinal: 1), default, TimeSpan.Zero, SpeedUnit.MilesPerHour, 60,
+                refreshDiagnostics: false, updateGForce: false);
+            foreach (var enabled in new[] { true, false })
+            {
+                viewModel.ShowBoostVacuum = enabled;
+                Assert.True(viewModel.BoostDisplay.IsAvailable);
+                Assert.Equal(0, viewModel.BoostDisplay.PressurePsi);
+                Assert.Equal(0, viewModel.PreviewBoostDisplay.PressurePsi);
+            }
+        }
+    }
+
+    [Fact]
+    public void VacuumOptionRestoresAndChangesThePreviewScaleWithoutInventingLiveData()
+    {
+        var viewModel = new DiagnosticsViewModel(new AppSettings { ShowBoostVacuum = true });
+        Assert.True(viewModel.ShowBoostVacuum);
+        Assert.False(viewModel.BoostDisplay.IsAvailable);
+        Assert.Equal(-20, viewModel.PreviewBoostDisplay.ScaleMinimumPsi);
+        Assert.Equal(HudPreviewSample.Boost.PressurePsi, viewModel.PreviewBoostDisplay.PressurePsi);
+        viewModel.ShowBoostVacuum = false;
+        Assert.Equal(0, viewModel.PreviewBoostDisplay.ScaleMinimumPsi);
+        Assert.False(viewModel.BoostDisplay.IsAvailable);
+    }
+
     [Fact]
     public void DashboardDefaultsAreExplicitWithoutLiveTelemetry()
     {

--- a/tests/Wisp.App.Tests/HudPresetTests.cs
+++ b/tests/Wisp.App.Tests/HudPresetTests.cs
@@ -32,6 +32,7 @@ public sealed class HudPresetTests
             BoostGaugeColorNumber = true,
             DigitalBoostGaugeColorNumber = true,
             DigitalBoostGaugeStockColors = true,
+            ShowBoostVacuum = true,
             BoostPressureUnit = BoostPressureUnit.Bar,
             BoostGaugeScale = 1.25,
             TireTemperatureGaugeEnabled = true,
@@ -99,6 +100,7 @@ public sealed class HudPresetTests
         Assert.Equal(source.InvertLateralG, target.InvertLateralG);
         Assert.Equal(source.InvertLongitudinalG, target.InvertLongitudinalG);
         Assert.Equal(source.BoostGaugeAttached, target.BoostGaugeAttached);
+        Assert.True(target.ShowBoostVacuum);
         Assert.Equal(source.TireTemperatureUnit, target.TireTemperatureUnit);
         Assert.Equal(source.ColorTheme, target.ColorTheme);
         Assert.Equal(source.BackgroundTheme, target.BackgroundTheme);
@@ -143,7 +145,7 @@ public sealed class HudPresetTests
             "GForceEnabled", "GForceAttached", "GForceWidthScale", "GForceHeightScale",
             "InvertLateralG", "InvertLongitudinalG",
             "BoostGaugeEnabled", "BoostGaugeAttached", "BoostGaugeColorNumber",
-            "DigitalBoostGaugeColorNumber", "DigitalBoostGaugeStockColors", "BoostPressureUnit",
+            "DigitalBoostGaugeColorNumber", "DigitalBoostGaugeStockColors", "ShowBoostVacuum", "BoostPressureUnit",
             "BoostGaugeScale", "TireTemperatureGaugeEnabled", "TireTemperatureGaugeAttached",
             "TireTemperatureReactiveColors", "TireTemperatureUnit", "TireTemperatureGaugeScale",
             "TractionCueEnabled", "ColorTheme", "BackgroundTheme", "HudBorderTheme", "BoostGaugeTheme",

--- a/tests/Wisp.App.Tests/NativeCompatibilityCatalogTests.cs
+++ b/tests/Wisp.App.Tests/NativeCompatibilityCatalogTests.cs
@@ -816,6 +816,47 @@ public sealed class NativeCompatibilityCatalogTests
     }
 
     [Fact]
+    public void SignedUpdatedStoreMapRecoversPreviousCatalogInOneGenerationAndReloadsOffline()
+    {
+        using var fixture = new Fixture();
+        using var stream = typeof(NativeHudBuildContract).Assembly.GetManifestResourceStream("Wisp.NativeCompatibility.Store.json")!;
+        var storeJson = JsonNode.Parse(stream)!.AsObject();
+        var currentStore = NativeHudCompatibilityPack.Parse(Bytes(storeJson));
+        var previousStore = NativeHudBuildContract.PreviousStoreBuiltIn;
+        var oldBuiltIns = new[] { NativeHudBuildContract.PreviousSteamBuiltIn, previousStore };
+        var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn,
+            fixture.CacheDirectory, fixture.Keys, oldBuiltIns);
+        var envelope = fixture.Envelope(storeJson);
+
+        Assert.Null(Find(catalog, currentStore));
+        Assert.Same(previousStore, Find(catalog, previousStore));
+        Assert.Equal(0, catalog.Generation);
+
+        var result = catalog.Install(envelope, fixture.Now);
+
+        Assert.True(result.Success);
+        Assert.True(result.Changed);
+        Assert.Single(result.Packs);
+        Assert.Equal(1, catalog.Generation);
+        Assert.Same(result.Pack, Find(catalog, currentStore));
+        Assert.Same(previousStore, Find(catalog, previousStore));
+        Assert.Null(catalog.FindStore(currentStore.StoreIdentity!.PackageFullName, previousStore.ImageSize));
+        Assert.Null(catalog.FindStore(previousStore.StoreIdentity!.PackageFullName, currentStore.ImageSize));
+        Assert.Equal(NativeCompatibilityInstallCode.AlreadyInstalled, catalog.Install(envelope, fixture.Now).Code);
+        Assert.Equal(1, catalog.Generation);
+
+        var offline = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn,
+            fixture.CacheDirectory, fixture.Keys, oldBuiltIns);
+        Assert.False(offline.CacheLoadHadErrors);
+        Assert.Equal(currentStore.Revision, Find(offline, currentStore)!.Revision);
+        Assert.Equal(currentStore.NativeGauge!.HudTypeTokenRva, Find(offline, currentStore)!.NativeGauge!.HudTypeTokenRva);
+        Assert.Same(previousStore, Find(offline, previousStore));
+        Assert.Same(NativeHudBuildContract.BuiltIn, Find(offline, NativeHudBuildContract.BuiltIn));
+        Assert.Same(NativeHudBuildContract.PreviousSteamBuiltIn, Find(offline, NativeHudBuildContract.PreviousSteamBuiltIn));
+        Assert.Single(Directory.EnumerateFiles(fixture.CacheDirectory, "*.pack.json"));
+    }
+
+    [Fact]
     public void LegacyStoreEnvelopeRequiresPinnedSignatureAndUsesSeparateExactIdentity()
     {
         using var fixture = new Fixture();

--- a/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
+++ b/tests/Wisp.App.Tests/NativeHudMemoryResolverTests.cs
@@ -49,19 +49,29 @@ public sealed class NativeHudMemoryResolverTests
     }
 
     [Fact]
-    public void ProductionCatalogRetainsPreviousSteamAndStoreContractsOffline()
+    public void ProductionCatalogSelectsCurrentAndPreviousStoreContractsByExactIdentityOffline()
     {
         var catalog = new NativeCompatibilityCatalog(NativeHudBuildContract.BuiltIn, null,
             new Dictionary<string, byte[]>(), NativeHudBuildContract.AdditionalBuiltIns);
         var previous = NativeHudBuildContract.PreviousSteamBuiltIn;
         var store = NativeHudBuildContract.StoreBuiltIn;
+        var previousStore = NativeHudBuildContract.PreviousStoreBuiltIn;
 
         Assert.Equal("6.430.771.0", previous.GameVersion);
         Assert.Same(previous, catalog.Find(previous.GameVersion, previous.ExecutableLength, previous.ExecutableSha256));
+        Assert.Equal("3.440.853.0", store.GameVersion);
+        Assert.Equal(188_420_096U, store.ImageSize);
+        Assert.Equal("3.430.771.0", previousStore.GameVersion);
+        Assert.Equal(188_211_200U, previousStore.ImageSize);
         Assert.Same(store, catalog.FindStore(store.StoreIdentity!.PackageFullName, store.ImageSize));
+        Assert.Same(previousStore, catalog.FindStore(previousStore.StoreIdentity!.PackageFullName, previousStore.ImageSize));
         Assert.Null(catalog.Find(previous.GameVersion, NativeHudBuildContract.SupportedExecutableLength,
             NativeHudBuildContract.SupportedSha256));
         Assert.Null(catalog.FindStore(store.StoreIdentity.PackageFullName, NativeHudBuildContract.BuiltIn.ImageSize));
+        Assert.Null(catalog.FindStore(store.StoreIdentity.PackageFullName, previousStore.ImageSize));
+        Assert.Null(catalog.FindStore(previousStore.StoreIdentity.PackageFullName, store.ImageSize));
+        Assert.Null(catalog.FindStore("Microsoft.ForteBaseGame_3.440.854.0_x64__8wekyb3d8bbwe", store.ImageSize));
+        Assert.Null(catalog.Find(store.GameVersion, store.ImageSize, NativeHudBuildContract.SupportedSha256));
         Assert.False(catalog.HasTrustedPublishers);
     }
 

--- a/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
+++ b/tests/Wisp.App.Tests/NativeStorePackageIdentityTests.cs
@@ -58,7 +58,7 @@ public sealed class NativeStorePackageIdentityTests
         NativeStorePackageIdentity.TryValidate(name, 3, PackagePath, PackagePath, ExecutablePath, out _));
 
     [Theory]
-    [InlineData("Microsoft.ForteBaseGame_3.440.853.0_x64__8wekyb3d8bbwe")]
+    [InlineData("Microsoft.ForteBaseGame_3.440.854.0_x64__8wekyb3d8bbwe")]
     [InlineData("Microsoft.ForteBaseGame_6.430.771.0_x64__8wekyb3d8bbwe")]
     public void NewPackageVersionStillRequiresItsOwnTrustedBuildContract(string fullName)
     {

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.1.3", "1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));
@@ -20,12 +20,30 @@ public sealed class ReleaseNotesCatalogTests
     }
 
     [Fact]
-    public void CurrentCompatibilityEntryIdentifiesTheUpdatedGameBuild()
+    public void CurrentHotfixDocumentsUpdatedStoreCompatibilityAndOptInVacuumDisplay()
     {
         var entry = ReleaseNotesCatalog.Entries[0];
-        Assert.Equal("1.1.2", entry.Version);
+        Assert.Equal("1.1.3", entry.Version);
         Assert.Equal("COMPATIBILITY HOTFIX", entry.Label);
         Assert.True(entry.IsCurrent);
+        Assert.Contains("3.440.853.0", entry.Summary, StringComparison.Ordinal);
+        var text = string.Join(' ', entry.Groups.SelectMany(group => group.Items));
+        Assert.Contains("Xbox app / Microsoft Store FH6 3.440.853.0 on Windows PC", text, StringComparison.Ordinal);
+        Assert.Contains("retaining Store 3.430.771.0", text, StringComparison.Ordinal);
+        Assert.Contains("signed compatibility-map updates introduced in 1.1.2", text, StringComparison.Ordinal);
+        Assert.Contains("Show vacuum pressure", text, StringComparison.Ordinal);
+        Assert.Contains("off by default", text, StringComparison.Ordinal);
+        Assert.Contains("negative pressure reported by FH6", text, StringComparison.Ordinal);
+        Assert.Contains("HUD profiles", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HistoricalCompatibilityEntryIdentifiesTheUpdatedGameBuild()
+    {
+        var entry = ReleaseNotesCatalog.Entries.Single(entry => entry.Version == "1.1.2");
+        Assert.Equal("1.1.2", entry.Version);
+        Assert.Equal("COMPATIBILITY HOTFIX", entry.Label);
+        Assert.False(entry.IsCurrent);
         Assert.Contains("6.440.853.0", entry.Summary, StringComparison.Ordinal);
         var text = string.Join(' ', entry.Groups.SelectMany(group => group.Items));
         Assert.Contains("6.440.853.0", text, StringComparison.Ordinal);

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -64,6 +64,9 @@ public sealed class WpfStyleRuntimeTests
             {
                 var application = new ResourceOnlyApplication();
                 application.Resources = LoadApplicationResources();
+                BoostGaugeVisualsTests.AssertOnCurrentDispatcher();
+                BoostVacuumUiTests.AssertOnCurrentDispatcher();
+                ApplicationUpdateCheckPolicyTests.AssertBannerOnCurrentDispatcher();
                 NativeGaugeLifecycleTests.AssertConsumersOnCurrentDispatcher();
                 NativeRenderLifetimeTests.AssertConsumersOnCurrentDispatcher(_output.WriteLine);
                 decodedGearBackplate = ColorAt(

--- a/tests/Wisp.Core.Tests/AppSettingsTests.cs
+++ b/tests/Wisp.Core.Tests/AppSettingsTests.cs
@@ -9,6 +9,13 @@ namespace Wisp.Core.Tests;
 public sealed class AppSettingsTests
 {
     [Fact]
+    public void VacuumPressureIsOptInForNewAndExistingSettings()
+    {
+        Assert.False(new AppSettings().ShowBoostVacuum);
+        Assert.False(JsonSerializer.Deserialize<AppSettings>("{}")!.ShowBoostVacuum);
+    }
+
+    [Fact]
     public void NewSettingsDefaultToAquaWithAnExpandedSidebar()
     {
         var settings = new AppSettings();
@@ -197,6 +204,7 @@ public sealed class AppSettingsTests
             BoostGaugeColorNumber = true,
             DigitalBoostGaugeColorNumber = true,
             DigitalBoostGaugeStockColors = true,
+            ShowBoostVacuum = true,
             BoostPressureUnit = BoostPressureUnit.Bar,
             BoostGaugeScale = 1.3,
             BoostGaugeTheme = "Stock",
@@ -250,6 +258,7 @@ public sealed class AppSettingsTests
                 Assert.True(loaded.BoostGaugeColorNumber);
                 Assert.True(loaded.DigitalBoostGaugeColorNumber);
                 Assert.True(loaded.DigitalBoostGaugeStockColors);
+                Assert.True(loaded.ShowBoostVacuum);
                 Assert.Equal(BoostPressureUnit.Bar, loaded.BoostPressureUnit);
             }
         }

--- a/tests/Wisp.Telemetry.Tests/Fh6PacketParserTests.cs
+++ b/tests/Wisp.Telemetry.Tests/Fh6PacketParserTests.cs
@@ -59,18 +59,21 @@ public sealed class Fh6PacketParserTests
         Assert.Null(state.ReceivedTimestamp);
     }
 
-    [Fact]
-    public void ParsesBoostPressureFromTheDashChannel()
+    [Theory]
+    [InlineData(29.3437f)]
+    [InlineData(-10.5f)]
+    [InlineData(-0.1f)]
+    public void ParsesBoostPressureFromTheDashChannel(float pressurePsi)
     {
         var packet = Fh6PacketFixture.Create();
-        Fh6PacketFixture.WriteSingle(packet, Fh6PacketLayout.Boost, 29.3437f);
+        Fh6PacketFixture.WriteSingle(packet, Fh6PacketLayout.Boost, pressurePsi);
 
         var parsed = _parser.TryParse(packet, DateTimeOffset.UtcNow, out var state, out var error);
 
         Assert.True(parsed);
         Assert.Equal(PacketParseError.None, error);
         Assert.NotNull(state);
-        Assert.Equal(29.3437f, state.BoostPressurePsi);
+        Assert.Equal(pressurePsi, state.BoostPressurePsi);
     }
 
     [Fact]


### PR DESCRIPTION
## Purpose

Restore the Native HUD for the updated Xbox app / Microsoft Store FH6 build, add the requested optional boost-vacuum display, and make automatic application-update checks run on each intentional open and every 24 hours. Related compatibility report: #43.

## Root cause and solution

The Store update changed the exact native build contract. Add the reviewed Store 3.440.853.0 map derived from that build and retain previous Store and Steam contracts. Existing identity checks, read-only access, and fail-closed behavior remain in place.

Add an off-by-default Show vacuum pressure option to existing boost settings, profiles, gauge layouts, units, and previews. The existing boost visibility toggle permits a stationary zero gauge for naturally aspirated cars; electric vehicles never show it. Negative-pressure readings require positive-boost evidence from the current car/session.

Remove the previous-launch timing suppression from startup update checks, reuse the existing running-session schedule, honor the automatic-check setting, and retain known-update or staged-installer banners across transient automatic failures. Update only connected version, release, documentation, and regression-test files for 1.1.3.

## Validation

- 172 focused tests passed after the final naturally aspirated / EV behavior correction.
- The clean release build for this exact commit passed all 2,836 .NET tests, 75 Python tests, and both separate installer validators.
- The official installer build completed successfully, including locked audited restore, formatting, WPF/UI-review build, updater guard smoke validation, and Inno packaging.
- Formatting and repository-policy checks passed for the committed source.
- Private testing confirmed that the updated Store HUD works. The map also passed guarded identity, structural, and field-contract validation.

- [x] The change is within the approved scope.
- [x] The change improves usability, functionality, reliability, or maintenance, or fixes a verified bug.
- [x] I have read and agree to the contributor-rights terms in CONTRIBUTING.md.
- [x] Regression coverage has been added or updated where appropriate.
- [x] The complete Release test suite passes for this exact commit.
- [x] No credentials, personal data, machine paths, game binaries, save data, private captures, or generated output are included.
- [x] User-facing changes are recorded in CHANGELOG.md.
- [x] Native HUD assets are unchanged.

## Outstanding validation

Required pull-request checks and the tag-triggered release pipeline must pass before publication. A visible update-check banner does not prove a completed production HTTP update request. This release does not claim to fix or close the separate focus-related HUD choppiness report.
