### PR TITLE
Fix analogue tach freezing and clipping after G-force toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Notable changes to Wisp are recorded here.
 
 - Move the live combustion Analogue HUD to a dedicated Direct3D11 and DirectComposition renderer to address tachometer stutter while Forza is focused.
 - Keep the original gauge artwork, native needle angle and blur, and existing playback timing. Digital and electric HUDs and Appearance previews continue using WPF.
+- Keep the Analogue tach rendering through HUD resizes, fixing a stalled, misplaced or clipped speedometer after toggling the attached G-force meter.
 - Correct RPM fallback motion blur to use FH6's combustion needle shutter calculation when native needle data is unavailable.
 - Include telemetry, native needle source, and render-submission timing in local debug exports, grouped by logging period to help investigate remaining smoothness reports.
 

--- a/docs/releases/Wisp-1.1.4-release-notes.md
+++ b/docs/releases/Wisp-1.1.4-release-notes.md
@@ -5,6 +5,8 @@ combustion Analogue HUD now uses Direct3D11 and DirectComposition on a dedicated
 render thread, with the original gauge artwork, native needle angle and blur,
 and existing playback timing.
 
+- Fixes the Analogue tach freezing in the wrong position or clipping the speed
+  readout after toggling the attached G-force meter.
 - Corrects motion blur when the tachometer uses RPM because native needle data
   is unavailable, including when Forza stops updating its stock gauge.
 - Adds needle-source and render-submission timing to local debug exports so

--- a/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
+++ b/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
@@ -81,7 +81,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
         var playback = new AnalogHudPlayback();
         var batch = new (NativeGaugeFrame Frame, long Timestamp)[64];
         var waitHandles = new WaitHandle[] { _stop, _changed };
-        bool announced = false, hasFrame = false, wasActive = false;
+        bool announced = false, hasFrame = false, wasActive = false, frameReady = false;
         int width = 0, height = 0;
         try
         {
@@ -140,13 +140,21 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 }
                 // A previously hidden surface can still contain the old car.
                 // Resume with a transparent swapchain before making it visible.
-                if (!wasActive) device.PrepareForResume();
+                if (!wasActive && device.PrepareForResume()) frameReady = false;
                 device.SetOpacity(presentation.Opacity);
                 device.SetVisible(true);
                 wasActive = true;
-                var ready = device.WaitForNextFrame(100, _stop.SafeWaitHandle);
-                if (ready == DirectCompositionWaitResult.Cancelled) break;
-                if (ready == DirectCompositionWaitResult.Timeout) continue;
+                if (!frameReady)
+                {
+                    var ready = device.WaitForNextFrame(100, _stop.SafeWaitHandle);
+                    if (ready == DirectCompositionWaitResult.Cancelled) break;
+                    if (ready == DirectCompositionWaitResult.Timeout) continue;
+                    frameReady = true;
+                }
+
+                // A layout change or playback reset can restart this iteration
+                // after the frame wait. Keep its readiness until Present succeeds;
+                // waiting again without presenting can stall the swapchain.
 
                 // Fresh samples received while awaiting the swapchain belong
                 // to this frame; never render an earlier queued snapshot.
@@ -179,6 +187,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                     _stop.WaitOne(1);
                     continue;
                 }
+                frameReady = false;
                 AnnounceReady();
                 Record(sample);
             }

--- a/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
+++ b/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
@@ -54,10 +54,13 @@ internal sealed class DirectCompositionDevice : IDisposable
 
     public bool LastRenderWasOccluded { get; private set; }
 
-    public void PrepareForResume()
+    // Only a replaced swapchain requires a new frame-readiness wait.
+    public bool PrepareForResume()
     {
         ThrowIfDisposed();
-        Marshal.ThrowExceptionForHR(Native.PrepareForResume(_handle));
+        var result = Native.PrepareForResume(_handle);
+        Marshal.ThrowExceptionForHR(result);
+        return result == 0;
     }
 
     public void SetOpacity(float opacity)

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -35,6 +35,8 @@ int main()
     uint32_t initialReady = 99;
     Require(SUCCEEDED(WispRendererWaitForFrame(renderer, 100, nullptr, &initialReady)), "initial queue wait");
     std::printf("initialHiddenWait=%u\n", initialReady);
+    Require(WispRendererPrepareForResume(renderer) == S_FALSE,
+        "fresh resume preserves the current chain and acquired readiness");
     std::vector<uint8_t> pixels(32 * 32 * 4);
     Require(WispRendererCapture(renderer, pixels.data(), static_cast<uint32_t>(pixels.size()), 128) == E_INVALIDARG,
         "readback requires explicit capture draw");
@@ -102,7 +104,8 @@ int main()
     for (uint32_t index = 0; index < 8; ++index)
     {
         Require(SUCCEEDED(WispRendererSetVisible(renderer, 0)), "suspend opacity commit");
-        Require(SUCCEEDED(WispRendererPrepareForResume(renderer)), "resume replaces only the stale swapchain");
+        Require(WispRendererPrepareForResume(renderer) == S_OK, "resume reports replacement of the stale swapchain");
+        Require(WispRendererPrepareForResume(renderer) == S_FALSE, "repeated resume retains the fresh swapchain");
         Require(SUCCEEDED(WispRendererCapture(renderer, pixels.data(), static_cast<uint32_t>(pixels.size()), 1152)), "explicit fresh target readback");
         bool freshTransparent = true; for (uint8_t value : pixels) freshTransparent = freshTransparent && value == 0;
         Require(freshTransparent, "fresh resume target contains no previous colored frame");

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
@@ -172,7 +172,7 @@ namespace
         {
             CHECK_HR(CheckThread());
             if (visible) return HRESULT_FROM_WIN32(ERROR_INVALID_STATE);
-            if (!hasDrawn) return S_OK;
+            if (!hasDrawn) return S_FALSE;
             ComPtr<IDXGIDevice> dxgiDevice;
             ComPtr<IDXGIAdapter> adapter;
             ComPtr<IDXGIFactory2> factory;

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
@@ -19,6 +19,7 @@ static_assert(sizeof(WispDrawCommand) == 80, "Managed/native draw ABI mismatch."
 #endif
 WISP_API HRESULT __cdecl WispRendererCreate(HWND hwnd, uint32_t width, uint32_t height, void** renderer) noexcept;
 WISP_API void __cdecl WispRendererDestroy(void* renderer) noexcept;
+// S_OK replaces the swapchain; S_FALSE preserves an already fresh chain.
 WISP_API HRESULT __cdecl WispRendererPrepareForResume(void* renderer) noexcept;
 WISP_API HRESULT __cdecl WispRendererSetOpacity(void* renderer, float opacity) noexcept;
 WISP_API HRESULT __cdecl WispRendererSetVisible(void* renderer, int visible) noexcept;

--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -99,6 +99,7 @@ internal static class NativeRendererIntegrationTests
         var previousOverlay = controller.Overlay;
         var hwnd = new WindowInteropHelper(window).Handle;
         var root = Assert.IsType<Grid>(window.FindName("RootPanel"));
+        var viewbox = Assert.IsType<Viewbox>(window.FindName("RootViewbox"));
         var gForce = Assert.IsAssignableFrom<FrameworkElement>(window.FindName("AttachedNativeGForce"));
         controller.Overlay = window;
         controller.Settings.OverlayWidthScale = 4d / 3;
@@ -137,7 +138,9 @@ internal static class NativeRendererIntegrationTests
             var top = enabled ? 72d : 0;
             Assert.Equal(293.5 + top, root.Height);
             Assert.Equal((293.5 + top) * 4 / 3, window.Height, 6);
-            Assert.Equal(top * 4 / 3, gauge.TransformToAncestor(window).Transform(new Point()).Y, 6);
+            // The HWND rounds to physical pixels before the Viewbox scales its content.
+            Assert.Equal(top * viewbox.ActualHeight / root.Height,
+                gauge.TransformToAncestor(window).Transform(new Point()).Y, 6);
             Assert.Equal(enabled ? Visibility.Visible : Visibility.Collapsed, gForce.Visibility);
             Assert.True(window.IsVisible);
             Assert.True(gauge.IsVisible);

--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Threading;
+using Wisp.App.DebugLogging;
 using Wisp.Core;
 using Xunit;
 
@@ -79,6 +80,8 @@ internal static class NativeRendererIntegrationTests
             Assert.Equal(expectedContentVisibility, Assert.IsAssignableFrom<UIElement>(gauge.Content).Visibility);
             if (!hardwareAvailable) AssertFallbackNeedle(gauge, 7200);
             Assert.NotEqual(hwnd, GetForegroundWindow());
+
+            AssertAttachedGForceResizeKeepsRendering(controller, window, gauge, hardwareAvailable);
         }
         finally
         {
@@ -86,6 +89,81 @@ internal static class NativeRendererIntegrationTests
             Pump();
             controller.DisposeAsync().AsTask().GetAwaiter().GetResult();
             Application.Current.ShutdownMode = previousShutdown;
+        }
+    }
+
+    private static void AssertAttachedGForceResizeKeepsRendering(
+        AppController controller, OverlayWindow window, NativeAnalogSpeedometer gauge, bool hardwareAvailable)
+    {
+        var previousDiagnosticsEnabled = TachDiagnostics.IsEnabled;
+        var previousOverlay = controller.Overlay;
+        var hwnd = new WindowInteropHelper(window).Handle;
+        var root = Assert.IsType<Grid>(window.FindName("RootPanel"));
+        var gForce = Assert.IsAssignableFrom<FrameworkElement>(window.FindName("AttachedNativeGForce"));
+        controller.Overlay = window;
+        controller.Settings.OverlayWidthScale = 4d / 3;
+        controller.Settings.OverlayHeightScale = 4d / 3;
+        controller.ViewModel.GForceAttached = true;
+        TachDiagnostics.SetEnabled(true);
+        try
+        {
+            // Each settled state must consume new input, not merely retain the
+            // old surface or report the renderer's initialization status.
+            AssertState(true, 4300);
+            for (int cycle = 0; cycle < 4; cycle++)
+            {
+                AssertState(false, 4800 + cycle * 200);
+                AssertState(true, 6800 + cycle * 200);
+            }
+        }
+        finally
+        {
+            controller.Overlay = previousOverlay;
+            TachDiagnostics.SetEnabled(previousDiagnosticsEnabled);
+            if (!previousDiagnosticsEnabled) TachDiagnostics.Clear();
+        }
+
+        void AssertState(bool enabled, double rpm)
+        {
+            var started = Stopwatch.GetTimestamp();
+            // Appearance updates the binding first, then ApplyViewOptions
+            // applies this layout. Avoid its live focus query in this fixture.
+            controller.ViewModel.GForceEnabled = enabled;
+            controller.Settings.GForceEnabled = enabled;
+            window.ApplyLayout(HudLayoutMode.Native, NativeGaugeMode.Analogue,
+                controller.Settings.OverlayWidthScale, controller.Settings.OverlayHeightScale, 1);
+            Pump();
+
+            var top = enabled ? 72d : 0;
+            Assert.Equal(293.5 + top, root.Height);
+            Assert.Equal((293.5 + top) * 4 / 3, window.Height, 6);
+            Assert.Equal(top * 4 / 3, gauge.TransformToAncestor(window).Transform(new Point()).Y, 6);
+            Assert.Equal(enabled ? Visibility.Visible : Visibility.Collapsed, gForce.Visibility);
+            Assert.True(window.IsVisible);
+            Assert.True(gauge.IsVisible);
+
+            if (hardwareAvailable)
+            {
+                PumpUntil(() =>
+                {
+                    SetFrame(gauge, 315, rpm);
+                    var snapshot = TachDiagnostics.Snapshot();
+                    if (snapshot is null) return false;
+                    var fresh = snapshot.NeedleStartup.Concat(snapshot.NeedleRecent)
+                        .Where(row => row.Route == "directcomposition" && row.HostKind == nameof(OverlayWindow) &&
+                            row.HostWindowHandle == hwnd.ToInt64() && row.RawRpm == rpm &&
+                            row.AppliedTimestamp >= started && row.ReceivedTimestamp is long received && received >= started)
+                        .DistinctBy(row => (row.ControlId, row.AppliedTimestamp)).ToArray();
+                    return fresh.Length >= 4 && fresh.Select(row => row.ReceivedTimestamp).Distinct().Count() >= 2;
+                }, 2000);
+            }
+            else
+            {
+                SetFrame(gauge, 315, rpm);
+                AssertFallbackNeedle(gauge, rpm);
+            }
+            Assert.NotEqual(hwnd, GetForegroundWindow());
+            Assert.False(window.IsActive);
         }
     }
 


### PR DESCRIPTION
Toggling the attached G-force meter resizes the HUD. If the new size arrived while the native renderer was waiting for a frame, it could discard the acquired readiness and wait again without presenting. The tach then froze at its old position while the other gauges moved, clipping the speed readout or overlapping the G-force meter.

Keep acquired readiness until a frame is submitted or the swapchain is replaced. Distinguish a fresh-chain resume from an actual replacement, preserving the existing normal pacing and gauge layout.

Validation: the new actual-window regression fails with the old render loop and passes with this fix. Composed-window captures confirm correct OFF/ON placement and fully visible speed digits. All 2,939 .NET tests, 73 compatibility checks, two installer validators and native hardware contracts passed locally; two compatibility checks were skipped. The corrected 1.1.4 test installer was delivered for review before publication was approved. Release notes include this fix.

Issue #30 will receive its closing comment only after the corrected release assets are public.
