### PR TITLE
Wisp 1.2: record, review and compare runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.2.0 - 2026-09-09
+
+- Record drives locally from Dashboard or Runs, with optional shortcuts, a start countdown, timed stops and markers for moments to review.
+- Review measured findings, readable charts and selected-interval statistics inside Wisp. Open all eight graph views from one Show graphs button.
+- Compare two saved runs over time or through a shared speed range, including starting-condition differences and capture gaps. Separate run colors and line styles carry through graphs, legends, markers and exported images.
+- Inspect power and torque against RPM with gear and throttle filters, a G-force plot, or front/rear tire-temperature changes.
+- Export a readable report image, raw telemetry CSV, or a Wisp recording that can be imported for comparison.
+- Keep raw run capture and post-run analysis separate from the live HUD renderer and preserve existing HUD profiles.
+
 ## 1.1.4 - 2026-09-08
 
 - Move the live combustion Analogue HUD to a dedicated Direct3D11 and DirectComposition renderer to address tachometer stutter while Forza is focused.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
+## New in Wisp 1.2
+
+Record a drive and compare it with another run without leaving Wisp. Start from
+Dashboard or Runs, or set a recording shortcut. Add a countdown, choose a timed
+stop, and mark moments while driving. Runs stay on your PC, with names, tune
+labels and notes.
+
+Open **Show graphs** to review speed, driver inputs, engine readings, G-force
+and tire temperatures. Compare power and torque against RPM, inspect individual
+readings, or select a section for its own statistics. Run A and Run B use
+different colors and line styles in both Wisp and exported images.
+
+Compare whole recordings or match an acceleration speed range. Findings explain
+what the telemetry shows, with starting conditions and missing data called out.
+Export a report image, raw CSV, or a Wisp run file that someone else can open.
+Recordings are limited to ten minutes; Wisp does not identify tunes automatically
+or record gameplay video.
+
+[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.2 release notes](docs/releases/Wisp-1.2.0-release-notes.md)
+
 ## New in Wisp 1.1.4
 
 Addresses choppy Analogue tachometer motion while Forza is focused. The live

--- a/docs/releases/Wisp-1.2.0-release-notes.md
+++ b/docs/releases/Wisp-1.2.0-release-notes.md
@@ -1,0 +1,26 @@
+# Wisp 1.2
+
+Record a drive, see what happened, and compare it with another run inside Wisp.
+Recordings stay on your PC and can include a run name, tune label and notes.
+
+- Start and stop from Dashboard or Runs, or assign a keyboard shortcut. Choose
+  a countdown or timed stop, and mark moments to return to after driving.
+- Open **Show graphs** for eight views covering speed, driver inputs, engine
+  readings, G-force and tire temperatures. Inspect individual readings or
+  select a section to see its statistics.
+- Compare two saved runs over time or through the same acceleration speed
+  range. Run A and Run B have separate colors and line styles throughout the
+  graphs, legends, markers and report images.
+- Plot power and torque against RPM, with gear and throttle filters. Review
+  cornering and acceleration together in a G-force plot, or compare starting
+  and ending tire temperatures.
+- Read findings based on recorded measurements, with starting conditions and
+  missing data shown alongside the results.
+- Export a report image, raw telemetry CSV, or a Wisp recording that another
+  person can import and compare. Removed runs can be restored.
+
+Runs are limited to ten minutes. Tune names are your own labels; Forza does not
+provide a tune identifier. This records telemetry, not gameplay video. Existing
+HUD rendering, profiles and tire calibration are preserved.
+
+The installer is `Wisp-Setup-1.2.0.exe`. Install over your current Wisp version.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.1.4"
+#define MyAppVersion "1.2.0"
 #define MyAppDisplayVersion MyAppVersion
 #define MyAppOutputVersion MyAppVersion
 #define MyAppPublisher "Wisp"

--- a/src/Wisp.App/App.xaml.cs
+++ b/src/Wisp.App/App.xaml.cs
@@ -23,6 +23,8 @@ public partial class App : Application
     private DispatcherTimer? _forzaStartupTimer;
     private StartupTrayIcon? _startupTray;
     private OverlayHotkeyService? _overlayHotkey;
+    private OverlayHotkeyService? _recordingHotkey;
+    private OverlayHotkeyService? _markerHotkey;
     private bool _runtimeActive;
     private bool _applicationUpdateHandoffActive;
     private bool _exiting;
@@ -54,6 +56,24 @@ public partial class App : Application
         _overlayHotkey = new OverlayHotkeyService();
         _overlayHotkey.Pressed += (_, _) => _controller?.ToggleManualOverlayHidden();
         _controller.SetOverlayHotkeyRegistration(_overlayHotkey.Apply);
+        _recordingHotkey = new OverlayHotkeyService();
+        _recordingHotkey.Pressed += async (_, _) =>
+        {
+            if (_controller is not null && _runtimeActive && !_controller.Runs.ShortcutCaptureActive)
+            {
+                await _controller.Runs.ToggleRecordingAsync();
+            }
+        };
+        _controller.SetRecordingHotkeyRegistration(_recordingHotkey.Apply);
+        _markerHotkey = new OverlayHotkeyService();
+        _markerHotkey.Pressed += (_, _) =>
+        {
+            if (_controller is not null && _runtimeActive && !_controller.Runs.ShortcutCaptureActive)
+            {
+                _controller.Runs.MarkMoment();
+            }
+        };
+        _controller.SetMarkerHotkeyRegistration(_markerHotkey.Apply);
         if (ApplicationUpdateLauncher.TryConsumeResult(out var updateResult))
         {
             _controller.ViewModel.UpdateApplicationUpdateStatus(
@@ -178,6 +198,10 @@ public partial class App : Application
         {
             _overlayHotkey?.Dispose();
             _overlayHotkey = null;
+            _recordingHotkey?.Dispose();
+            _recordingHotkey = null;
+            _markerHotkey?.Dispose();
+            _markerHotkey = null;
             _activationCancellation?.Dispose();
             _activationEvent?.Dispose();
             _instanceMutex?.Dispose();

--- a/src/Wisp.App/AppController.Runs.cs
+++ b/src/Wisp.App/AppController.Runs.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics;
+using System.IO;
+using Wisp.App.Runs;
+using Wisp.Core;
+
+namespace Wisp.App;
+
+public sealed partial class AppController
+{
+    private RunRecordingService _runRecording = null!;
+    private Func<bool, OverlayHotkeyChord, OverlayHotkeyRegistrationResult>? _recordingHotkeyRegistration;
+    private Func<bool, OverlayHotkeyChord, OverlayHotkeyRegistrationResult>? _markerHotkeyRegistration;
+    private bool _runsInitialized;
+    private DrivetrainType? _runCalibrationDrivetrain;
+
+    public RunsViewModel Runs { get; private set; } = null!;
+
+    private void InitializeRuns(string? directory)
+    {
+        // Tests and preview hosts without a SettingsService never open the real library.
+        directory ??= Path.Combine(Path.GetTempPath(), "Wisp", "RunReview", Guid.NewGuid().ToString("N"));
+        _runRecording = new RunRecordingService(_receiver, directory);
+        Runs = new RunsViewModel(_runRecording, Settings, _dispatcher);
+        Runs.BeforeStart = () => PublishRunContext(force: true);
+        Runs.PreferencesChanged += (_, _) => ScheduleSettingsSave();
+    }
+
+    internal void SetRecordingHotkeyRegistration(
+        Func<bool, OverlayHotkeyChord, OverlayHotkeyRegistrationResult> registration)
+    {
+        _recordingHotkeyRegistration = registration;
+        Runs.SetHotkeyHandler(ConfigureRecordingShortcut);
+    }
+
+    private string? ConfigureRecordingShortcut(bool enabled, OverlayHotkeyChord chord)
+    {
+        if (_disposed || _runtimeSuspended || Settings.RequiresSetup)
+        {
+            return "The recording shortcut becomes available when Wisp is running.";
+        }
+        var result = _recordingHotkeyRegistration?.Invoke(enabled, chord)
+            ?? new OverlayHotkeyRegistrationResult(false, "the shortcut service is unavailable");
+        if (!result.Succeeded)
+        {
+            return result.Error;
+        }
+        Settings.RecordingShortcutEnabled = enabled;
+        Settings.RecordingShortcutModifiers = chord.Modifiers;
+        Settings.RecordingShortcutKey = chord.Key;
+        ScheduleSettingsSave();
+        return null;
+    }
+
+    private void StartRunsUi()
+    {
+        Runs.RefreshHotkey();
+        Runs.RefreshMarkerHotkey();
+        if (!_runsInitialized && ControlPanel is not null)
+        {
+            _runsInitialized = true;
+            _ = Runs.InitializeAsync();
+        }
+    }
+
+    private void SuspendRunShortcut()
+    {
+        _ = _recordingHotkeyRegistration?.Invoke(false,
+            new OverlayHotkeyChord(Settings.RecordingShortcutModifiers, Settings.RecordingShortcutKey));
+        Runs.SuspendHotkeyStatus();
+        _ = _markerHotkeyRegistration?.Invoke(false,
+            new OverlayHotkeyChord(Settings.MarkerShortcutModifiers, Settings.MarkerShortcutKey));
+        Runs.SuspendMarkerHotkeyStatus();
+    }
+
+    internal void SetMarkerHotkeyRegistration(
+        Func<bool, OverlayHotkeyChord, OverlayHotkeyRegistrationResult> registration)
+    {
+        _markerHotkeyRegistration = registration;
+        Runs.SetMarkerHotkeyHandler(ConfigureMarkerShortcut);
+    }
+
+    private string? ConfigureMarkerShortcut(bool enabled, OverlayHotkeyChord chord)
+    {
+        if (_disposed || _runtimeSuspended || Settings.RequiresSetup)
+        {
+            return "The marker shortcut becomes available when Wisp is running.";
+        }
+        var result = _markerHotkeyRegistration?.Invoke(enabled, chord)
+            ?? new OverlayHotkeyRegistrationResult(false, "the shortcut service is unavailable");
+        if (!result.Succeeded) return result.Error;
+        Settings.MarkerShortcutEnabled = enabled;
+        Settings.MarkerShortcutModifiers = chord.Modifiers;
+        Settings.MarkerShortcutKey = chord.Key;
+        ScheduleSettingsSave();
+        return null;
+    }
+
+    private void PublishRunContext(bool force = false)
+    {
+        if (!force && !_runRecording.IsRecording)
+        {
+            return;
+        }
+        var state = _receiver.Latest;
+        if (state is null)
+        {
+            return;
+        }
+        var now = Stopwatch.GetTimestamp();
+        var snapshot = _nativeHudProcessService.SnapshotFor(state.CarOrdinal);
+        var visibility = EvaluateNativeGameplayVisibility(snapshot, now);
+        var fresh = state.ReceivedTimestamp is { } received && now >= received &&
+            Stopwatch.GetElapsedTime(received, now) <= TelemetryTimeout;
+        var radii = _hasDebugDerivedTelemetry && _debugDerivedCarOrdinal == state.CarOrdinal &&
+            _runCalibrationDrivetrain == state.Drivetrain &&
+            _debugCalibration.IsTrusted && fresh ? _debugCalibration.TrustedRadii : null;
+        _runRecording.UpdateContext(new RunRecordingContext(
+            now, state.CarOrdinal, state.Drivetrain,
+            fresh && state.IsRaceOn && visibility.Fresh && visibility.Visibility == NativeGameplayVisibility.Visible,
+            radii?.FrontMeters, radii?.RearMeters,
+            visibility.Fresh ? snapshot.VisibilityObservedTimestamp + NativeVisibilityFreshnessTicks : now));
+    }
+}

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -14,7 +14,7 @@ namespace Wisp.App;
 
 public sealed record ApplicationUpdateDetails(string Version, string ReleaseSummary);
 
-public sealed class AppController : IAsyncDisposable
+public sealed partial class AppController : IAsyncDisposable
 {
     private static readonly TimeSpan ConnectedTimerInterval = TimeSpan.FromMilliseconds(50);
     private static readonly TimeSpan IdleTimerInterval = TimeSpan.FromSeconds(1);
@@ -103,7 +103,8 @@ public sealed class AppController : IAsyncDisposable
             settings,
             settingsService.Save,
             new StartupRegistrationService(),
-            settingsService.SaveCompletedSetup)
+            settingsService.SaveCompletedSetup,
+            runsDirectory: Path.Combine(settingsService.DataDirectory, "Runs"))
     {
     }
 
@@ -112,7 +113,8 @@ public sealed class AppController : IAsyncDisposable
         Action<AppSettings> saveSettings,
         IStartupRegistrationService startupRegistrationService,
         Action<AppSettings>? saveCompletedSetup = null,
-        Func<Version, CancellationToken, Task<UpdateRelease?>>? checkForApplicationUpdate = null)
+        Func<Version, CancellationToken, Task<UpdateRelease?>>? checkForApplicationUpdate = null,
+        string? runsDirectory = null)
     {
         Settings = settings;
         _saveSettings = saveSettings ?? throw new ArgumentNullException(nameof(saveSettings));
@@ -145,6 +147,7 @@ public sealed class AppController : IAsyncDisposable
         SetTachDiagnosticsEnabled(_debugLog.IsEnabled);
         ViewModel = new DiagnosticsViewModel(settings);
         _dispatcher = Dispatcher.CurrentDispatcher;
+        InitializeRuns(runsDirectory);
         _debugHealthMonitor = new DebugHealthMonitor(
             _receiver,
             _nativeHudProcessService,
@@ -339,6 +342,7 @@ public sealed class AppController : IAsyncDisposable
 
         _uiTimer.Start();
         ApplyOverlayHotkeyRegistration();
+        StartRunsUi();
     }
 
     internal bool InitializeStartupRegistration()
@@ -384,6 +388,8 @@ public sealed class AppController : IAsyncDisposable
         // Closing to the opt-in companion releases UDP and native demand.
         // Queued packet/compositor callbacks cannot restart a suspended session.
         _runtimeSuspended = true;
+        SuspendRunShortcut();
+        var stoppedRun = _runRecording.StopAsync("Forza session ended");
         _manualOverlayHidden = false;
         _ = _overlayHotkeyRegistration?.Invoke(
             false,
@@ -407,6 +413,7 @@ public sealed class AppController : IAsyncDisposable
             SaveSettings();
         }
         await _receiver.StopAsync().ConfigureAwait(false);
+        await stoppedRun.ConfigureAwait(false);
     }
 
     public void CompleteSetup(SetupPreferences preferences)
@@ -831,6 +838,7 @@ public sealed class AppController : IAsyncDisposable
 
         try
         {
+            await _runRecording.StopAsync("Telemetry listener restarted");
             await _receiver.RestartAsync(port);
         }
         catch
@@ -1024,6 +1032,7 @@ public sealed class AppController : IAsyncDisposable
 
             UpdateOverlayVisibility(DateTimeOffset.UtcNow, force: true);
             ScheduleSettingsSave();
+            Runs.RefreshStatus();
             if (!previousAutomaticApplicationUpdateChecks && Settings.AutomaticApplicationUpdateChecks)
             {
                 BeginStartupApplicationUpdateCheck();
@@ -1712,6 +1721,8 @@ public sealed class AppController : IAsyncDisposable
         }
 
         _calibration.ResetProfile(carOrdinal);
+        _runCalibrationDrivetrain = null;
+        PublishRunContext();
         _capturedCalibrationProfiles.Remove(carOrdinal);
         Settings.Calibrations = _calibration.ExportSnapshots().ToList();
         _speedModel.Reset();
@@ -1801,6 +1812,9 @@ public sealed class AppController : IAsyncDisposable
         }
 
         _disposed = true;
+        _ = _runRecording.StopAsync("Wisp closed before the run finished");
+        SuspendRunShortcut();
+        Runs.Dispose();
         SetTachDiagnosticsEnabled(false);
         _compatibilityLifetime.Cancel();
         _applicationUpdateLifetime.Cancel();
@@ -1848,6 +1862,7 @@ public sealed class AppController : IAsyncDisposable
         {
             // Optional local logging must never prevent clean application shutdown.
         }
+        await _runRecording.DisposeAsync().ConfigureAwait(false);
         await _nativeHudProcessService.DisposeAsync().ConfigureAwait(false);
         await _receiver.DisposeAsync().ConfigureAwait(false);
         _compatibilityLifetime.Dispose();
@@ -1986,6 +2001,9 @@ public sealed class AppController : IAsyncDisposable
         {
             _nextStatisticsAtUtc = now + TimeSpan.FromMilliseconds(250);
             _cachedStatistics = _receiver.GetStatistics(now);
+            _runRecording.RefreshStatus();
+            PublishRunContext();
+            if (Runs.IsCountingDown) Runs.RefreshStatus();
         }
 
         var latest = _receiver.Latest;
@@ -2149,7 +2167,9 @@ public sealed class AppController : IAsyncDisposable
         _debugDerivedCarOrdinal = current.CarOrdinal;
         _debugIndicatedSpeed = indicated;
         _debugCalibration = calibration;
+        _runCalibrationDrivetrain = current.Drivetrain;
         _hasDebugDerivedTelemetry = true;
+        PublishRunContext();
         var detachedBoostWasEnabled = IsDetachedBoostGaugeEnabled;
         var detachedTireTemperatureWasEnabled = IsDetachedTireTemperatureGaugeEnabled;
         ViewModel.Update(

--- a/src/Wisp.App/AppSettings.cs
+++ b/src/Wisp.App/AppSettings.cs
@@ -102,6 +102,17 @@ public sealed class AppSettings
     public OverlayHotkeyModifiers OverlayHotkeyModifiers { get; set; } =
         OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift;
     public Key OverlayHotkeyKey { get; set; } = Key.H;
+    public Wisp.Core.Runs.RunPurpose RunPurpose { get; set; }
+    public bool RecordingShortcutEnabled { get; set; }
+    public OverlayHotkeyModifiers RecordingShortcutModifiers { get; set; } =
+        OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift;
+    public Key RecordingShortcutKey { get; set; } = Key.R;
+    public int RecordingCountdownSeconds { get; set; }
+    public int RecordingStopAfterSeconds { get; set; }
+    public bool MarkerShortcutEnabled { get; set; }
+    public OverlayHotkeyModifiers MarkerShortcutModifiers { get; set; } =
+        OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift;
+    public Key MarkerShortcutKey { get; set; } = Key.M;
     public bool AutoMinimizeOnTelemetry { get; set; } = true;
     public bool TractionCueEnabled { get; set; } = true;
     public bool HasCompletedSetup { get; set; }
@@ -266,6 +277,25 @@ public sealed class AppSettings
             OverlayHotkeyEnabled = false;
             OverlayHotkeyModifiers = OverlayHotkeyChord.Default.Modifiers;
             OverlayHotkeyKey = OverlayHotkeyChord.Default.Key;
+        }
+
+        if (!Enum.IsDefined(RunPurpose))
+        {
+            RunPurpose = Wisp.Core.Runs.RunPurpose.General;
+        }
+        if (!OverlayHotkeyChord.TryCreate(RecordingShortcutModifiers, RecordingShortcutKey, out _, out _))
+        {
+            RecordingShortcutEnabled = false;
+            RecordingShortcutModifiers = OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift;
+            RecordingShortcutKey = Key.R;
+        }
+        if (RecordingCountdownSeconds is not (0 or 3 or 5 or 10)) RecordingCountdownSeconds = 0;
+        if (RecordingStopAfterSeconds is not (0 or 30 or 60 or 120 or 300 or 600)) RecordingStopAfterSeconds = 0;
+        if (!OverlayHotkeyChord.TryCreate(MarkerShortcutModifiers, MarkerShortcutKey, out _, out _))
+        {
+            MarkerShortcutEnabled = false;
+            MarkerShortcutModifiers = OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift;
+            MarkerShortcutKey = Key.M;
         }
 
         var debugLoggingNowUtc = DateTimeOffset.UtcNow;
@@ -462,6 +492,8 @@ public sealed class SettingsService
 
     private readonly string _settingsPath;
     private readonly string _setupRequiredMarkerPath;
+
+    internal string DataDirectory => Path.GetDirectoryName(_settingsPath)!;
 
     public SettingsService(string? settingsPath = null)
     {

--- a/src/Wisp.App/ApplicationVersionInfo.cs
+++ b/src/Wisp.App/ApplicationVersionInfo.cs
@@ -19,8 +19,9 @@ public static class ApplicationVersionInfo
         ? $"WHEEL-INDICATED SPEED PANEL {label} (private)"
         : $"WHEEL-INDICATED SPEED PANEL {DisplayVersion}";
 
-    public static string ReleaseHistoryIntroduction =>
-        $"Feature updates, hotfixes, and important refinements from every documented public release. The current {DisplayVersion} entry covers this release.";
+    public static string ReleaseHistoryIntroduction => DiagnosticBuildLabel is { Length: > 0 } label
+        ? $"You are testing {label}. The test features and previous public releases are listed below."
+        : $"Feature updates, hotfixes, and important refinements from every documented public release. The current {DisplayVersion} entry covers this release.";
 
     public static string Format(Version version) => Format(
         new SemanticVersion(version.Major, version.Minor, Math.Max(0, version.Build)));

--- a/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
@@ -206,7 +206,10 @@ internal static class TachDiagnosticReport
             var nativeFile = nativeRenderer.GetProperty("file").GetString();
             var nativeHash = nativeRenderer.GetProperty("sha256").GetString();
             var nativeBytes = nativeRenderer.GetProperty("bytes").GetInt64();
-            if (root.GetProperty("schema_version").GetInt32() != 1 || kind != "release" ||
+            var validBuildKind = kind == "release" ||
+                (kind == "private" && ApplicationVersionInfo.DiagnosticBuildId is { Length: > 0 } privateId &&
+                 root.TryGetProperty("private_build_id", out var packagedId) && packagedId.GetString() == privateId);
+            if (root.GetProperty("schema_version").GetInt32() != 1 || !validBuildKind ||
                 version != ApplicationVersionInfo.MachineVersion ||
                 revision is not { Length: 40 or 64 } || !revision.All(Uri.IsHexDigit) ||
                 hash is not { Length: 64 } || !hash.All(Uri.IsHexDigit) || bytes <= 0 ||

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
         xmlns:local="clr-namespace:Wisp.App"
+        xmlns:runs="clr-namespace:Wisp.App.Runs"
         Title="Wisp" Width="1080" Height="780" MinWidth="720" MinHeight="440"
         FontFamily="Segoe UI Variable Text, Segoe UI" FontSize="13"
         Foreground="{DynamicResource TextBrush}" Background="{DynamicResource WindowBrush}" WindowStartupLocation="CenterScreen" Cursor="Arrow"
@@ -124,14 +125,16 @@
                         <TranslateTransform x:Name="SidebarTranslation" />
                     </Border.RenderTransform>
                     <Grid>
-                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+                        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="*" /><RowDefinition Height="Auto" /></Grid.RowDefinitions>
                         <TextBlock Text="Workspace" Margin="22,24,0,8" FontSize="11" Foreground="{DynamicResource MutedBrush}" />
                         <ListBox x:Name="SidebarNavigation" Grid.Row="1" Margin="10,0" Padding="0"
                                  Background="Transparent" BorderThickness="0" ItemContainerStyle="{StaticResource SidebarItemStyle}"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                 VirtualizingPanel.IsVirtualizing="False" VerticalAlignment="Top"
                                  SelectedIndex="{Binding SelectedIndex, ElementName=RootTabs, Mode=TwoWay}"
                                  AutomationProperties.Name="Wisp pages">
                             <ListBoxItem AutomationProperties.Name="Dashboard"><StackPanel Orientation="Horizontal"><Path Style="{StaticResource SidebarIconStyle}" Data="M1,1 H7 V7 H1 Z M11,1 H17 V7 H11 Z M1,11 H7 V17 H1 Z M11,11 H17 V17 H11 Z" /><TextBlock Text="Dashboard" VerticalAlignment="Center" /></StackPanel></ListBoxItem>
+                            <ListBoxItem AutomationProperties.Name="Runs"><StackPanel Orientation="Horizontal"><Path Style="{StaticResource SidebarIconStyle}" Data="M1,1 V17 H18 M4,12 L8,7 L12,10 L17,3" /><TextBlock Text="Runs" VerticalAlignment="Center" /></StackPanel></ListBoxItem>
                             <ListBoxItem AutomationProperties.Name="Appearance"><StackPanel Orientation="Horizontal"><Path Style="{StaticResource SidebarIconStyle}" Data="M1,3 H7 M11,3 H17 M1,9 H11 M15,9 H17 M1,15 H4 M8,15 H17 M7,1 V5 H11 V1 Z M11,7 V11 H15 V7 Z M4,13 V17 H8 V13 Z" /><TextBlock Text="Appearance" VerticalAlignment="Center" /></StackPanel></ListBoxItem>
                             <ListBoxItem AutomationProperties.Name="Diagnostics"><StackPanel Orientation="Horizontal"><Path Style="{StaticResource SidebarIconStyle}" Data="M0,9 H4 L7,2 L11,16 L14,9 H18" /><TextBlock Text="Diagnostics" VerticalAlignment="Center" /></StackPanel></ListBoxItem>
                             <ListBoxItem AutomationProperties.Name="Profiles"><StackPanel Orientation="Horizontal"><Path Style="{StaticResource SidebarIconStyle}" Data="M3,2 H15 V6 H3 Z M3,8 H15 V12 H3 Z M3,14 H15 V18 H3 Z" /><TextBlock Text="Profiles" VerticalAlignment="Center" /></StackPanel></ListBoxItem>
@@ -368,10 +371,30 @@
                                                     VerticalAlignment="Center" Click="ToggleLock_Click" />
                                         </Grid>
                                     </Border>
+                                    <Border x:Name="DashboardRunPanel" Style="{StaticResource CardStyle}" Margin="0,14,0,0">
+                                        <StackPanel>
+                                            <TextBlock Text="Record a run" FontWeight="SemiBold" FontSize="15" />
+                                            <TextBlock Text="Save a drive, explore the graphs, and compare another run." TextWrapping="Wrap" Foreground="{DynamicResource MutedBrush}" Margin="0,5,0,12" />
+                                            <WrapPanel>
+                                                <Button Content="{Binding RecordButtonText}" Command="{Binding ToggleRecordingCommand}" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,8,8" AutomationProperties.Name="Start or stop recording a run" />
+                                                <Button Content="Open Runs" Click="OpenRuns_Click" Margin="0,0,0,8" />
+                                                <Button Content="Mark moment" Command="{Binding MarkMomentCommand}" Margin="8,0,0,8">
+                                                    <Button.Style><Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}"><Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsRecording}" Value="False"><Setter Property="Visibility" Value="Collapsed" /></DataTrigger>
+                                                    </Style.Triggers></Style></Button.Style>
+                                                </Button>
+                                            </WrapPanel>
+                                            <TextBlock Text="{Binding RecordingStatus}" TextWrapping="Wrap" Foreground="{DynamicResource MutedBrush}" AutomationProperties.LiveSetting="Polite" />
+                                        </StackPanel>
+                                    </Border>
                                 </StackPanel>
                                 </Viewbox>
                                 </Decorator>
                             </ScrollViewer>
+                        </TabItem>
+
+                        <TabItem x:Name="RunsTab" Header="Runs">
+                            <runs:RunsPage x:Name="RunsSurface" />
                         </TabItem>
 
                         <TabItem Header="Appearance">

--- a/src/Wisp.App/MainWindow.xaml.cs
+++ b/src/Wisp.App/MainWindow.xaml.cs
@@ -64,6 +64,8 @@ public partial class MainWindow : Window
         LoadSelectedColorTarget();
         SetSidebarOpen(!controller.Settings.SidebarCollapsed, animate: false);
         DataContext = controller.ViewModel;
+        RunsSurface.DataContext = controller.Runs;
+        DashboardRunPanel.DataContext = controller.Runs;
         MphRadio.IsChecked = controller.Settings.SpeedUnit == SpeedUnit.MilesPerHour;
         KphRadio.IsChecked = controller.Settings.SpeedUnit == SpeedUnit.KilometersPerHour;
         NewtonMetersRadio.IsChecked = controller.Settings.TorqueUnit == TorqueUnit.NewtonMeters;
@@ -1018,6 +1020,8 @@ public partial class MainWindow : Window
     {
         _controller.ResetOverlayPosition();
     }
+
+    private void OpenRuns_Click(object sender, RoutedEventArgs e) => RootTabs.SelectedItem = RunsTab;
 
     private void RelearnTires_Click(object sender, RoutedEventArgs e)
     {

--- a/src/Wisp.App/Properties/AssemblyInfo.cs
+++ b/src/Wisp.App/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Wisp.App.Tests")]
+[assembly: InternalsVisibleTo("Wisp.UiReview")]

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,28 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.2",
+            "September 9, 2026",
+            "RECORD & COMPARE RUNS",
+            "Record a drive, review what happened, and compare it with another run inside Wisp.",
+            true,
+            [
+                Group("Record a run",
+                    "Start and stop from Dashboard or Runs, with an optional keyboard shortcut while driving.",
+                    "Choose a countdown or timed stop, and mark moments to find them again after the run.",
+                    "Save recordings locally with a name, tune label and notes. Existing HUD profiles and settings stay in place."),
+                Group("Review and compare",
+                    "Open Show graphs for all eight views. Read concise findings alongside speed, inputs, engine and tire charts, or select a section of the run.",
+                    "Compare two recordings over time or through the same speed range. Distinct run colors and line styles, starting conditions, and missing data keep the comparison clear.",
+                    "Switch to power and torque against RPM, a G-force plot, or tire-temperature changes. Filter RPM plots by gear and throttle.",
+                    "Export a report image, raw telemetry CSV, or a Wisp recording for another person to open and compare.")
+            ]),
+        new(
             "1.1.4",
             "September 8, 2026",
             "TACHOMETER HOTFIX",
             "Addresses choppy Analogue tachometer motion while Forza is focused, with corrected motion blur when native needle data is unavailable.",
-            true,
+            false,
             [
                 Group("Analogue tachometer",
                     "Moves the live combustion Analogue HUD to Direct3D11 and DirectComposition on a dedicated render thread, keeping the original gauge artwork, native needle angle and blur, and existing playback timing.",

--- a/src/Wisp.App/Runs/RunAlternativePlotView.cs
+++ b/src/Wisp.App/Runs/RunAlternativePlotView.cs
@@ -1,0 +1,235 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Wisp.App.Runs;
+
+public sealed class RunAlternativePlotView : FrameworkElement
+{
+    public static readonly DependencyProperty PanelProperty = DependencyProperty.Register(nameof(Panel), typeof(RunAlternativePlotPanel), typeof(RunAlternativePlotView), new FrameworkPropertyMetadata(null, Changed));
+    public static readonly DependencyProperty AccentBrushProperty = DependencyProperty.Register(nameof(AccentBrush), typeof(Brush), typeof(RunAlternativePlotView), new FrameworkPropertyMetadata(Brushes.Turquoise, Changed));
+    public static readonly DependencyProperty TextBrushProperty = DependencyProperty.Register(nameof(TextBrush), typeof(Brush), typeof(RunAlternativePlotView), new FrameworkPropertyMetadata(Brushes.WhiteSmoke, Changed));
+    public static readonly DependencyProperty MutedBrushProperty = DependencyProperty.Register(nameof(MutedBrush), typeof(Brush), typeof(RunAlternativePlotView), new FrameworkPropertyMetadata(Brushes.SlateGray, Changed));
+    public RunAlternativePlotPanel? Panel { get => (RunAlternativePlotPanel?)GetValue(PanelProperty); set => SetValue(PanelProperty, value); }
+    public Brush AccentBrush { get => (Brush)GetValue(AccentBrushProperty); set => SetValue(AccentBrushProperty, value); }
+    public Brush TextBrush { get => (Brush)GetValue(TextBrushProperty); set => SetValue(TextBrushProperty, value); }
+    public Brush MutedBrush { get => (Brush)GetValue(MutedBrushProperty); set => SetValue(MutedBrushProperty, value); }
+    public event Action<RunAlternativeSelection>? PointSelected;
+    internal bool ShowInteractionHints { get; set; } = true;
+    private readonly List<(Geometry Geometry, bool Comparison)> _geometry = [];
+    private readonly List<Hit> _hits = [];
+    private Size _size;
+    private bool _prepared;
+    private int _selected = -1;
+    private sealed record Hit(Point Position, bool Comparison, double Seconds, int SampleIndex, string Detail);
+
+    public RunAlternativePlotView()
+    {
+        MinHeight = 280; Focusable = true; Cursor = Cursors.Cross;
+        AutomationProperties.SetHelpText(this, "Use left and right arrows to inspect recorded points. Press Enter to select a point in the run.");
+    }
+
+    private static void Changed(DependencyObject target, DependencyPropertyChangedEventArgs args)
+    {
+        var view = (RunAlternativePlotView)target;
+        view._prepared = false; view._selected = -1;
+        if (args.Property == PanelProperty)
+        {
+            AutomationProperties.SetName(view, view.Panel?.Title ?? "Run plot");
+            view.SetCurrentValue(MinHeightProperty, view.Panel?.EqualAxes == true ? 340d : 280d);
+        }
+        view.InvalidateVisual();
+    }
+
+    private Rect Plot
+    {
+        get
+        {
+            double width = Math.Max(1, ActualWidth - 82), height = Math.Max(1, ActualHeight - 154);
+            if (Panel?.EqualAxes == true)
+            {
+                var side = Math.Min(width, height);
+                return new(64 + (width - side) / 2, 88 + (height - side) / 2, side, side);
+            }
+            return new(64, 88, width, height);
+        }
+    }
+
+    protected override void OnRender(DrawingContext drawing)
+    {
+        base.OnRender(drawing);
+        if (Panel is null || ActualWidth < 180 || ActualHeight < 180) return;
+        drawing.DrawRectangle(Brushes.Transparent, null, new Rect(RenderSize));
+        Text(drawing, Panel.Title, 14, TextBrush, new(0, 0), ActualWidth);
+        Text(drawing, Panel.Description, 11, MutedBrush, new(0, 23), ActualWidth);
+        for (var i = 0; i < Panel.Series.Length; i++)
+        {
+            var series = Panel.Series[i];
+            var x = i * ActualWidth / Math.Max(1, Panel.Series.Length);
+            var color = series.Comparison ? RunComparisonColors.RunB : AccentBrush;
+            drawing.DrawRectangle(series.Comparison ? null : color, new Pen(color, 1.6), new Rect(x, 49, 10, 10));
+            var count = Panel.Kind == RunAlternativePlotKind.Scatter ? $" · {series.Points.Length:N0} of {series.SourcePointCount:N0} readings" : "";
+            Text(drawing, series.Name + count, 11, color, new(x + 17, 45), ActualWidth / Math.Max(1, Panel.Series.Length) - 20);
+        }
+        var plot = Plot;
+        Text(drawing, Panel.YLabel + " (" + Panel.YUnit + ")", 10.5, MutedBrush, new(0, 68), ActualWidth);
+        var grid = new Pen(MutedBrush, .45);
+        for (var i = 0; i <= 4; i++)
+        {
+            var fraction = i / 4d;
+            var y = plot.Bottom - fraction * plot.Height;
+            drawing.DrawLine(grid, new(plot.Left, y), new(plot.Right, y));
+            Text(drawing, Format(Panel.YMinimum + fraction * (Panel.YMaximum - Panel.YMinimum)), 10, MutedBrush, new(plot.Left - 61, y - 7), 56);
+            if (Panel.Kind == RunAlternativePlotKind.Scatter)
+            {
+                var x = plot.Left + fraction * plot.Width;
+                drawing.DrawLine(grid, new(x, plot.Top), new(x, plot.Bottom));
+                var labelWidth = Math.Min(70, plot.Width / 4);
+                Text(drawing, Format(Panel.XMinimum + fraction * (Panel.XMaximum - Panel.XMinimum)), 10, MutedBrush,
+                    new(x - labelWidth / 2, plot.Bottom + 7), labelWidth, TextAlignment.Center);
+            }
+        }
+        if (Panel.Kind == RunAlternativePlotKind.Bars)
+        {
+            for (var i = 0; i < Panel.Categories.Length; i++)
+                Text(drawing, Panel.Categories[i], 10, MutedBrush, new(X(i) - plot.Width / 8 + 2, plot.Bottom + 7), plot.Width / 4 - 4);
+        }
+        else Text(drawing, Panel.XLabel + " (" + Panel.XUnit + ")", 10.5, MutedBrush, new(plot.Left, plot.Bottom + 25), plot.Width);
+
+        if (!_prepared || _size != RenderSize) Prepare();
+        drawing.PushClip(new RectangleGeometry(plot));
+        if (Panel.XMinimum < 0 && Panel.XMaximum > 0)
+            drawing.DrawLine(new Pen(MutedBrush, 1), new(X(0), plot.Top), new(X(0), plot.Bottom));
+        if (Panel.YMinimum < 0 && Panel.YMaximum > 0)
+            drawing.DrawLine(new Pen(MutedBrush, 1), new(plot.Left, Y(0)), new(plot.Right, Y(0)));
+        foreach (var (geometry, comparison) in _geometry)
+        {
+            var brush = comparison ? RunComparisonColors.RunB : AccentBrush;
+            drawing.PushOpacity(comparison ? .8 : .7);
+            drawing.DrawGeometry(comparison ? null : brush, comparison ? new Pen(brush, 1.3) : null, geometry);
+            drawing.Pop();
+        }
+        if (_selected >= 0 && _selected < _hits.Count)
+            drawing.DrawEllipse(null, new Pen(TextBrush, 1.5), _hits[_selected].Position, 5, 5);
+        drawing.Pop();
+        if (Panel.Kind == RunAlternativePlotKind.Bars)
+        {
+            foreach (var series in Panel.Series.Take(2))
+                for (var category = 0; category < Math.Min(4, Panel.Categories.Length); category++)
+                {
+                    var bar = Panel.Bars.FirstOrDefault(value => value.Comparison == series.Comparison && value.Category == category);
+                    var x = X(category) + (Panel.Series.Length == 1 ? 0 : (series.Comparison ? .17 : -.17) * plot.Width / 4);
+                    var y = bar is null ? plot.Bottom - 15 : Math.Clamp(Y(bar.Value) - 16, plot.Top, plot.Bottom - 15);
+                    Text(drawing, bar is null ? "—" : Format(bar.Value), 10, series.Comparison ? RunComparisonColors.RunB : AccentBrush, new(x - 18, y), 40);
+                }
+        }
+        if (_hits.Count == 0)
+            Text(drawing, Panel.Kind == RunAlternativePlotKind.Bars ? "Tire temperatures were unavailable for this selection." : Panel.XUnit == "RPM"
+                    ? "No matching RPM readings. Adjust the gear/throttle filters or select another section." : "No recorded driving points were available in this selection.",
+                12, MutedBrush, new(plot.Left + 8, plot.Top + 15), plot.Width - 16, lines: 3);
+        var detail = _selected >= 0 && _selected < _hits.Count ? _hits[_selected].Detail :
+            Panel.Kind == RunAlternativePlotKind.Bars ? "Hover a bar, or focus the plot and use arrow keys, to read its value." : "Hover a dot, or focus the plot and use arrow keys, to inspect its recorded value.";
+        if (ShowInteractionHints) Text(drawing, detail, 11, TextBrush, new(0, ActualHeight - 20), ActualWidth);
+    }
+
+    private void Prepare()
+    {
+        _geometry.Clear(); _hits.Clear();
+        if (Panel is null) return;
+        foreach (var series in Panel.Series.Take(2))
+        {
+            var geometry = new StreamGeometry { FillRule = FillRule.Nonzero };
+            using (var context = geometry.Open())
+            {
+                if (Panel.Kind == RunAlternativePlotKind.Scatter)
+                {
+                    foreach (var point in series.Points.Take(RunAlternativePlots.MaximumSeriesPoints))
+                    {
+                        if (!double.IsFinite(point.X) || !double.IsFinite(point.Y)) continue;
+                        var position = new Point(X(point.X), Y(point.Y));
+                        if (!Plot.Contains(position)) continue;
+                        Square(context, new Rect(position.X - 2, position.Y - 2, 4, 4));
+                        _hits.Add(new(position, series.Comparison, point.SourceSeconds, point.SampleIndex,
+                            $"{series.Name} · {point.SourceSeconds:0.000}s · gear {(int)point.Gear} · {Format(point.X)} {Panel.XUnit} / {Format(point.Y)} {Panel.YUnit}"));
+                    }
+                }
+                else
+                {
+                    foreach (var bar in Panel.Bars.Where(bar => bar.Comparison == series.Comparison).Take(4))
+                    {
+                        if (!double.IsFinite(bar.Value) || bar.Category < 0 || bar.Category >= Panel.Categories.Length) continue;
+                        var groupWidth = Plot.Width / 4;
+                        var width = groupWidth * (Panel.Series.Length == 1 ? .46 : .28);
+                        var offset = Panel.Series.Length == 1 ? 0 : (series.Comparison ? .17 : -.17) * groupWidth;
+                        var x = X(bar.Category) + offset;
+                        var y = Y(bar.Value); var zero = Y(0);
+                        Square(context, new Rect(x - width / 2, Math.Min(y, zero), width, Math.Max(.8, Math.Abs(zero - y))));
+                        _hits.Add(new(new(x, y), series.Comparison, bar.SourceSeconds, -1,
+                            $"{series.Name} · {Panel.Categories[bar.Category]} · {Format(bar.Value)} {Panel.YUnit} · boundary {bar.SourceSeconds:0.000}s"));
+                    }
+                }
+            }
+            geometry.Freeze(); _geometry.Add((geometry, series.Comparison));
+        }
+        _prepared = true; _size = RenderSize;
+        if (_selected >= _hits.Count) _selected = -1;
+    }
+
+    private static void Square(StreamGeometryContext context, Rect rectangle)
+    {
+        context.BeginFigure(rectangle.TopLeft, true, true); context.LineTo(rectangle.TopRight, true, false);
+        context.LineTo(rectangle.BottomRight, true, false); context.LineTo(rectangle.BottomLeft, true, false);
+    }
+    private double X(double value) => Plot.Left + (value - Panel!.XMinimum) / Math.Max(.0001, Panel.XMaximum - Panel.XMinimum) * Plot.Width;
+    private double Y(double value) => Plot.Bottom - (value - Panel!.YMinimum) / Math.Max(.0001, Panel.YMaximum - Panel.YMinimum) * Plot.Height;
+    private static string Format(double value) => value.ToString(Math.Abs(value) >= 100 ? "0" : "0.##", CultureInfo.CurrentCulture);
+    private void Text(DrawingContext drawing, string value, double size, Brush brush, Point position, double width,
+        TextAlignment alignment = TextAlignment.Left, int lines = 1)
+    {
+        var text = new FormattedText(value, CultureInfo.CurrentCulture, FlowDirection.LeftToRight, new Typeface("Segoe UI"), size, brush, VisualTreeHelper.GetDpi(this).PixelsPerDip)
+        { MaxTextWidth = Math.Max(1, width), MaxLineCount = lines, Trimming = TextTrimming.CharacterEllipsis, TextAlignment = alignment };
+        drawing.DrawText(text, position);
+    }
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        base.OnMouseMove(e);
+        var mouse = e.GetPosition(this); var closest = -1; var distance = Panel?.Kind == RunAlternativePlotKind.Bars ? double.MaxValue : 225d;
+        for (var i = 0; i < _hits.Count; i++)
+        {
+            var d = (_hits[i].Position - mouse).LengthSquared;
+            if (d < distance && Plot.Contains(mouse)) { closest = i; distance = d; }
+        }
+        Select(closest);
+    }
+    protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        base.OnMouseLeftButtonDown(e); Focus(); PublishSelection(); e.Handled = true;
+    }
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (_hits.Count == 0) return;
+        if (e.Key is Key.Left or Key.Right or Key.Home or Key.End)
+        {
+            var selected = e.Key switch { Key.Home => 0, Key.End => _hits.Count - 1, Key.Left => Math.Max(0, _selected - 1), _ => Math.Min(_hits.Count - 1, _selected + 1) };
+            Select(selected); e.Handled = true;
+        }
+        else if (e.Key == Key.Enter) { PublishSelection(); e.Handled = true; }
+    }
+    private void Select(int selected)
+    {
+        if (_selected == selected) return;
+        _selected = selected;
+        AutomationProperties.SetItemStatus(this, selected >= 0 && selected < _hits.Count ? _hits[selected].Detail : "");
+        InvalidateVisual();
+    }
+    private void PublishSelection()
+    {
+        if (_selected >= 0 && _selected < _hits.Count && _hits[_selected].SampleIndex >= 0)
+        {
+            var hit = _hits[_selected]; PointSelected?.Invoke(new(hit.Comparison, hit.Seconds, hit.SampleIndex));
+        }
+    }
+}

--- a/src/Wisp.App/Runs/RunAlternativePlots.cs
+++ b/src/Wisp.App/Runs/RunAlternativePlots.cs
@@ -1,0 +1,163 @@
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public enum RunPlotMode { TimeSeries, PowerByRpm, GForce, TireChange }
+public enum RunAlternativePlotKind { Scatter, Bars }
+public readonly record struct RunAlternativePoint(double X, double Y, double SourceSeconds, int SampleIndex, int Segment, TransmissionGear Gear);
+public sealed record RunAlternativeSeries(string Name, bool Comparison, RunAlternativePoint[] Points, int SourcePointCount);
+public sealed record RunAlternativeBar(int Category, bool Comparison, double Value, double SourceSeconds);
+public readonly record struct RunAlternativeSelection(bool Comparison, double SourceSeconds, int SampleIndex);
+public sealed record RunAlternativePlotPanel(string Title, string Description, RunAlternativePlotKind Kind,
+    string XLabel, string XUnit, string YLabel, string YUnit,
+    double XMinimum, double XMaximum, double YMinimum, double YMaximum,
+    RunAlternativeSeries[] Series, RunAlternativeBar[] Bars, string[] Categories, bool EqualAxes = false);
+
+public static class RunAlternativePlots
+{
+    public const int MaximumSeriesPoints = 1200;
+    private const double Gravity = 9.80665;
+
+    public static RunAlternativePlotPanel[] Build(RecordedRun a, RecordedRun? b, RunPlotMode mode,
+        TireTemperatureUnit temperatureUnit, TorqueUnit torqueUnit, RunInterval? intervalA = null, RunInterval? intervalB = null,
+        bool fullThrottleOnly = true, TransmissionGear? gear = null)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        Validate(intervalA); Validate(intervalB);
+        if (!Enum.IsDefined(mode)) throw new ArgumentOutOfRangeException(nameof(mode));
+        if (mode == RunPlotMode.TimeSeries) return [];
+        if (mode == RunPlotMode.PowerByRpm && gear is { } selected && (selected < TransmissionGear.First || selected > TransmissionGear.Tenth))
+            throw new ArgumentOutOfRangeException(nameof(gear), "Select a forward gear.");
+        if (mode == RunPlotMode.TireChange) return [TirePanel(a, b, temperatureUnit, intervalA, intervalB)];
+        if (mode == RunPlotMode.GForce)
+            return [Scatter("Cornering and acceleration", "+Y acceleration · −Y braking. Each dot is one recorded driving sample.",
+                "Lateral", "g", "Longitudinal", "g", sample => sample.State.LateralAccelerationMetersPerSecondSquared / Gravity,
+                sample => sample.State.LongitudinalAccelerationMetersPerSecondSquared / Gravity, false, true)];
+        var filters = (fullThrottleOnly ? "Full throttle" : "All throttle inputs") + (gear is { } g ? $" · gear {(int)g}" : " · all forward gears");
+        return
+        [
+            Scatter("Power by RPM", filters + ". Each dot is a recorded reading.", "Engine speed", "RPM", "Power", "hp",
+                sample => sample.State.EngineRpm, sample => sample.State.PowerWatts / 745.699872, true, false),
+            Scatter("Torque by RPM", filters + ". Each dot is a recorded reading.", "Engine speed", "RPM", "Torque",
+                torqueUnit == TorqueUnit.NewtonMeters ? "Nm" : "lb-ft", sample => sample.State.EngineRpm,
+                sample => sample.State.TorqueNm * (torqueUnit == TorqueUnit.NewtonMeters ? 1 : .7375621493), true, false)
+        ];
+
+        RunAlternativePlotPanel Scatter(string title, string description, string xLabel, string xUnit, string yLabel, string yUnit,
+            Func<RunSample, double> x, Func<RunSample, double> y, bool power, bool equalAxes)
+        {
+            var series = new List<RunAlternativeSeries> { Series(a, false, intervalA) };
+            if (b is not null) series.Add(Series(b, true, intervalB));
+            var all = series.SelectMany(value => value.Points).ToArray();
+            double xMin, xMax, yMin, yMax;
+            if (equalAxes)
+            {
+                var limit = Math.Max(1, Math.Ceiling(all.Select(point => Math.Max(Math.Abs(point.X), Math.Abs(point.Y))).DefaultIfEmpty(0).Max() * 1.05 * 4) / 4);
+                xMin = yMin = -limit; xMax = yMax = limit;
+            }
+            else
+            {
+                (xMin, xMax) = Bounds(all.Select(point => point.X), true);
+                (yMin, yMax) = Bounds(all.Select(point => point.Y), true);
+            }
+            return new(title, description, RunAlternativePlotKind.Scatter, xLabel, xUnit, yLabel, yUnit,
+                xMin, xMax, yMin, yMax, series.ToArray(), [], [], equalAxes);
+
+            RunAlternativeSeries Series(RecordedRun run, bool comparison, RunInterval? interval)
+            {
+                var points = new List<RunAlternativePoint>();
+                for (var index = 0; index < run.Samples.Length; index++)
+                {
+                    var sample = run.Samples[index];
+                    if (!Driving(sample) || interval is { } range && (sample.ElapsedSeconds < range.StartSeconds || sample.ElapsedSeconds > range.EndSeconds)) continue;
+                    if (power && (sample.State.Gear < TransmissionGear.First || sample.State.Gear > TransmissionGear.Tenth ||
+                        sample.State.EngineRpm <= 0 || fullThrottleOnly && sample.State.Accelerator < RunAnalysis.FullThrottleMinimum ||
+                        gear is { } selectedGear && sample.State.Gear != selectedGear)) continue;
+                    double xx = x(sample), yy = y(sample);
+                    if (!double.IsFinite(xx) || !double.IsFinite(yy)) continue;
+                    points.Add(new(xx, yy, sample.ElapsedSeconds, index, sample.Segment, sample.State.Gear));
+                }
+                return new(comparison ? "Run B" : "Run A", comparison, Reduce(points), points.Count);
+            }
+        }
+    }
+
+    // Every retained dot is an original reading. No connection or interpolation crosses a gap.
+    internal static RunAlternativePoint[] Reduce(IReadOnlyList<RunAlternativePoint> points)
+    {
+        if (points.Count <= MaximumSeriesPoints) return points.ToArray();
+        var output = new List<RunAlternativePoint>(MaximumSeriesPoints);
+        var bucketSize = (int)Math.Ceiling(points.Count / (MaximumSeriesPoints / 6d));
+        for (var start = 0; start < points.Count; start += bucketSize)
+        {
+            int end = Math.Min(points.Count, start + bucketSize), minX = start, maxX = start, minY = start, maxY = start;
+            for (var index = start + 1; index < end; index++)
+            {
+                if (points[index].X < points[minX].X) minX = index;
+                if (points[index].X > points[maxX].X) maxX = index;
+                if (points[index].Y < points[minY].Y) minY = index;
+                if (points[index].Y > points[maxY].Y) maxY = index;
+            }
+            foreach (var index in new[] { start, minX, maxX, minY, maxY, end - 1 }.Distinct().Order()) output.Add(points[index]);
+        }
+        return output.ToArray();
+    }
+
+    private static RunAlternativePlotPanel TirePanel(RecordedRun a, RecordedRun? b, TireTemperatureUnit unit, RunInterval? intervalA, RunInterval? intervalB)
+    {
+        var bars = new List<RunAlternativeBar>();
+        Add(a, false, intervalA); if (b is not null) Add(b, true, intervalB);
+        var (minimum, maximum) = Bounds(bars.Select(bar => bar.Value), true);
+        return new("Tire temperature change", "Start/end axle averages. Boundary interpolation stays within continuous data; gaps stay empty.",
+            RunAlternativePlotKind.Bars, "", "", "Temperature", unit == TireTemperatureUnit.Celsius ? "°C" : "°F",
+            -.5, 3.5, minimum, maximum, b is null ? [new("Run A", false, [], 0)] : [new("Run A", false, [], 0), new("Run B", true, [], 0)],
+            bars.ToArray(), ["Front · start", "Front · end", "Rear · start", "Rear · end"]);
+
+        void Add(RecordedRun run, bool comparison, RunInterval? interval)
+        {
+            var report = RunAnalysis.BuildReport(run, interval: interval);
+            var values = new[] { report.Statistics.StartingFrontTemperatureFahrenheit, report.Statistics.EndingFrontTemperatureFahrenheit,
+                report.Statistics.StartingRearTemperatureFahrenheit, report.Statistics.EndingRearTemperatureFahrenheit };
+            var startAvailable = SupportedBoundary(run, report.Interval.StartSeconds);
+            var endAvailable = SupportedBoundary(run, report.Interval.EndSeconds);
+            for (var index = 0; index < values.Length; index++)
+                if ((index % 2 == 0 ? startAvailable : endAvailable) && values[index] is { } fahrenheit && double.IsFinite(fahrenheit))
+                    bars.Add(new(index, comparison, unit == TireTemperatureUnit.Celsius ? (fahrenheit - 32) * 5 / 9 : fahrenheit,
+                        index % 2 == 0 ? report.Interval.StartSeconds : report.Interval.EndSeconds));
+        }
+    }
+
+    private static bool SupportedBoundary(RecordedRun run, double seconds)
+    {
+        RunSample? previous = null;
+        var latest = double.NegativeInfinity;
+        foreach (var sample in run.Samples)
+        {
+            if (!Driving(sample) || sample.ElapsedSeconds < latest - 1e-7) { previous = null; continue; }
+            latest = sample.ElapsedSeconds;
+            if (Math.Abs(sample.ElapsedSeconds - seconds) <= 1e-7) return true;
+            if (previous is not null && seconds > previous.ElapsedSeconds && seconds < sample.ElapsedSeconds && RunAnalysis.AreContinuous(previous, sample))
+                return true;
+            previous = sample;
+        }
+        return false;
+    }
+
+    private static (double Minimum, double Maximum) Bounds(IEnumerable<double> values, bool includeZero)
+    {
+        var array = values.ToArray();
+        if (array.Length == 0) return (0, 1);
+        double minimum = array.Min(), maximum = array.Max();
+        if (includeZero) { minimum = Math.Min(0, minimum); maximum = Math.Max(0, maximum); }
+        var padding = Math.Max(1, maximum - minimum) * .06;
+        return (minimum < 0 ? minimum - padding : minimum, maximum + padding);
+    }
+    private static bool Driving(RunSample sample) => sample.IsDriving && sample.State.IsRaceOn && double.IsFinite(sample.ElapsedSeconds) && sample.ElapsedSeconds >= 0 &&
+        float.IsFinite(sample.State.GroundSpeedMetersPerSecond) && sample.State.GroundSpeedMetersPerSecond >= 0;
+    private static void Validate(RunInterval? interval)
+    {
+        if (interval is { } value && (!double.IsFinite(value.StartSeconds) || !double.IsFinite(value.EndSeconds) || value.StartSeconds < 0 || value.EndSeconds < value.StartSeconds))
+            throw new ArgumentOutOfRangeException(nameof(interval));
+    }
+}

--- a/src/Wisp.App/Runs/RunChartView.cs
+++ b/src/Wisp.App/Runs/RunChartView.cs
@@ -1,0 +1,214 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Wisp.App.Runs;
+
+public sealed class RunChartView : FrameworkElement
+{
+    private StreamGeometry? _gapGeometry;
+    public static readonly DependencyProperty PanelProperty = DependencyProperty.Register(nameof(Panel), typeof(RunPlotPanel), typeof(RunChartView), new FrameworkPropertyMetadata(null, InvalidatePlot));
+    public static readonly DependencyProperty StartSecondsProperty = DependencyProperty.Register(nameof(StartSeconds), typeof(double), typeof(RunChartView), new FrameworkPropertyMetadata(0d, InvalidatePlot));
+    public static readonly DependencyProperty EndSecondsProperty = DependencyProperty.Register(nameof(EndSeconds), typeof(double), typeof(RunChartView), new FrameworkPropertyMetadata(1d, InvalidatePlot));
+    public static readonly DependencyProperty CursorSecondsProperty = DependencyProperty.Register(nameof(CursorSeconds), typeof(double), typeof(RunChartView), new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+    public static readonly DependencyProperty SelectionStartProperty = DependencyProperty.Register(nameof(SelectionStart), typeof(double), typeof(RunChartView), new FrameworkPropertyMetadata(double.NaN, FrameworkPropertyMetadataOptions.AffectsRender));
+    public static readonly DependencyProperty SelectionEndProperty = DependencyProperty.Register(nameof(SelectionEnd), typeof(double), typeof(RunChartView), new FrameworkPropertyMetadata(double.NaN, FrameworkPropertyMetadataOptions.AffectsRender));
+    public static readonly DependencyProperty AccentBrushProperty = DependencyProperty.Register(nameof(AccentBrush), typeof(Brush), typeof(RunChartView), new FrameworkPropertyMetadata(Brushes.Turquoise, InvalidatePlot));
+    public static readonly DependencyProperty TextBrushProperty = DependencyProperty.Register(nameof(TextBrush), typeof(Brush), typeof(RunChartView), new FrameworkPropertyMetadata(Brushes.WhiteSmoke, InvalidatePlot));
+    public static readonly DependencyProperty MutedBrushProperty = DependencyProperty.Register(nameof(MutedBrush), typeof(Brush), typeof(RunChartView), new FrameworkPropertyMetadata(Brushes.SlateGray, FrameworkPropertyMetadataOptions.AffectsRender));
+    public static readonly DependencyProperty WarningBrushProperty = DependencyProperty.Register(nameof(WarningBrush), typeof(Brush), typeof(RunChartView), new FrameworkPropertyMetadata(Brushes.Orange, InvalidatePlot));
+    public static readonly DependencyProperty MarkersProperty = DependencyProperty.Register(nameof(Markers), typeof(IEnumerable<RunPlotMarker>), typeof(RunChartView), new FrameworkPropertyMetadata(Array.Empty<RunPlotMarker>(), FrameworkPropertyMetadataOptions.AffectsRender));
+    private readonly List<(Geometry Geometry, Pen Pen)> _paths = [];
+    private Size _preparedSize;
+    private bool _prepared;
+    private double? _dragStart;
+    private double? _dragEnd;
+    public event Action<double, double>? IntervalSelected;
+    public RunPlotPanel? Panel { get => (RunPlotPanel?)GetValue(PanelProperty); set => SetValue(PanelProperty, value); }
+    public double StartSeconds { get => (double)GetValue(StartSecondsProperty); set => SetValue(StartSecondsProperty, value); }
+    public double EndSeconds { get => (double)GetValue(EndSecondsProperty); set => SetValue(EndSecondsProperty, value); }
+    public double CursorSeconds { get => (double)GetValue(CursorSecondsProperty); set => SetValue(CursorSecondsProperty, value); }
+    public double SelectionStart { get => (double)GetValue(SelectionStartProperty); set => SetValue(SelectionStartProperty, value); }
+    public double SelectionEnd { get => (double)GetValue(SelectionEndProperty); set => SetValue(SelectionEndProperty, value); }
+    public Brush AccentBrush { get => (Brush)GetValue(AccentBrushProperty); set => SetValue(AccentBrushProperty, value); }
+    public Brush TextBrush { get => (Brush)GetValue(TextBrushProperty); set => SetValue(TextBrushProperty, value); }
+    public Brush MutedBrush { get => (Brush)GetValue(MutedBrushProperty); set => SetValue(MutedBrushProperty, value); }
+    public Brush WarningBrush { get => (Brush)GetValue(WarningBrushProperty); set => SetValue(WarningBrushProperty, value); }
+    public IEnumerable<RunPlotMarker> Markers { get => (IEnumerable<RunPlotMarker>)GetValue(MarkersProperty); set => SetValue(MarkersProperty, value); }
+    internal bool RenderOffscreen { get; set; }
+    private bool HasComparison => Panel?.Series.Any(series => series.Comparison) == true;
+    public RunChartView()
+    {
+        Focusable = true; Cursor = Cursors.Cross; MinHeight = 180;
+        // A chart measured while its pane is hidden may retain an empty drawing.
+        IsVisibleChanged += (_, _) => { if (IsVisible) InvalidateVisual(); };
+    }
+    private Rect Plot => new(52, 30 + Math.Ceiling((Panel?.Series.Length ?? 0) / 2d) * 19,
+        Math.Max(1, ActualWidth - 64), Math.Max(1, ActualHeight - 60 - Math.Ceiling((Panel?.Series.Length ?? 0) / 2d) * 19));
+    private static void InvalidatePlot(DependencyObject target, DependencyPropertyChangedEventArgs args)
+    {
+        var chart = (RunChartView)target;
+        chart._prepared = false;
+        chart.InvalidateVisual();
+    }
+    protected override void OnRender(DrawingContext drawing)
+    {
+        if ((!IsVisible && !RenderOffscreen) || Panel is null || ActualWidth < 100 || ActualHeight < 100) return;
+        base.OnRender(drawing);
+        drawing.DrawRectangle(Brushes.Transparent, null, new Rect(RenderSize));
+        Text(drawing, Panel.Title + " · " + Panel.Unit, 13, TextBrush, new Point(0, 0));
+        for (int index = 0; index < Panel.Series.Length; index++)
+        {
+            var series = Panel.Series[index];
+            var x = index % 2 * ActualWidth / 2;
+            var y = 24 + index / 2 * 19;
+            var pen = PenFor(series);
+            drawing.DrawLine(pen, new Point(x, y + 7), new Point(x + 20, y + 7));
+            Text(drawing, series.Name + ": " + ValueAt(series, CursorSeconds), 10.5, HasComparison ? pen.Brush : TextBrush, new Point(x + 26, y), ActualWidth / 2 - 30);
+        }
+        var plot = Plot;
+        var gridPen = new Pen(MutedBrush, .4);
+        for (int index = 0; index <= 4; index++)
+        {
+            double fraction = index / 4d;
+            var y = plot.Bottom - fraction * plot.Height;
+            drawing.DrawLine(gridPen, new Point(plot.Left, y), new Point(plot.Right, y));
+            Text(drawing, (Panel.Minimum + fraction * (Panel.Maximum - Panel.Minimum)).ToString("0.#", CultureInfo.CurrentCulture),
+                10, MutedBrush, new Point(0, y - 6), 48);
+            Text(drawing, RunPresentation.Time(StartSeconds + fraction * Range), 10, MutedBrush,
+                new Point(plot.Left + fraction * plot.Width - (index == 4 ? 30 : 0), plot.Bottom + 7), 58);
+        }
+        drawing.PushClip(new RectangleGeometry(plot));
+        double selectionStart = _dragStart ?? SelectionStart, selectionEnd = _dragEnd ?? SelectionEnd;
+        if (double.IsFinite(selectionStart) && double.IsFinite(selectionEnd))
+        {
+            var left = X(Math.Min(selectionStart, selectionEnd));
+            var right = X(Math.Max(selectionStart, selectionEnd));
+            drawing.PushOpacity(.13);
+            drawing.DrawRectangle(AccentBrush, null, new Rect(left, plot.Top, Math.Max(0, right - left), plot.Height));
+            drawing.Pop();
+        }
+        if (!_prepared || _preparedSize != RenderSize) Prepare();
+        foreach (var (geometry, pen) in _paths) drawing.DrawGeometry(null, pen, geometry);
+        if (_gapGeometry is not null)
+        {
+            drawing.PushOpacity(.15); drawing.DrawGeometry(MutedBrush, null, _gapGeometry); drawing.Pop();
+        }
+        DrawMarkers(drawing);
+        if (CursorSeconds >= StartSeconds && CursorSeconds <= EndSeconds)
+            drawing.DrawLine(new Pen(TextBrush, 1), new Point(X(CursorSeconds), plot.Top), new Point(X(CursorSeconds), plot.Bottom));
+        drawing.Pop();
+        if (Panel.Series.All(series => series.Points.Length == 0))
+            Text(drawing, "This channel was not available in the recording.", 12, MutedBrush, new Point(plot.Left + 8, plot.Top + 24), plot.Width - 16);
+    }
+    private void DrawMarkers(DrawingContext drawing)
+    {
+        var markers = (Markers ?? []).Where(marker => double.IsFinite(marker.Seconds) && marker.Seconds >= StartSeconds && marker.Seconds <= EndSeconds)
+            .OrderBy(marker => marker.Seconds).Take(256).ToArray();
+        var labelEvery = Math.Max(1, (int)Math.Ceiling(markers.Length / 8d));
+        for (var index = 0; index < markers.Length; index++)
+        {
+            var marker = markers[index]; var brush = marker.Comparison ? RunComparisonColors.RunB : HasComparison ? RunComparisonColors.RunA : AccentBrush;
+            var pen = new Pen(brush, .8) { DashStyle = DashStyles.Dot };
+            var x = X(marker.Seconds);
+            drawing.DrawLine(pen, new Point(x, Plot.Top), new Point(x, Plot.Bottom));
+            if (index % labelEvery == 0)
+                Text(drawing, (marker.Comparison ? "B · " : "A · ") + marker.Label, 9, brush,
+                    new Point(Math.Min(x + 3, Plot.Right - 86), Plot.Top + 3 + (index / labelEvery % 2) * 13), 86);
+        }
+    }
+    private void Prepare()
+    {
+        _paths.Clear();
+        if (Panel is null) return;
+        _gapGeometry = new StreamGeometry { FillRule = FillRule.Nonzero };
+        using (var context = _gapGeometry.Open())
+        {
+            foreach (var gap in Panel.Series.SelectMany(series => series.Gaps).Distinct())
+            {
+                if (gap.EndSeconds <= StartSeconds || gap.StartSeconds >= EndSeconds) continue;
+                double left = X(Math.Max(StartSeconds, gap.StartSeconds)), right = X(Math.Min(EndSeconds, gap.EndSeconds));
+                context.BeginFigure(new(left, Plot.Top), true, true);
+                context.LineTo(new(right, Plot.Top), true, false); context.LineTo(new(right, Plot.Bottom), true, false);
+                context.LineTo(new(left, Plot.Bottom), true, false);
+            }
+        }
+        _gapGeometry.Freeze();
+        foreach (var series in Panel.Series)
+        {
+            var geometry = new StreamGeometry();
+            using (var context = geometry.Open())
+            {
+                bool started = false;
+                foreach (var point in series.Points)
+                {
+                    var position = new Point(X(point.Seconds), Y(point.Value));
+                    if (!started || point.BreakBefore) context.BeginFigure(position, false, false);
+                    else context.LineTo(position, true, false);
+                    started = true;
+                }
+            }
+            geometry.Freeze();
+            _paths.Add((geometry, PenFor(series)));
+        }
+        _prepared = true;
+        _preparedSize = RenderSize;
+    }
+    private Pen PenFor(RunPlotSeries series)
+    {
+        var brush = HasComparison ? RunComparisonColors.Series(series.Comparison, series.ColorIndex)
+            : series.ColorIndex switch { 1 => TextBrush, 2 => WarningBrush, _ => AccentBrush };
+        var pen = new Pen(brush, series.Comparison ? 1.8 : 2) { DashStyle = series.Comparison ? DashStyles.Dash : DashStyles.Solid };
+        if (pen.CanFreeze) pen.Freeze();
+        return pen;
+    }
+    private static string ValueAt(RunPlotSeries series, double seconds)
+    {
+        return series.ReadRecordedValue?.Invoke(seconds) is double value ? value.ToString("0.#", CultureInfo.CurrentCulture) : "—";
+    }
+    private void Text(DrawingContext drawing, string value, double size, Brush brush, Point point, double width = double.PositiveInfinity)
+    {
+        var text = new FormattedText(value, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
+            new Typeface("Segoe UI"), size, brush, VisualTreeHelper.GetDpi(this).PixelsPerDip);
+        if (double.IsFinite(width)) { text.MaxTextWidth = Math.Max(1, width); text.MaxLineCount = 1; text.Trimming = TextTrimming.CharacterEllipsis; }
+        drawing.DrawText(text, point);
+    }
+    private double Range => Math.Max(.01, EndSeconds - StartSeconds);
+    private double X(double seconds) => Plot.Left + (seconds - StartSeconds) / Range * Plot.Width;
+    private double Y(double value) => Plot.Bottom - (value - Panel!.Minimum) / Math.Max(.01, Panel.Maximum - Panel.Minimum) * Plot.Height;
+    private double TimeAt(Point position) => StartSeconds + Math.Clamp((position.X - Plot.Left) / Plot.Width, 0, 1) * Range;
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        base.OnMouseMove(e);
+        var seconds = TimeAt(e.GetPosition(this));
+        SetCurrentValue(CursorSecondsProperty, seconds);
+        if (_dragStart is not null) { _dragEnd = seconds; InvalidateVisual(); }
+    }
+    protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+    {
+        base.OnMouseLeftButtonDown(e);
+        Focus(); _dragStart = _dragEnd = TimeAt(e.GetPosition(this)); CaptureMouse(); e.Handled = true;
+    }
+    protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+    {
+        base.OnMouseLeftButtonUp(e);
+        if (_dragStart is double start)
+        {
+            var end = TimeAt(e.GetPosition(this));
+            _dragStart = _dragEnd = null; ReleaseMouseCapture();
+            if (Math.Abs(end - start) >= .05) IntervalSelected?.Invoke(Math.Min(start, end), Math.Max(start, end));
+            InvalidateVisual();
+        }
+    }
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        if (e.Key is Key.Left or Key.Right or Key.Home)
+        {
+            SetCurrentValue(CursorSecondsProperty, e.Key == Key.Home ? StartSeconds : Math.Clamp(CursorSeconds + (e.Key == Key.Left ? -1 : 1) * Range / 100, StartSeconds, EndSeconds));
+            e.Handled = true;
+        }
+        if (e.Key == Key.Escape) { _dragStart = _dragEnd = null; ReleaseMouseCapture(); InvalidateVisual(); }
+    }
+}

--- a/src/Wisp.App/Runs/RunComparisonColors.cs
+++ b/src/Wisp.App/Runs/RunComparisonColors.cs
@@ -1,0 +1,22 @@
+using System.Windows.Media;
+
+namespace Wisp.App.Runs;
+
+public static class RunComparisonColors
+{
+    // Stable data colors keep the runs distinct even with a custom app accent.
+    public static Brush RunA { get; } = Frozen(0x63, 0xD8, 0xD4);
+    public static Brush RunB { get; } = Frozen(0xFF, 0xB8, 0x6B);
+    private static readonly Brush[] Baseline = [RunA, Frozen(0x91, 0xC5, 0xFF), Frozen(0xC5, 0xB3, 0xFF)];
+    private static readonly Brush[] Comparison = [RunB, Frozen(0xF6, 0xD8, 0x86), Frozen(0xFF, 0x9D, 0xBC)];
+
+    internal static Brush Series(bool comparison, int channel) =>
+        (comparison ? Comparison : Baseline)[channel is >= 0 and < 3 ? channel : 0];
+
+    private static Brush Frozen(byte red, byte green, byte blue)
+    {
+        var brush = new SolidColorBrush(Color.FromRgb(red, green, blue));
+        brush.Freeze();
+        return brush;
+    }
+}

--- a/src/Wisp.App/Runs/RunCsvExporter.cs
+++ b/src/Wisp.App/Runs/RunCsvExporter.cs
@@ -1,0 +1,79 @@
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public static class RunCsvExporter
+{
+    public const string Header = "time_s,segment,is_driving,is_race_on,game_timestamp_ms,car_ordinal,drivetrain,num_cylinders,ground_speed_mps,wheel_speed_mps,front_radius_m,rear_radius_m,engine_rpm,engine_maximum_rpm,gear,steering_raw,accelerator_raw,brake_raw,lateral_acceleration_mps2,longitudinal_acceleration_mps2,power_w,torque_nm,boost_psi,wheel_rotation_fl_rad_s,wheel_rotation_fr_rad_s,wheel_rotation_rl_rad_s,wheel_rotation_rr_rad_s,tire_slip_ratio_fl,tire_slip_ratio_fr,tire_slip_ratio_rl,tire_slip_ratio_rr,tire_slip_angle_fl,tire_slip_angle_fr,tire_slip_angle_rl,tire_slip_angle_rr,suspension_travel_fl,suspension_travel_fr,suspension_travel_rl,suspension_travel_rr,tire_temperature_fl_f,tire_temperature_fr_f,tire_temperature_rl_f,tire_temperature_rr_f";
+
+    public static Task WriteAsync(RecordedRun run, string newFilePath, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newFilePath);
+        return Task.Run(() => WriteCoreAsync(run, newFilePath, cancellationToken), cancellationToken);
+    }
+
+    private static async Task WriteCoreAsync(RecordedRun run, string newFilePath, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var destination = Path.GetFullPath(newFilePath);
+        if (File.Exists(destination)) throw new IOException("The export file already exists. Choose a new filename.");
+        var directory = Path.GetDirectoryName(destination)!;
+        var temporary = Path.Combine(directory, ".wisp-csv-" + Guid.NewGuid().ToString("N") + ".tmp");
+        try
+        {
+            await using (var file = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None, 64 * 1024,
+                FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                await using (var writer = new StreamWriter(file, new UTF8Encoding(false), 64 * 1024, leaveOpen: true))
+                {
+                    await writer.WriteLineAsync(Header.AsMemory(), cancellationToken).ConfigureAwait(false);
+                    foreach (var sample in run.Samples)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await writer.WriteLineAsync(Row(sample).AsMemory(), cancellationToken).ConfigureAwait(false);
+                    }
+                    await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+                file.Flush(flushToDisk: true);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(temporary, destination, overwrite: false);
+        }
+        finally
+        {
+            // The final export is never removed, including when a same-name file won a race.
+            try { File.Delete(temporary); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private static string Row(RunSample sample)
+    {
+        var state = sample.State;
+        var values = new List<string>(43)
+        {
+            Number(sample.ElapsedSeconds), Integer(sample.Segment), Bit(sample.IsDriving), Bit(state.IsRaceOn),
+            state.GameTimestampMilliseconds.ToString(CultureInfo.InvariantCulture), Integer(state.CarOrdinal), Integer((int)state.Drivetrain), Integer(state.NumCylinders),
+            Number(state.GroundSpeedMetersPerSecond), Number(sample.WheelSpeedMetersPerSecond), Number(sample.FrontRadiusMeters), Number(sample.RearRadiusMeters),
+            Number(state.EngineRpm), Number(state.EngineMaximumRpm), Integer((int)state.Gear), Integer(state.Steering), Integer(state.Accelerator), Integer(state.Brake),
+            Number(state.LateralAccelerationMetersPerSecondSquared), Number(state.LongitudinalAccelerationMetersPerSecondSquared),
+            Number(state.PowerWatts), Number(state.TorqueNm), Number(state.BoostPressurePsi)
+        };
+        Wheels(state.WheelRotationRadiansPerSecond); Wheels(state.TireSlipRatio); Wheels(state.TireSlipAngle);
+        Wheels(state.NormalizedSuspensionTravel); Wheels(state.TireTemperatureFahrenheit);
+        return string.Join(',', values);
+
+        void Wheels(WheelValues wheels)
+        {
+            values.Add(Number(wheels.FrontLeft)); values.Add(Number(wheels.FrontRight));
+            values.Add(Number(wheels.RearLeft)); values.Add(Number(wheels.RearRight));
+        }
+    }
+    private static string Number(double? value) => value is { } number && double.IsFinite(number) ? number.ToString("R", CultureInfo.InvariantCulture) : "";
+    private static string Integer(int value) => value.ToString(CultureInfo.InvariantCulture);
+    private static string Bit(bool value) => value ? "1" : "0";
+}

--- a/src/Wisp.App/Runs/RunCursor.cs
+++ b/src/Wisp.App/Runs/RunCursor.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+internal static class RunCursor
+{
+    internal static string Describe(string label, RecordedRun run, double seconds, RunInterval? bounds = null)
+    {
+        var rpm = RunPresentation.RecordedValueAt(run.Samples, sample => sample.State.EngineRpm, seconds, bounds);
+        var gear = RunPresentation.RecordedValueAt(run.Samples,
+            sample => sample.State.Gear == TransmissionGear.Unknown ? null : (double)sample.State.Gear, seconds, bounds);
+        if (rpm is null && gear is null)
+        {
+            return $"{label} · Reading unavailable";
+        }
+
+        var rpmText = rpm is { } value ? value.ToString("N0", CultureInfo.CurrentCulture) + " RPM" : "RPM unavailable";
+        var gearText = gear switch
+        {
+            (double)TransmissionGear.Reverse => "reverse",
+            (double)TransmissionGear.Neutral => "neutral",
+            >= 1 and <= 10 => "gear " + gear.Value.ToString("0", CultureInfo.CurrentCulture),
+            _ => "gear unavailable"
+        };
+        return $"{label} · {rpmText} · {gearText}";
+    }
+}

--- a/src/Wisp.App/Runs/RunImageExporter.cs
+++ b/src/Wisp.App/Runs/RunImageExporter.cs
@@ -1,0 +1,179 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+internal sealed record RunImageSnapshot(
+    string RunA, string? RunB, string Interval, string Context,
+    RunFinding[] Findings, RunMetric[] Metrics, RunPlotPanel[] Charts,
+    RunAlternativePlotPanel[] AlternativeCharts, double StartSeconds, double EndSeconds);
+
+internal static class RunImageExporter
+{
+    internal const int ImageWidth = 1280;
+    internal const int MaximumImageHeight = 4096;
+    private static readonly Brush Background = Frozen(0x13, 0x1B, 0x20);
+    private static readonly Brush Surface = Frozen(0x1D, 0x29, 0x30);
+    private static readonly Brush Accent = RunComparisonColors.RunA;
+    private static readonly Brush Ink = Frozen(0xED, 0xF3, 0xF6);
+    private static readonly Brush Muted = Frozen(0xB0, 0xBF, 0xC8);
+
+    // Only this bounded offscreen layout runs on the dispatcher. Encoding and disk I/O do not.
+    internal static BitmapSource Render(RunImageSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (!double.IsFinite(snapshot.StartSeconds) || !double.IsFinite(snapshot.EndSeconds) ||
+            snapshot.EndSeconds < snapshot.StartSeconds || snapshot.Charts.Length > 4 ||
+            snapshot.AlternativeCharts.Length > 4 || snapshot.Metrics.Length > 16 || snapshot.Findings.Length > 32)
+            throw new ArgumentException("The report is too large or its interval is invalid.", nameof(snapshot));
+
+        var body = new StackPanel { Margin = new Thickness(48, 36, 48, 32) };
+        body.Children.Add(Label("WISP  /  RUN REVIEW", 18, Accent, 28, FontWeights.SemiBold));
+        body.Children.Add(Label(snapshot.RunB is null ? "Recorded run" : "Run comparison", 34, Ink, 48, FontWeights.SemiBold));
+        body.Children.Add(Label("A · " + snapshot.RunA, 20, RunComparisonColors.RunA, 56));
+        if (snapshot.RunB is not null) body.Children.Add(Label("B · " + snapshot.RunB, 20, RunComparisonColors.RunB, 56));
+        body.Children.Add(Label(snapshot.Interval, 17, Accent, 52));
+        body.Children.Add(Label(snapshot.Context, 15, Muted, 80));
+
+        var metrics = new System.Windows.Controls.Primitives.UniformGrid
+        {
+            Columns = snapshot.Metrics.Length == 9 ? 3 : 4,
+            Margin = new Thickness(0, 20, 0, 12)
+        };
+        foreach (var metric in snapshot.Metrics)
+        {
+            var content = new StackPanel();
+            content.Children.Add(Label(metric.Label, 13, Muted, 40));
+            content.Children.Add(Label(metric.Value, 22, Ink, 64, FontWeights.SemiBold));
+            if (metric.Comparison is not null) content.Children.Add(Label("B · " + metric.Comparison, 13, RunComparisonColors.RunB, 48));
+            metrics.Children.Add(new Border
+            {
+                Background = Surface,
+                CornerRadius = new CornerRadius(7),
+                Margin = new Thickness(0, 0, 10, 10),
+                Padding = new Thickness(14),
+                Child = content
+            });
+        }
+        body.Children.Add(metrics);
+        if (snapshot.RunB is not null && snapshot.Metrics.Any(metric => metric.Comparison is not null))
+            body.Children.Add(Label("Metric differences in brackets are B minus A.", 13, Muted, 40));
+
+        foreach (var finding in snapshot.Findings.Take(3))
+        {
+            var item = new StackPanel { Margin = new Thickness(0, 12, 0, 0) };
+            item.Children.Add(Label(finding.Title, 18, Ink, 54, FontWeights.SemiBold));
+            item.Children.Add(Label(finding.Detail, 15, Muted, 92));
+            body.Children.Add(item);
+        }
+        body.Children.Add(Label("Selected graphs", 21, Ink, 36, FontWeights.SemiBold, new Thickness(0, 26, 0, 12)));
+        foreach (var panel in snapshot.Charts)
+        {
+            body.Children.Add(ChartBorder(new RunChartView
+            {
+                Panel = panel,
+                StartSeconds = snapshot.StartSeconds,
+                EndSeconds = snapshot.EndSeconds,
+                CursorSeconds = snapshot.StartSeconds,
+                AccentBrush = Accent,
+                TextBrush = Ink,
+                MutedBrush = Muted,
+                Height = 285,
+                Focusable = false,
+                IsHitTestVisible = false,
+                RenderOffscreen = true
+            }));
+        }
+        foreach (var panel in snapshot.AlternativeCharts)
+        {
+            body.Children.Add(ChartBorder(new RunAlternativePlotView
+            {
+                Panel = panel,
+                AccentBrush = Accent,
+                TextBrush = Ink,
+                MutedBrush = Muted,
+                Height = 330,
+                Focusable = false,
+                IsHitTestVisible = false,
+                ShowInteractionHints = false
+            }));
+        }
+        if (snapshot.Charts.Length > 0)
+            body.Children.Add(Label("Time is in seconds. Legend values are recorded samples at the interval start; gaps stay empty.", 13, Muted, 48));
+        body.Children.Add(Label("wispoverlay.com", 14, Accent, 28, margin: new Thickness(0, 18, 0, 0)));
+
+        var root = new Border { Width = ImageWidth, Background = Background, Child = body };
+        root.Measure(new Size(ImageWidth, double.PositiveInfinity));
+        var height = (int)Math.Ceiling(root.DesiredSize.Height);
+        if (height is <= 0 or > MaximumImageHeight)
+            throw new InvalidOperationException("This report is too tall to export. Choose a smaller graph group.");
+        root.Arrange(new Rect(0, 0, ImageWidth, height));
+        root.UpdateLayout();
+        var bitmap = new RenderTargetBitmap(ImageWidth, height, 96, 96, PixelFormats.Pbgra32);
+        bitmap.Render(root);
+        bitmap.Freeze();
+        return bitmap;
+    }
+
+    internal static Task WriteAsync(BitmapSource image, string path, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        if (!image.IsFrozen) throw new ArgumentException("The report image must be frozen before saving.", nameof(image));
+        var destination = Path.GetFullPath(path);
+        return Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var temporary = Path.Combine(Path.GetDirectoryName(destination)!, ".wisp-image-" + Guid.NewGuid().ToString("N") + ".tmp");
+            try
+            {
+                using (var stream = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    var encoder = new PngBitmapEncoder();
+                    encoder.Frames.Add(BitmapFrame.Create(image));
+                    encoder.Save(stream);
+                    stream.Flush(flushToDisk: true);
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                File.Move(temporary, destination, overwrite: false);
+            }
+            finally
+            {
+                if (File.Exists(temporary)) File.Delete(temporary);
+            }
+        }, cancellationToken);
+    }
+
+    private static Border ChartBorder(FrameworkElement chart) => new()
+    {
+        Background = Surface,
+        Padding = new Thickness(20),
+        CornerRadius = new CornerRadius(8),
+        Margin = new Thickness(0, 0, 0, 14),
+        Child = chart
+    };
+
+    private static TextBlock Label(string text, double size, Brush color, double maximumHeight,
+        FontWeight? weight = null, Thickness? margin = null) => new()
+        {
+            Text = text,
+            FontFamily = new FontFamily("Segoe UI"),
+            FontSize = size,
+            Foreground = color,
+            FontWeight = weight ?? FontWeights.Normal,
+            TextWrapping = TextWrapping.Wrap,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxHeight = maximumHeight,
+            Margin = margin ?? new Thickness(0, 2, 0, 2)
+        };
+
+    private static Brush Frozen(byte red, byte green, byte blue)
+    {
+        var brush = new SolidColorBrush(Color.FromRgb(red, green, blue));
+        brush.Freeze();
+        return brush;
+    }
+}

--- a/src/Wisp.App/Runs/RunPlotMarker.cs
+++ b/src/Wisp.App/Runs/RunPlotMarker.cs
@@ -1,0 +1,3 @@
+namespace Wisp.App.Runs;
+
+public sealed record RunPlotMarker(double Seconds, string Label, bool Comparison);

--- a/src/Wisp.App/Runs/RunPresentation.cs
+++ b/src/Wisp.App/Runs/RunPresentation.cs
@@ -1,0 +1,221 @@
+using System.Globalization;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public enum RunChartGroup { Speed, Inputs, Engine, Tires, Handling }
+public readonly record struct RunPlotPoint(double Seconds, double Value, bool BreakBefore);
+public sealed record RunPlotSeries(string Name, bool Comparison, int ColorIndex, RunPlotPoint[] Points)
+{
+    internal Func<double, double?>? ReadRecordedValue { get; init; }
+    internal RunInterval[] Gaps { get; init; } = [];
+}
+public sealed record RunPlotPanel(string Title, string Unit, RunPlotSeries[] Series, double Minimum, double Maximum);
+public sealed record RunMetric(string Label, string Value, string? Comparison = null);
+
+internal static class RunPresentation
+{
+    internal const int MaximumSeriesPoints = 1200;
+    internal static string Time(double seconds) => seconds >= 60
+        ? $"{(int)(seconds / 60)}:{seconds % 60:00.0}" : $"{seconds:0.0}s";
+    internal static double SpeedFactor(SpeedUnit unit) => unit == SpeedUnit.MilesPerHour ? 2.2369362921 : 3.6;
+    internal static string SpeedLabel(SpeedUnit unit) => unit == SpeedUnit.MilesPerHour ? "mph" : "km/h";
+    internal static string Number(double? value, string suffix = "", string format = "0.0") =>
+        value is double finite && double.IsFinite(finite) ? finite.ToString(format, CultureInfo.CurrentCulture) + suffix : "Unavailable";
+
+    internal static RunMetric[] Metrics(RunReport a, RunReport? b, SpeedUnit speed, TorqueUnit torque)
+    {
+        var factor = SpeedFactor(speed);
+        string Speed(double? value) => Number(value * factor, " " + SpeedLabel(speed));
+        string Power(double? value) => Number(value / 745.699872, " hp", "0");
+        string Torque(double? value) => Number(value * (torque == TorqueUnit.NewtonMeters ? 1 : .7375621493),
+            torque == TorqueUnit.NewtonMeters ? " Nm" : " lb-ft", "0");
+        string? Difference(double? first, double? second, Func<double?, string> format, double scale, string unit, string digits = "0.0")
+        {
+            if (b is null) return null;
+            var formatted = format(second);
+            if (first is not double left || second is not double right || !double.IsFinite(left) || !double.IsFinite(right)) return formatted;
+            return formatted + " (" + ((right - left) * scale).ToString("+" + digits + ";-" + digits + ";" + digits, CultureInfo.CurrentCulture) + unit + ")";
+        }
+        string Duration(double? value) => value is double seconds ? Time(seconds) : "Unavailable";
+        return
+        [
+            new("Recorded time", Time(a.Statistics.RecordedSeconds), Difference(a.Statistics.RecordedSeconds, b?.Statistics.RecordedSeconds, Duration, 1, "s")),
+            new("Peak ground speed", Speed(a.Statistics.PeakSpeedMetersPerSecond), Difference(a.Statistics.PeakSpeedMetersPerSecond, b?.Statistics.PeakSpeedMetersPerSecond, Speed, factor, " " + SpeedLabel(speed))),
+            new("Average car speed", Speed(a.Statistics.AverageSpeedMetersPerSecond), Difference(a.Statistics.AverageSpeedMetersPerSecond, b?.Statistics.AverageSpeedMetersPerSecond, Speed, factor, " " + SpeedLabel(speed))),
+            new("Full throttle", Time(a.Statistics.FullThrottleSeconds), Difference(a.Statistics.FullThrottleSeconds, b?.Statistics.FullThrottleSeconds, Duration, 1, "s")),
+            new("Braking", Time(a.Statistics.BrakingSeconds), Difference(a.Statistics.BrakingSeconds, b?.Statistics.BrakingSeconds, Duration, 1, "s")),
+            new("Peak power", Power(a.Statistics.PeakPowerWatts), Difference(a.Statistics.PeakPowerWatts, b?.Statistics.PeakPowerWatts, Power, 1 / 745.699872, " hp", "0")),
+            new("Peak torque", Torque(a.Statistics.PeakTorqueNm), Difference(a.Statistics.PeakTorqueNm, b?.Statistics.PeakTorqueNm, Torque, torque == TorqueUnit.NewtonMeters ? 1 : .7375621493, torque == TorqueUnit.NewtonMeters ? " Nm" : " lb-ft", "0")),
+            new("Peak lateral load", Number(a.Statistics.PeakLateralG, " g"), Difference(a.Statistics.PeakLateralG, b?.Statistics.PeakLateralG, value => Number(value, " g"), 1, " g")),
+            new("Telemetry gaps", a.Statistics.GapCount.ToString(CultureInfo.CurrentCulture), b?.Statistics.GapCount.ToString(CultureInfo.CurrentCulture))
+        ];
+    }
+
+    internal static RunPlotPanel[] Charts(RecordedRun a, RecordedRun? b, RunChartGroup group,
+        SpeedUnit speedUnit, TireTemperatureUnit temperatureUnit, double offsetA = 0, double offsetB = 0,
+        RunInterval? boundsA = null, RunInterval? boundsB = null, TorqueUnit torqueUnit = TorqueUnit.NewtonMeters,
+        BoostPressureUnit boostUnit = BoostPressureUnit.Psi)
+    {
+        double speed = SpeedFactor(speedUnit);
+        double? Temperature(RunSample sample, bool front)
+        {
+            var value = sample.State.TireTemperatureFahrenheit;
+            if (front ? !float.IsFinite(value.FrontLeft) || !float.IsFinite(value.FrontRight) || value.FrontLeft <= 0 || value.FrontRight <= 0
+                : !float.IsFinite(value.RearLeft) || !float.IsFinite(value.RearRight) || value.RearLeft <= 0 || value.RearRight <= 0) return null;
+            var fahrenheit = front ? (value.FrontLeft + value.FrontRight) / 2d : (value.RearLeft + value.RearRight) / 2d;
+            return temperatureUnit == TireTemperatureUnit.Celsius ? (fahrenheit - 32) * 5 / 9 : fahrenheit;
+        }
+        return group switch
+        {
+            RunChartGroup.Inputs =>
+            [
+                Panel("Driver inputs", "%", -100, 100,
+                    ("Throttle", 0, sample => sample.State.Accelerator / 255d * 100),
+                    ("Brake", 1, sample => sample.State.Brake / 255d * 100),
+                    ("Steering", 2, sample => sample.State.Steering / (sample.State.Steering < 0 ? 128d : 127d) * 100)),
+                Panel("Ground and driven-wheel speed", SpeedLabel(speedUnit), 0, null,
+                    ("Ground", 0, sample => sample.State.GroundSpeedMetersPerSecond * speed),
+                    ("Wheels", 1, sample => sample.WheelSpeedMetersPerSecond * speed))
+            ],
+            RunChartGroup.Engine =>
+            [
+                Panel("Engine speed", "RPM", 0, null, ("Engine", 0, sample => sample.State.EngineRpm)),
+                Panel("Engine power", "hp", null, null, ("Power", 0, sample => sample.State.PowerWatts / 745.699872)),
+                Panel("Engine torque", torqueUnit == TorqueUnit.NewtonMeters ? "Nm" : "lb-ft", null, null,
+                    ("Torque", 0, sample => sample.State.TorqueNm * (torqueUnit == TorqueUnit.NewtonMeters ? 1 : .7375621493))),
+                Panel("Boost pressure", boostUnit == BoostPressureUnit.Psi ? "PSI" : "bar", null, null,
+                    ("Boost", 1, sample => sample.State.IsElectric ? null : sample.State.BoostPressurePsi * (boostUnit == BoostPressureUnit.Psi ? 1 : .0689475729)))
+            ],
+            RunChartGroup.Tires =>
+            [
+                Panel("Tire temperature", temperatureUnit == TireTemperatureUnit.Celsius ? "°C" : "°F", null, null,
+                    ("Front", 0, sample => Temperature(sample, true)), ("Rear", 1, sample => Temperature(sample, false)))
+            ],
+            RunChartGroup.Handling =>
+            [
+                Panel("Cornering and acceleration load", "g", null, null,
+                    ("Lateral", 0, sample => sample.State.LateralAccelerationMetersPerSecondSquared / 9.80665),
+                    ("Longitudinal", 1, sample => sample.State.LongitudinalAccelerationMetersPerSecondSquared / 9.80665))
+            ],
+            _ => [Panel("Ground and driven-wheel speed", SpeedLabel(speedUnit), 0, null,
+                ("Ground", 0, sample => sample.State.GroundSpeedMetersPerSecond * speed),
+                ("Wheels", 1, sample => sample.WheelSpeedMetersPerSecond * speed))]
+        };
+
+        RunPlotPanel Panel(string title, string unit, double? minimum, double? maximum,
+            params (string Label, int Color, Func<RunSample, double?> Read)[] channels)
+        {
+            var series = new List<RunPlotSeries>();
+            foreach (var (label, color, read) in channels)
+            {
+                series.Add(Series(a, "A · " + label, false, offsetA, boundsA));
+                if (b is not null) series.Add(Series(b, "B · " + label, true, offsetB, boundsB));
+                RunPlotSeries Series(RecordedRun run, string name, bool comparison, double offset, RunInterval? bounds)
+                {
+                    var boostedCars = label == "Boost" ? run.Samples.Where(sample => Driving(sample) && !sample.State.IsElectric &&
+                        float.IsFinite(sample.State.BoostPressurePsi) && sample.State.BoostPressurePsi > 0).Select(sample => sample.State.CarOrdinal).ToHashSet() : null;
+                    double? Read(RunSample sample) => boostedCars is not null && !boostedCars.Contains(sample.State.CarOrdinal) ? null : read(sample);
+                    return new(name, comparison, color, PreparePoints(run.Samples, Read, offset, bounds))
+                    {
+                        ReadRecordedValue = seconds => RecordedValueAt(run.Samples, Read, seconds + offset, bounds),
+                        Gaps = PrepareGaps(run.Samples, Read, offset, bounds)
+                    };
+                }
+            }
+            var values = series.SelectMany(item => item.Points).Select(point => point.Value).ToArray();
+            double low = minimum ?? (values.Length == 0 ? 0 : values.Min());
+            double high = maximum ?? (values.Length == 0 ? 1 : values.Max());
+            if (high - low < .01) high = low + Math.Max(1, Math.Abs(low) * .1);
+            if (maximum is null) high += (high - low) * .06;
+            return new(title, unit, series.ToArray(), low, high);
+        }
+    }
+
+    // Keep extrema and endpoints in chronological order, never bridge missing data.
+    internal static RunPlotPoint[] PreparePoints(RunSample[] samples, Func<RunSample, double?> read, double offset, RunInterval? bounds = null)
+    {
+        if (samples.Length == 0) return [];
+        var points = new List<RunPlotPoint>(Math.Min(samples.Length, MaximumSeriesPoints));
+        var bucketSize = Math.Max(1, (int)Math.Ceiling(samples.Length / (MaximumSeriesPoints / 4d)));
+        int continuity = 0, lastContinuity = -1;
+        for (int start = 0; start < samples.Length; start += bucketSize)
+        {
+            var candidates = new List<(int Index, double Value, int Continuity)>(bucketSize);
+            for (int index = start; index < Math.Min(samples.Length, start + bucketSize); index++)
+            {
+                if (index == 0 || !ChartContinuous(samples[index - 1], samples[index])) continuity++;
+                var sample = samples[index];
+                var value = read(sample);
+                if (!Driving(sample) || value is not double finite || !double.IsFinite(finite) ||
+                    (bounds is { } range && (sample.ElapsedSeconds < range.StartSeconds || sample.ElapsedSeconds > range.EndSeconds)))
+                { continuity++; continue; }
+                candidates.Add((index, finite, continuity));
+            }
+            if (candidates.Count == 0) continue;
+            var selected = new[] { candidates[0], candidates.MinBy(point => point.Value), candidates.MaxBy(point => point.Value), candidates[^1] }
+                .DistinctBy(point => point.Index).OrderBy(point => point.Index);
+            foreach (var point in selected)
+            {
+                points.Add(new(samples[point.Index].ElapsedSeconds - offset, point.Value, point.Continuity != lastContinuity));
+                lastContinuity = point.Continuity;
+            }
+        }
+        return points.ToArray();
+    }
+
+    internal static bool ChartContinuous(RunSample previous, RunSample current) => RunAnalysis.AreContinuous(previous, current) ||
+        (Driving(previous) && Driving(current) && current.ElapsedSeconds == previous.ElapsedSeconds &&
+         current.State.GameTimestampMilliseconds == previous.State.GameTimestampMilliseconds && current.Segment == previous.Segment &&
+         current.State.CarOrdinal == previous.State.CarOrdinal && current.State.Drivetrain == previous.State.Drivetrain);
+
+    private static bool Driving(RunSample sample) => sample.IsDriving && sample.State.IsRaceOn &&
+        double.IsFinite(sample.ElapsedSeconds) && sample.ElapsedSeconds >= 0 &&
+        float.IsFinite(sample.State.GroundSpeedMetersPerSecond) && sample.State.GroundSpeedMetersPerSecond >= 0;
+
+    // Cursor values come from the nearest original reading, never from reduced drawing vertices.
+    internal static double? RecordedValueAt(RunSample[] samples, Func<RunSample, double?> read, double seconds, RunInterval? bounds = null)
+    {
+        if (samples.Length == 0 || seconds < samples[0].ElapsedSeconds || seconds > samples[^1].ElapsedSeconds ||
+            (bounds is { } range && (seconds < range.StartSeconds || seconds > range.EndSeconds))) return null;
+        int low = 0, high = samples.Length - 1;
+        while (low < high)
+        { int middle = (low + high + 1) / 2; if (samples[middle].ElapsedSeconds <= seconds) low = middle; else high = middle - 1; }
+        var nearest = samples[low];
+        if (low < samples.Length - 1 && seconds > nearest.ElapsedSeconds)
+        {
+            var next = samples[low + 1];
+            if (!ChartContinuous(nearest, next) || read(nearest) is not double left || !double.IsFinite(left) ||
+                read(next) is not double right || !double.IsFinite(right)) return null;
+            if (next.ElapsedSeconds - seconds < seconds - nearest.ElapsedSeconds) nearest = next;
+        }
+        var value = read(nearest);
+        if (bounds is { } selected && (nearest.ElapsedSeconds < selected.StartSeconds || nearest.ElapsedSeconds > selected.EndSeconds))
+        {
+            var alternative = ReferenceEquals(nearest, samples[low]) && low + 1 < samples.Length ? samples[low + 1] : samples[low];
+            if (alternative.ElapsedSeconds < selected.StartSeconds || alternative.ElapsedSeconds > selected.EndSeconds) return null;
+            nearest = alternative; value = read(nearest);
+        }
+        return Driving(nearest) && value is double finite && double.IsFinite(finite) ? finite : null;
+    }
+
+    internal static RunInterval[] PrepareGaps(RunSample[] samples, Func<RunSample, double?> read, double offset, RunInterval? bounds = null)
+    {
+        var gaps = new List<RunInterval>();
+        RunSample? previous = null; bool interrupted = false;
+        foreach (var sample in samples)
+        {
+            if (!Driving(sample) || read(sample) is not double value || !double.IsFinite(value)) { interrupted = true; continue; }
+            if (previous is not null && (interrupted || !ChartContinuous(previous, sample)) && sample.ElapsedSeconds > previous.ElapsedSeconds)
+            {
+                var from = Math.Max(previous.ElapsedSeconds, bounds?.StartSeconds ?? 0);
+                var to = Math.Min(sample.ElapsedSeconds, bounds?.EndSeconds ?? double.MaxValue);
+                if (to > from) gaps.Add(new(from - offset, to - offset));
+            }
+            previous = sample; interrupted = false;
+        }
+        // Lines retain every continuity break. Bound the extra shading geometry for pathological files.
+        return gaps.Count <= MaximumSeriesPoints ? gaps.ToArray() : gaps.OrderByDescending(gap => gap.EndSeconds - gap.StartSeconds).Take(MaximumSeriesPoints).ToArray();
+    }
+}

--- a/src/Wisp.App/Runs/RunRecordingOptions.cs
+++ b/src/Wisp.App/Runs/RunRecordingOptions.cs
@@ -1,0 +1,7 @@
+namespace Wisp.App.Runs;
+
+public sealed record RunRecordingOptions(TimeSpan? StopAfter = null)
+{
+    internal bool IsValid => StopAfter is null || StopAfter > TimeSpan.Zero && StopAfter <= TimeSpan.FromMinutes(10);
+    internal TimeSpan Limit => StopAfter ?? TimeSpan.FromMinutes(10);
+}

--- a/src/Wisp.App/Runs/RunRecordingService.cs
+++ b/src/Wisp.App/Runs/RunRecordingService.cs
@@ -1,0 +1,459 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Wisp.Telemetry;
+
+namespace Wisp.App.Runs;
+
+public sealed record RunRecordingContext(long EffectiveTimestamp, int CarOrdinal, DrivetrainType Drivetrain,
+    bool IsDriving, double? FrontRadiusMeters = null, double? RearRadiusMeters = null, long? DrivingValidUntilTimestamp = null);
+
+public sealed class RunRecordingService : IAsyncDisposable
+{
+    private readonly TelemetryUdpReceiver _receiver;
+    private readonly object _gate = new();
+    private Session? _session;
+    private RunRecordingContext? _latestContext;
+    private string? _error;
+    private string _status = "Ready to record";
+    private string _markerStatus = string.Empty;
+    private long _lastElapsedTicks;
+    private readonly object _notificationGate = new();
+    private StateSnapshot? _lastNotified;
+    private bool _disposed;
+
+    public RunRecordingService(TelemetryUdpReceiver receiver, string directory)
+    {
+        _receiver = receiver;
+        Store = new RunStore(directory);
+    }
+
+    public RunStore Store { get; }
+    public event EventHandler? StateChanged;
+    public event Action<RecordedRun>? RunSaved;
+    public bool IsRecording => Volatile.Read(ref _session) is { Stopping: false };
+    public bool IsPreparing => Volatile.Read(ref _session) is { Stopping: true };
+    public TimeSpan Elapsed => Volatile.Read(ref _session) is { } session
+        ? Stopwatch.GetElapsedTime(session.StartedTimestamp, EndTimestamp(session))
+        : TimeSpan.FromTicks(Interlocked.Read(ref _lastElapsedTicks));
+    public string Status => Volatile.Read(ref _status);
+    public string? Error => Volatile.Read(ref _error);
+    public string MarkerStatus => Volatile.Read(ref _markerStatus);
+    public bool CanStart => !_disposed && !Store.IsFull && Volatile.Read(ref _session) is null && _receiver.IsRunning &&
+        _receiver.Latest is { IsRaceOn: true, CarOrdinal: > 0, ReceivedTimestamp: { } stamp } &&
+        Stopwatch.GetElapsedTime(stamp) is { TotalMilliseconds: >= 0 and <= 300 };
+
+    public void UpdateContext(RunRecordingContext context)
+    {
+        if (context.EffectiveTimestamp <= 0 || context.CarOrdinal <= 0 || !Enum.IsDefined(context.Drivetrain)) return;
+        if (context.FrontRadiusMeters is not { } front || context.RearRadiusMeters is not { } rear || !new RollingRadii(front, rear).IsPlausible)
+            context = context with { FrontRadiusMeters = null, RearRadiusMeters = null };
+        Volatile.Write(ref _latestContext, context);
+        var session = Volatile.Read(ref _session);
+        if (session is null || session.Stopping) return;
+        session.Contexts.Enqueue(context);
+        while (session.Contexts.Count > 2048) session.Contexts.TryDequeue(out _);
+    }
+
+    public bool Start(RunRecordingOptions? options = null)
+    {
+        options ??= new RunRecordingOptions();
+        lock (_gate)
+        {
+            _error = null;
+            if (!options.IsValid)
+            {
+                _status = "Choose a recording time above zero and no longer than ten minutes.";
+                return false;
+            }
+            if (!CanStart)
+            {
+                _status = Store.IsFull ? "The run library is full. Export or remove a run before recording another." : "Return to free roam with live telemetry to record a run.";
+                return false;
+            }
+            var state = _receiver.Latest;
+            var now = Stopwatch.GetTimestamp();
+            if (state is not { IsRaceOn: true, CarOrdinal: > 0, ReceivedTimestamp: { } received } ||
+                now < received || Stopwatch.GetElapsedTime(received, now).TotalMilliseconds > 300)
+            {
+                _status = "Return to free roam with live telemetry to record a run.";
+                return false;
+            }
+            var context = Volatile.Read(ref _latestContext);
+            if (context is not { IsDriving: true } || context.CarOrdinal != state.CarOrdinal || context.Drivetrain != state.Drivetrain ||
+                Stopwatch.GetElapsedTime(context.EffectiveTimestamp, now).TotalMilliseconds is < 0 or > 300 ||
+                (context.DrivingValidUntilTimestamp is { } deadline && now > deadline))
+            {
+                _status = "Waiting for a confirmed driving scene; return to free roam.";
+                return false;
+            }
+            var reservation = Store.TryReserveJournalStart();
+            if (reservation is null)
+            {
+                _status = "A saved run is still being read or written. Try recording again when it finishes.";
+                return false;
+            }
+            RunDatagramCapture? capture = null;
+            try
+            {
+                capture = _receiver.BeginRunCapture();
+                var session = new Session(capture, state.CarOrdinal, state.Drivetrain, context, reservation, options);
+                _session = session;
+                _error = null;
+                _status = "Recording";
+                _markerStatus = string.Empty;
+                session.Completion = Task.Run(async () =>
+                {
+                    try { return await RecordAsync(session).ConfigureAwait(false); }
+                    finally { reservation.Dispose(); }
+                });
+            }
+            catch (Exception error) when (error is InvalidOperationException or IOException or OutOfMemoryException)
+            {
+                reservation.Dispose();
+                if (capture is not null) _receiver.EndRunCapture(capture, "Recording could not start");
+                _session = null;
+                _error = "Recording could not start. Live telemetry is still running.";
+                _status = _error;
+                return false;
+            }
+        }
+        NotifyStateChanged();
+        return true;
+    }
+
+    public Task<RecordedRun?> StopAsync(string reason = "Stopped by you")
+    {
+        Task<RecordedRun?> completion;
+        lock (_gate)
+        {
+            var session = _session;
+            if (session is null) return Task.FromResult<RecordedRun?>(null);
+            if (!session.Stopping)
+            {
+                var now = Stopwatch.GetTimestamp();
+                if (now >= session.DeadlineTimestamp) reason = session.LimitReason;
+                Interlocked.CompareExchange(ref session.StopTimestamp, Math.Min(now, session.DeadlineTimestamp), 0);
+                session.Stopping = true;
+                session.Reason ??= SafeReason(reason);
+                if (session.Reason is not "Stopped by you" and not "10-minute recording limit reached" and not "Timed recording completed") session.Incomplete = true;
+                _status = "Preparing your run…";
+                _receiver.EndRunCapture(session.Capture, session.Reason);
+            }
+            completion = session.Completion;
+        }
+        NotifyStateChanged();
+        return completion;
+    }
+
+    public void RefreshStatus()
+    {
+        var session = Volatile.Read(ref _session);
+        if (session is { Stopping: false })
+        {
+            if (Stopwatch.GetTimestamp() >= session.DeadlineTimestamp) _ = StopAsync(session.LimitReason);
+            else if (Stopwatch.GetElapsedTime(Interlocked.Read(ref session.LastValidTimestamp)) >= TimeSpan.FromSeconds(10))
+            {
+                session.Incomplete = true;
+                _ = StopAsync("Telemetry was unavailable for 10 seconds");
+            }
+        }
+        NotifyStateChanged();
+    }
+
+    public bool MarkMoment(string? label = null)
+    {
+        var added = false;
+        lock (_gate)
+        {
+            var session = _session;
+            var position = session is null ? null : Volatile.Read(ref session.MarkerPosition);
+            var context = Volatile.Read(ref _latestContext);
+            var now = Stopwatch.GetTimestamp();
+            if (session is null || session.Stopping || now >= session.DeadlineTimestamp)
+                _markerStatus = "Start recording before adding a moment.";
+            else if (position is null || position.Sequence != session.Capture.ObservedDatagrams || now > position.ValidUntilTimestamp ||
+                context is not { IsDriving: true } || context.CarOrdinal != session.CarOrdinal || context.Drivetrain != session.Drivetrain ||
+                now < context.EffectiveTimestamp || Stopwatch.GetElapsedTime(context.EffectiveTimestamp, now).TotalMilliseconds > 300 ||
+                (context.DrivingValidUntilTimestamp is { } deadline && now > deadline))
+                _markerStatus = "Moment not added; waiting for current driving data. Recording continues.";
+            else if (session.MarkerCount >= RunStore.MaximumMarkers)
+                _markerStatus = "All 128 moments are used. Recording continues.";
+            else
+            {
+                label = label is null ? $"Moment {session.MarkerCount + 1}" : label.Trim();
+                if (!RunStore.ValidMarkerLabel(label))
+                    _markerStatus = "Use a moment label from 1 to 80 characters, without line breaks. Recording continues.";
+                else
+                {
+                    session.PendingMarkers.Enqueue(new RunMarker(position.ElapsedSeconds, label));
+                    session.MarkerCount++;
+                    _markerStatus = $"Moment marked at {position.ElapsedSeconds:0.0}s.";
+                    added = true;
+                }
+            }
+        }
+        NotifyStateChanged();
+        return added;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+        await StopAsync("Wisp closed before the run finished").ConfigureAwait(false);
+    }
+
+    private async Task<RecordedRun?> RecordAsync(Session session)
+    {
+        RunJournal? journal = null;
+        RecordedRun? saved = null;
+        try
+        {
+            var parser = new Fh6PacketParser();
+            var builder = new RunSampleBuilder(session.StartedTimestamp);
+            var samples = new List<RunSample>(8192);
+            var markers = new List<RunMarker>();
+            var header = new RecordedRun
+            {
+                StartedAtUtc = session.StartedAtUtc,
+                Name = $"Run {session.StartedAtUtc.ToLocalTime():MMM d, h:mm tt}"
+            };
+            long rejected = 0;
+            var lastFlush = session.StartedTimestamp;
+            journal = Store.CreateJournal(header, session.JournalReservation);
+            await foreach (var packet in session.Capture.ReadAllAsync().ConfigureAwait(false))
+            {
+                var stopped = Interlocked.Read(ref session.StopTimestamp);
+                if (stopped != 0 && packet.Timestamp > stopped) break;
+                if (packet.Timestamp >= session.DeadlineTimestamp)
+                {
+                    Interlocked.CompareExchange(ref session.StopTimestamp, session.DeadlineTimestamp, 0);
+                    session.Reason = session.LimitReason;
+                    break;
+                }
+                var receivedAt = session.StartedAtUtc + Stopwatch.GetElapsedTime(session.StartedTimestamp, packet.Timestamp);
+                if (!parser.TryParse(packet.Bytes.Span, receivedAt, out var state, out _, packet.Timestamp) || state is null)
+                {
+                    rejected++;
+                    builder.MarkGap();
+                    continue;
+                }
+                Interlocked.Exchange(ref session.LastValidTimestamp, packet.Timestamp);
+                if (state.CarOrdinal <= 0 || (!state.IsRaceOn && (state.CarOrdinal != session.CarOrdinal || state.Drivetrain != session.Drivetrain)))
+                {
+                    rejected++;
+                    builder.MarkGap();
+                    continue;
+                }
+                if (state.CarOrdinal != session.CarOrdinal || state.Drivetrain != session.Drivetrain)
+                {
+                    session.Incomplete = true;
+                    session.Reason = "The car or drivetrain changed";
+                    break;
+                }
+                while (session.Contexts.TryPeek(out var pending) && pending.EffectiveTimestamp <= packet.Timestamp)
+                {
+                    session.Contexts.TryDequeue(out pending);
+                    if (pending is not null && (session.Context is null || pending.EffectiveTimestamp >= session.Context.EffectiveTimestamp)) session.Context = pending;
+                }
+                var sample = builder.Add(state, packet.Timestamp, packet.Sequence, session.Context);
+                if (sample.ElapsedSeconds > 600) { session.Reason = "10-minute recording limit reached"; break; }
+                try { RunStore.ValidateSample(sample, samples.LastOrDefault()); }
+                catch (InvalidDataException) { rejected++; builder.MarkGap(); continue; }
+                samples.Add(sample);
+                await journal.AppendAsync(sample).ConfigureAwait(false);
+                var validUntil = Math.Min(packet.Timestamp + (long)(Stopwatch.Frequency * .3),
+                    session.Context?.DrivingValidUntilTimestamp ?? long.MaxValue);
+                if (session.Context is { } markerContext)
+                    validUntil = Math.Min(validUntil, markerContext.EffectiveTimestamp + (long)(Stopwatch.Frequency * .3));
+                Volatile.Write(ref session.MarkerPosition, sample.IsDriving
+                    ? new MarkerPosition(sample.ElapsedSeconds, packet.Sequence, validUntil) : null);
+                await WritePendingMarkersAsync().ConfigureAwait(false);
+                if (Stopwatch.GetElapsedTime(lastFlush, packet.Timestamp) >= TimeSpan.FromSeconds(1))
+                {
+                    await journal.FlushAsync().ConfigureAwait(false);
+                    lastFlush = packet.Timestamp;
+                }
+                if (samples.Count >= RunStore.MaximumSamples || sample.ElapsedSeconds >= 600)
+                {
+                    session.Reason = samples.Count >= RunStore.MaximumSamples ? "Recording sample limit reached" : "10-minute recording limit reached";
+                    break;
+                }
+            }
+            lock (_gate)
+            {
+                Interlocked.CompareExchange(ref session.StopTimestamp, Math.Min(Stopwatch.GetTimestamp(), session.DeadlineTimestamp), 0);
+                session.Stopping = true;
+                if (session.Reason is null) { session.Reason = SafeReason(session.Capture.CompletionReason); session.Incomplete = true; }
+                _status = "Preparing your run…";
+            }
+            _receiver.EndRunCapture(session.Capture, session.Reason);
+            NotifyStateChanged();
+            await WritePendingMarkersAsync().ConfigureAwait(false);
+            if (samples.Count == 0)
+            {
+                _status = "No usable telemetry was recorded.";
+                await journal.DisposeAsync().ConfigureAwait(false);
+                journal.RemoveAfterSave();
+                return null;
+            }
+            saved = header with
+            {
+                Samples = samples.ToArray(),
+                Markers = markers.ToArray(),
+                FinishReason = session.Reason,
+                IsIncomplete = session.Incomplete || builder.HasGap || rejected > 0 || session.Capture.DroppedDatagrams > 0 ||
+                    Stopwatch.GetElapsedTime(Interlocked.Read(ref session.LastValidTimestamp), EndTimestamp(session)).TotalMilliseconds > 300,
+                RejectedDatagrams = rejected,
+                DroppedDatagrams = session.Capture.DroppedDatagrams
+            };
+            await Store.SaveAsync(saved).ConfigureAwait(false);
+            try
+            {
+                await journal.DisposeAsync().ConfigureAwait(false);
+                journal.RemoveAfterSave();
+                _status = saved.IsIncomplete ? "Run saved with gaps" : "Run saved";
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException)
+            {
+                _status = "Run saved; temporary recovery data was kept.";
+            }
+            return saved;
+
+            async Task WritePendingMarkersAsync()
+            {
+                while (session.PendingMarkers.TryDequeue(out var marker))
+                {
+                    await journal.AppendMarkerAsync(marker).ConfigureAwait(false);
+                    markers.Add(marker);
+                }
+            }
+        }
+        catch (Exception error) when (error is not StackOverflowException)
+        {
+            saved = null;
+            _error = error is RunLibraryFullException ? "The run library is full. Export or remove a run before recording another." :
+                "The run could not be saved. Any recovery data has been kept. Live telemetry is still running.";
+            _status = _error;
+            return null;
+        }
+        finally
+        {
+            _receiver.EndRunCapture(session.Capture, session.Reason ?? "Recording stopped after an error");
+            if (journal is not null)
+            {
+                try { await journal.DisposeAsync().ConfigureAwait(false); }
+                catch (Exception error) when (error is IOException or UnauthorizedAccessException or ObjectDisposedException) { }
+            }
+            lock (_gate)
+            {
+                Interlocked.Exchange(ref _lastElapsedTicks, Stopwatch.GetElapsedTime(session.StartedTimestamp, EndTimestamp(session)).Ticks);
+                if (ReferenceEquals(_session, session)) _session = null;
+            }
+            NotifyStateChanged();
+            if (saved is not null) NotifyRunSaved(saved);
+        }
+    }
+
+    private static string SafeReason(string reason) => string.IsNullOrWhiteSpace(reason) ? "Recording stopped" :
+        new string(reason.Where(character => !char.IsControl(character)).Take(200).ToArray());
+    private static long EndTimestamp(Session session) => Interlocked.Read(ref session.StopTimestamp) is var timestamp && timestamp != 0 ? timestamp : Math.Min(Stopwatch.GetTimestamp(), session.DeadlineTimestamp);
+    private void NotifyStateChanged()
+    {
+        var snapshot = new StateSnapshot(IsRecording, IsPreparing, CanStart, (int)Elapsed.TotalSeconds, Status, Error, MarkerStatus, Volatile.Read(ref _session)?.MarkerCount ?? 0);
+        lock (_notificationGate)
+        {
+            if (_lastNotified == snapshot) return;
+            _lastNotified = snapshot;
+        }
+        var handlers = StateChanged;
+        if (handlers is null) return;
+        foreach (EventHandler handler in handlers.GetInvocationList())
+            try { handler(this, EventArgs.Empty); } catch { /* Subscribers cannot affect recording. */ }
+    }
+
+    private readonly record struct StateSnapshot(bool IsRecording, bool IsPreparing, bool CanStart, int ElapsedSeconds, string Status, string? Error, string MarkerStatus, int MarkerCount);
+    private sealed record MarkerPosition(double ElapsedSeconds, long Sequence, long ValidUntilTimestamp);
+    private void NotifyRunSaved(RecordedRun run)
+    {
+        var handlers = RunSaved;
+        if (handlers is null) return;
+        foreach (Action<RecordedRun> handler in handlers.GetInvocationList())
+            try { handler(run); } catch { /* Subscribers cannot affect the saved run. */ }
+    }
+
+    private sealed class Session(RunDatagramCapture capture, int carOrdinal, DrivetrainType drivetrain, RunRecordingContext? context,
+        RunJournalStartReservation reservation, RunRecordingOptions options)
+    {
+        internal readonly RunDatagramCapture Capture = capture;
+        internal readonly RunJournalStartReservation JournalReservation = reservation;
+        internal readonly int CarOrdinal = carOrdinal;
+        internal readonly DrivetrainType Drivetrain = drivetrain;
+        internal readonly long StartedTimestamp = Stopwatch.GetTimestamp();
+        internal long DeadlineTimestamp => StartedTimestamp + (long)Math.Ceiling(options.Limit.TotalSeconds * Stopwatch.Frequency);
+        internal string LimitReason => options.StopAfter is null ? "10-minute recording limit reached" : "Timed recording completed";
+        internal readonly DateTimeOffset StartedAtUtc = DateTimeOffset.UtcNow;
+        internal readonly ConcurrentQueue<RunRecordingContext> Contexts = new();
+        internal readonly ConcurrentQueue<RunMarker> PendingMarkers = new();
+        internal MarkerPosition? MarkerPosition;
+        internal int MarkerCount;
+        internal RunRecordingContext? Context = context;
+        internal long LastValidTimestamp = Stopwatch.GetTimestamp();
+        internal volatile bool Stopping;
+        internal volatile bool Incomplete;
+        internal long StopTimestamp;
+        internal string? Reason;
+        internal Task<RecordedRun?> Completion = Task.FromResult<RecordedRun?>(null);
+    }
+}
+
+internal sealed class RunSampleBuilder(long startedTimestamp)
+{
+    private long _lastTimestamp = startedTimestamp;
+    private long _lastSequence;
+    private uint? _lastGameTimestamp;
+    private double _elapsed;
+    private int _segment;
+    private bool _gap;
+    private RunSample? _previous;
+    internal bool HasGap { get; private set; }
+    internal void MarkGap() { _gap = true; HasGap = true; }
+
+    internal RunSample Add(VehicleState state, long timestamp, long sequence, RunRecordingContext? context)
+    {
+        var receiptDelta = Math.Max(0, Stopwatch.GetElapsedTime(_lastTimestamp, timestamp).TotalSeconds);
+        var gameDelta = _lastGameTimestamp is { } previousGame ? unchecked(state.GameTimestampMilliseconds - previousGame) : 0u;
+        if (_lastGameTimestamp is not null)
+        {
+            _elapsed += gameDelta <= 250 ? gameDelta / 1000.0 : receiptDelta;
+            if (gameDelta > 250 || receiptDelta > .25 || timestamp < _lastTimestamp || sequence != _lastSequence + 1) MarkGap();
+        }
+        var validContext = context is not null && context.CarOrdinal == state.CarOrdinal && context.Drivetrain == state.Drivetrain &&
+            timestamp >= context.EffectiveTimestamp && Stopwatch.GetElapsedTime(context.EffectiveTimestamp, timestamp).TotalSeconds <= .3;
+        var isDriving = validContext && context!.IsDriving && state.IsRaceOn &&
+            (context.DrivingValidUntilTimestamp is null || timestamp <= context.DrivingValidUntilTimestamp.Value);
+        RollingRadii? radii = validContext && context!.FrontRadiusMeters is { } front && context.RearRadiusMeters is { } rear && new RollingRadii(front, rear).IsPlausible
+            ? new RollingRadii(front, rear) : null;
+        if (!isDriving) HasGap = true;
+        if (_previous is not null && (_gap || _previous.IsDriving != isDriving ||
+            _previous.FrontRadiusMeters != radii?.FrontMeters || _previous.RearRadiusMeters != radii?.RearMeters)) _segment++;
+        var sample = new RunSample
+        {
+            ElapsedSeconds = _elapsed,
+            Segment = _segment,
+            IsDriving = isDriving,
+            State = state with { ReceivedTimestamp = null },
+            WheelSpeedMetersPerSecond = radii is { } trusted ? DrivenWheelSpeed.MetersPerSecond(state, trusted) : null,
+            FrontRadiusMeters = radii?.FrontMeters,
+            RearRadiusMeters = radii?.RearMeters
+        };
+        _lastTimestamp = timestamp;
+        _lastSequence = sequence;
+        _lastGameTimestamp = state.GameTimestampMilliseconds;
+        _previous = sample;
+        _gap = false;
+        return sample;
+    }
+}

--- a/src/Wisp.App/Runs/RunStore.cs
+++ b/src/Wisp.App/Runs/RunStore.cs
@@ -1,0 +1,563 @@
+using System.IO;
+using System.Collections.Concurrent;
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public sealed record RunSummary(Guid Id, string Name, string Tune, string Notes,
+    DateTimeOffset StartedAtUtc, double DurationSeconds, int SampleCount, int CarOrdinal,
+    bool IsIncomplete, string FinishReason);
+
+public sealed class RunStore
+{
+    public const int MaximumSamples = 180_000;
+    public const int MaximumMarkers = 128;
+    public const int MaximumMarkerLabelLength = 80;
+    public const int MaximumLibraryEntries = 2000;
+    public const long MaximumFileBytes = 64 * 1024 * 1024;
+    internal const long MaximumJsonBytes = 256 * 1024 * 1024;
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        MaxDepth = 16,
+        Converters = { new JsonStringEnumConverter() }
+    };
+    private readonly string _directory;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly ConcurrentDictionary<Guid, byte> _activeJournals = new();
+    private bool _recovered;
+    private bool _isFull;
+    public string? Warning { get; private set; }
+    public bool IsFull => Volatile.Read(ref _isFull);
+
+    public RunStore(string directory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directory);
+        _directory = Path.GetFullPath(directory);
+    }
+
+    public Task<IReadOnlyList<RunSummary>> ListAsync() => InBackground<IReadOnlyList<RunSummary>>(async () =>
+    {
+        await RecoverAsync().ConfigureAwait(false);
+        var summaries = new List<RunSummary>();
+        foreach (var path in Directory.EnumerateFiles(_directory, "*.wisprun"))
+        {
+            if (!Guid.TryParseExact(Path.GetFileNameWithoutExtension(path), "N", out var id)) continue;
+            try
+            {
+                var summaryPath = SummaryPath(id);
+                RunSummary? summary = null;
+                if (File.Exists(summaryPath) && new FileInfo(summaryPath).Length <= 65_536 &&
+                    File.GetLastWriteTimeUtc(summaryPath) >= File.GetLastWriteTimeUtc(path))
+                {
+                    try
+                    {
+                        CheckPath(summaryPath);
+                        summary = JsonSerializer.Deserialize<RunSummary>(await File.ReadAllTextAsync(summaryPath).ConfigureAwait(false), JsonOptions);
+                        if (summary is null || summary.Id != id || !ValidSummary(summary)) summary = null;
+                    }
+                    catch (Exception error) when (IsDataError(error)) { summary = null; }
+                }
+                if (summary is null)
+                {
+                    var run = await ReadAsync(path, id).ConfigureAwait(false);
+                    summary = Summarize(run);
+                    try { await WriteSummaryAsync(summary).ConfigureAwait(false); }
+                    catch (Exception error) when (IsDataError(error)) { Warning = "A run summary could not be refreshed. The saved run is available."; }
+                }
+                summaries.Add(summary);
+            }
+            catch (Exception error) when (IsDataError(error))
+            {
+                Warning = "A saved run could not be read. Its file has been kept.";
+            }
+        }
+        Volatile.Write(ref _isFull, summaries.Count >= MaximumLibraryEntries);
+        return summaries.OrderByDescending(value => value.StartedAtUtc).ToArray();
+    });
+
+    public Task<RecordedRun> LoadAsync(Guid id) => InBackground(() => ReadAsync(RunPath(id), id));
+
+    public Task<RunSummary> SaveAsync(RecordedRun run) => InBackground(async () =>
+    {
+        await WriteAsync(run, overwrite: false).ConfigureAwait(false);
+        return Summarize(run);
+    });
+
+    public Task<RunSummary> UpdateMetadataAsync(Guid id, string name, string tune, string notes) => InBackground(async () =>
+    {
+        var run = await ReadAsync(RunPath(id), id).ConfigureAwait(false);
+        var updated = run with { Name = name.Trim(), Tune = tune.Trim(), Notes = notes.Trim() };
+        await WriteAsync(updated, overwrite: true).ConfigureAwait(false);
+        return Summarize(updated);
+    });
+
+    public Task DeleteAsync(Guid id) => InBackground(async () =>
+    {
+        var trash = Path.Combine(_directory, "Deleted");
+        CheckPath(trash);
+        Directory.CreateDirectory(trash);
+        var source = RunPath(id);
+        var destination = Path.Combine(trash, $"{id:N}.wisprun");
+        CheckPath(destination);
+        File.Move(source, destination, overwrite: false);
+        Volatile.Write(ref _isFull, false);
+        await Task.CompletedTask;
+        return true;
+    });
+
+    public Task RestoreAsync(Guid id) => InBackground(async () =>
+    {
+        var source = Path.Combine(_directory, "Deleted", $"{id:N}.wisprun");
+        CheckPath(source);
+        var run = await ReadAsync(source, id).ConfigureAwait(false);
+        if (run.Id != id) throw new InvalidDataException("The deleted run identity is invalid.");
+        EnsureCapacity(id);
+        File.Move(source, RunPath(id), overwrite: false);
+        return true;
+    });
+
+    public Task ExportAsync(Guid id, string destination) => InBackground(async () =>
+    {
+        _ = await ReadAsync(RunPath(id), id).ConfigureAwait(false);
+        ValidateExternalPath(destination);
+        if (File.Exists(destination)) throw new IOException("Choose a different export filename; that file already exists.");
+        var temporary = Path.Combine(Path.GetDirectoryName(destination)!, $".wisp-export-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (var input = File.OpenRead(RunPath(id)))
+            await using (var output = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None, 65536, true))
+            {
+                await input.CopyToAsync(output).ConfigureAwait(false);
+                output.Flush(flushToDisk: true);
+            }
+            File.Move(temporary, destination, overwrite: false);
+        }
+        finally { if (File.Exists(temporary)) File.Delete(temporary); }
+        return true;
+    });
+
+    public Task<RunSummary> ImportAsync(string source) => InBackground(async () =>
+    {
+        ValidateExternalPath(source);
+        var run = await ReadAsync(source).ConfigureAwait(false);
+        run = run with { Id = Guid.NewGuid() };
+        await WriteAsync(run, overwrite: false).ConfigureAwait(false);
+        return Summarize(run);
+    });
+
+    private Task<T> InBackground<T>(Func<Task<T>> operation) => Task.Run(async () =>
+    {
+        await _gate.WaitAsync().ConfigureAwait(false);
+        try { EnsureDirectory(); return await operation().ConfigureAwait(false); }
+        finally { _gate.Release(); }
+    });
+
+    internal RunJournal CreateJournal(RecordedRun header)
+    {
+        _gate.Wait();
+        using var reservation = new RunJournalStartReservation(this, _gate);
+        return CreateJournal(header, reservation);
+    }
+
+    internal RunJournalStartReservation? TryReserveJournalStart()
+    {
+        if (!_gate.Wait(0)) return null;
+        try { return new RunJournalStartReservation(this, _gate); }
+        catch { _gate.Release(); throw; }
+    }
+
+    internal RunJournal CreateJournal(RecordedRun header, RunJournalStartReservation reservation)
+    {
+        if (!reservation.BelongsTo(this)) throw new InvalidOperationException("The recording startup reservation is no longer valid.");
+        try
+        {
+            EnsureDirectory();
+            EnsureCapacity(header.Id);
+            if (!_activeJournals.TryAdd(header.Id, 0)) throw new InvalidOperationException("This run is already being recorded.");
+            try { return new RunJournal(Path.Combine(_directory, $"{header.Id:N}.partial"), header, () => _activeJournals.TryRemove(header.Id, out _)); }
+            catch { _activeJournals.TryRemove(header.Id, out _); throw; }
+        }
+        finally { reservation.Dispose(); }
+    }
+
+    private void EnsureCapacity(Guid id)
+    {
+        var count = Directory.EnumerateFiles(_directory, "*.wisprun").Take(MaximumLibraryEntries).Count();
+        var reserved = _activeJournals.Count - (_activeJournals.ContainsKey(id) ? 1 : 0);
+        if (count + reserved >= MaximumLibraryEntries)
+        {
+            Volatile.Write(ref _isFull, true);
+            throw new RunLibraryFullException();
+        }
+    }
+
+    private void EnsureDirectory()
+    {
+        CheckPath(_directory);
+        Directory.CreateDirectory(_directory);
+    }
+
+    private string RunPath(Guid id)
+    {
+        if (id == Guid.Empty) throw new ArgumentException("Choose a saved run.", nameof(id));
+        var path = Path.Combine(_directory, $"{id:N}.wisprun");
+        CheckPath(path);
+        return path;
+    }
+
+    private string SummaryPath(Guid id) => Path.Combine(_directory, $"{id:N}.summary.json");
+
+    internal static void CheckPath(string path)
+    {
+        var current = Path.GetFullPath(path);
+        while (current is not null)
+        {
+            if ((File.Exists(current) || Directory.Exists(current)) &&
+                (File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+                throw new IOException("Run files cannot use linked folders or files.");
+            current = Path.GetDirectoryName(current);
+        }
+    }
+
+    private static void ValidateExternalPath(string path)
+    {
+        if (!Path.IsPathFullyQualified(path) || !string.Equals(Path.GetExtension(path), ".wisprun", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidDataException("Choose a .wisprun file using a full path.");
+        CheckPath(path);
+    }
+
+    private static async Task<RecordedRun> ReadAsync(string path, Guid? expectedId = null)
+    {
+        CheckPath(path);
+        var info = new FileInfo(path);
+        if (!info.Exists || info.Length is <= 0 or > MaximumFileBytes)
+            throw new InvalidDataException("The run file is missing or too large.");
+        await using var file = File.OpenRead(path);
+        await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+        await using var bounded = new BoundedReadStream(gzip, MaximumJsonBytes);
+        using var reader = new StreamReader(bounded);
+        var lines = new BoundedLineReader(reader);
+        var header = await lines.ReadLineAsync(131_072).ConfigureAwait(false) ?? throw new InvalidDataException("The run is empty.");
+        var run = JsonSerializer.Deserialize<RecordedRun>(header, JsonOptions) ?? throw new InvalidDataException("The run header is invalid.");
+        if (run.SchemaVersion != RecordedRun.CurrentSchemaVersion || run.Samples is null || run.Samples.Length != 0 || run.Markers is null || run.Markers.Length > MaximumMarkers)
+            throw new InvalidDataException("The run format is unsupported.");
+        var samples = new List<RunSample>();
+        while (await lines.ReadLineAsync(8192).ConfigureAwait(false) is { } line)
+        {
+            if (samples.Count >= MaximumSamples) throw new InvalidDataException("The run has too many samples.");
+            var sample = JsonSerializer.Deserialize<RunSample>(line, JsonOptions) ?? throw new InvalidDataException("The run contains a missing sample.");
+            ValidateSample(sample, samples.LastOrDefault());
+            samples.Add(sample);
+        }
+        run = run with { Samples = samples.ToArray() };
+        Validate(run);
+        if (expectedId is { } expected && expected != run.Id)
+            throw new InvalidDataException("The run file identity does not match its contents.");
+        return run;
+    }
+
+    private async Task WriteAsync(RecordedRun run, bool overwrite)
+    {
+        Validate(run);
+        if (!overwrite) EnsureCapacity(run.Id);
+        var destination = RunPath(run.Id);
+        var temporary = Path.Combine(_directory, $".{run.Id:N}-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (var file = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None, 65536, true))
+            {
+                await using (var gzip = new GZipStream(file, CompressionLevel.Fastest, leaveOpen: true))
+                await using (var writer = new StreamWriter(gzip, new System.Text.UTF8Encoding(false), 65536, leaveOpen: true))
+                {
+                    long decodedBytes = 0;
+                    await WriteRecordAsync(JsonSerializer.Serialize(run with { Samples = [] }, JsonOptions)).ConfigureAwait(false);
+                    foreach (var sample in run.Samples)
+                        await WriteRecordAsync(JsonSerializer.Serialize(sample, JsonOptions)).ConfigureAwait(false);
+
+                    async Task WriteRecordAsync(string line)
+                    {
+                        decodedBytes += System.Text.Encoding.UTF8.GetByteCount(line) + System.Text.Encoding.UTF8.GetByteCount(writer.NewLine);
+                        if (decodedBytes > MaximumJsonBytes) throw new InvalidDataException("The decoded run is too large to save.");
+                        await writer.WriteLineAsync(line).ConfigureAwait(false);
+                    }
+                }
+                file.Flush(flushToDisk: true);
+            }
+            if (new FileInfo(temporary).Length > MaximumFileBytes) throw new InvalidDataException("The run is too large to save.");
+            File.Move(temporary, destination, overwrite);
+            try { await WriteSummaryAsync(Summarize(run)).ConfigureAwait(false); }
+            catch (Exception error) when (IsDataError(error)) { Warning = "The run is saved. Its library summary will be rebuilt when needed."; }
+        }
+        finally { if (File.Exists(temporary)) File.Delete(temporary); }
+    }
+
+    private async Task WriteSummaryAsync(RunSummary summary)
+    {
+        var destination = SummaryPath(summary.Id);
+        CheckPath(destination);
+        var temporary = Path.Combine(_directory, $".{summary.Id:N}-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await File.WriteAllTextAsync(temporary, JsonSerializer.Serialize(summary, JsonOptions)).ConfigureAwait(false);
+            File.Move(temporary, destination, overwrite: true);
+        }
+        finally { if (File.Exists(temporary)) File.Delete(temporary); }
+    }
+
+    private async Task RecoverAsync()
+    {
+        if (_recovered) return;
+        foreach (var path in Directory.EnumerateFiles(_directory, "*.partial"))
+        {
+            try
+            {
+                CheckPath(path);
+                if (Guid.TryParseExact(Path.GetFileNameWithoutExtension(path), "N", out var activeId) && _activeJournals.ContainsKey(activeId)) continue;
+                var info = new FileInfo(path);
+                if (info.Length is <= 0 or > MaximumJsonBytes) continue;
+                using var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+                using var reader = new StreamReader(file);
+                var lines = new BoundedLineReader(reader);
+                var headerLine = await lines.ReadLineAsync(131_072).ConfigureAwait(false);
+                if (headerLine is null) continue;
+                var header = JsonSerializer.Deserialize<RecordedRun>(headerLine, JsonOptions);
+                if (header is null || header.Samples is null || header.Samples.Length != 0 || header.Markers is null || header.Markers.Length > MaximumMarkers || !Guid.TryParseExact(Path.GetFileNameWithoutExtension(path), "N", out var id) || header.Id != id) continue;
+                var samples = new List<RunSample>();
+                var markers = header.Markers.ToList();
+                while (await lines.ReadLineAsync(8192).ConfigureAwait(false) is { } line)
+                {
+                    if (line.Length > 8192) break;
+                    try
+                    {
+                        if (line.StartsWith("{\"marker\":", StringComparison.Ordinal))
+                        {
+                            var entry = JsonSerializer.Deserialize<RunJournalMarker>(line, JsonOptions);
+                            if (entry is null || markers.Count >= MaximumMarkers) break;
+                            ValidateMarker(entry.Marker, markers.LastOrDefault(), samples.LastOrDefault()?.ElapsedSeconds ?? -1);
+                            markers.Add(entry.Marker);
+                            continue;
+                        }
+                        if (samples.Count >= MaximumSamples) break;
+                        var sample = JsonSerializer.Deserialize<RunSample>(line, JsonOptions);
+                        if (sample is null) break;
+                        ValidateSample(sample, samples.LastOrDefault());
+                        samples.Add(sample);
+                    }
+                    catch (Exception error) when (IsDataError(error)) { break; }
+                }
+                if (samples.Count == 0) continue;
+                if (!File.Exists(RunPath(header.Id)))
+                    await WriteAsync(header with { Samples = samples.ToArray(), Markers = markers.ToArray(), IsIncomplete = true, FinishReason = "Recovered after Wisp closed before the run finished" }, false).ConfigureAwait(false);
+                reader.Dispose();
+                file.Dispose();
+                File.Delete(path);
+            }
+            catch (Exception error) when (IsDataError(error))
+            {
+                Warning = "An unfinished run could not be recovered. Its file has been kept.";
+            }
+        }
+        _recovered = true;
+    }
+
+    internal static RunSummary Summarize(RecordedRun run) => new(run.Id, run.Name, run.Tune, run.Notes,
+        run.StartedAtUtc, run.Samples.Length == 0 ? 0 : run.Samples[^1].ElapsedSeconds,
+        run.Samples.Length, run.Samples.Length == 0 ? 0 : run.Samples[0].State.CarOrdinal, run.IsIncomplete, run.FinishReason);
+
+    private static bool ValidSummary(RunSummary value) => value.Id != Guid.Empty &&
+        ValidText(value.Name, 100, false) && !string.IsNullOrWhiteSpace(value.Name) && ValidText(value.Tune, 150, false) &&
+        ValidText(value.Notes, 4000, true) && ValidText(value.FinishReason, 200, false) &&
+        double.IsFinite(value.DurationSeconds) && value.DurationSeconds is >= 0 and <= 600 &&
+        value.SampleCount is > 0 and <= MaximumSamples && value.CarOrdinal is > 0 and <= 10_000_000;
+
+    internal static void Validate(RecordedRun run)
+    {
+        if (run.SchemaVersion != RecordedRun.CurrentSchemaVersion || run.Samples is null || run.Samples.Length is 0 or > MaximumSamples ||
+            run.Markers is null || run.Markers.Length > MaximumMarkers ||
+            run.RejectedDatagrams < 0 || run.DroppedDatagrams < 0 ||
+            run.StartedAtUtc < new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero) || run.StartedAtUtc > DateTimeOffset.UtcNow.AddDays(1))
+            throw new InvalidDataException("The run metadata, version, or sample count is invalid.");
+        RunSample? previous = null;
+        foreach (var sample in run.Samples)
+        {
+            ValidateSample(sample, previous);
+            if (sample.State.CarOrdinal != run.Samples[0].State.CarOrdinal || sample.State.Drivetrain != run.Samples[0].State.Drivetrain)
+                throw new InvalidDataException("A run cannot combine different cars or drivetrains.");
+            previous = sample;
+        }
+        if (!ValidSummary(Summarize(run))) throw new InvalidDataException("The run metadata is invalid.");
+        RunMarker? previousMarker = null;
+        foreach (var marker in run.Markers)
+        {
+            ValidateMarker(marker, previousMarker, run.Samples[^1].ElapsedSeconds);
+            previousMarker = marker;
+        }
+    }
+
+    internal static bool ValidMarkerLabel(string label) => ValidText(label, MaximumMarkerLabelLength, false) && !string.IsNullOrWhiteSpace(label);
+
+    private static void ValidateMarker(RunMarker marker, RunMarker? previous, double duration)
+    {
+        if (marker is null || !double.IsFinite(marker.ElapsedSeconds) || marker.ElapsedSeconds < 0 || marker.ElapsedSeconds > duration ||
+            (previous is not null && marker.ElapsedSeconds < previous.ElapsedSeconds) || !ValidMarkerLabel(marker.Label))
+            throw new InvalidDataException("The run contains an invalid moment marker.");
+    }
+
+    internal static void ValidateSample(RunSample sample, RunSample? previous)
+    {
+        if (sample is null) throw new InvalidDataException("The run contains a missing sample.");
+        var state = sample.State;
+        if (state is null || !double.IsFinite(sample.ElapsedSeconds) || sample.ElapsedSeconds is < 0 or > 600 ||
+            sample.Segment < 0 || (previous is not null && (sample.ElapsedSeconds < previous.ElapsedSeconds || sample.Segment < previous.Segment)) ||
+            state.CarOrdinal is <= 0 or > 10_000_000 || !Enum.IsDefined(state.Drivetrain) || !Enum.IsDefined(state.Gear) || state.NumCylinders is < 0 or > 32 ||
+            !FiniteBound(state.GroundSpeedMetersPerSecond, 500) || !FiniteBound(state.EngineRpm, 40_000) || state.EngineRpm < 0 ||
+            !FiniteBound(state.EngineMaximumRpm, 30_000) || state.EngineMaximumRpm < 0 ||
+            !FiniteBound(state.PowerWatts, 100_000_000) || !FiniteBound(state.TorqueNm, 10_000_000) || !FiniteBound(state.BoostPressurePsi, 200) ||
+            !FiniteBound(state.LateralAccelerationMetersPerSecondSquared, 10_000) || !FiniteBound(state.LongitudinalAccelerationMetersPerSecondSquared, 10_000) ||
+            !ValidWheels(state.WheelRotationRadiansPerSecond, 10_000) || !ValidWheels(state.TireSlipRatio, 10_000) ||
+            !ValidWheels(state.TireSlipAngle, 10_000) || !ValidWheels(state.NormalizedSuspensionTravel, 10_000) || !ValidWheels(state.TireTemperatureFahrenheit, 5000))
+            throw new InvalidDataException("The run contains invalid or out-of-order samples.");
+        var hasRadii = sample.FrontRadiusMeters is { } front && sample.RearRadiusMeters is { } rear && new RollingRadii(front, rear).IsPlausible;
+        if ((sample.FrontRadiusMeters is not null || sample.RearRadiusMeters is not null || sample.WheelSpeedMetersPerSecond is not null) &&
+            (!hasRadii || sample.WheelSpeedMetersPerSecond is not { } wheel || !double.IsFinite(wheel) || wheel < 0 ||
+             Math.Abs(wheel - DrivenWheelSpeed.MetersPerSecond(state, new RollingRadii(sample.FrontRadiusMeters!.Value, sample.RearRadiusMeters!.Value))) > .001))
+            throw new InvalidDataException("The run's wheel-speed calibration is inconsistent.");
+    }
+
+    private static bool ValidText(string? text, int maximum, bool multiline) => text is not null && text.Length <= maximum &&
+        !text.Any(character => char.IsControl(character) && (!multiline || character is not '\r' and not '\n' and not '\t'));
+    private static bool FiniteBound(float value, float bound) => float.IsFinite(value) && MathF.Abs(value) <= bound;
+    private static bool ValidWheels(WheelValues value, float bound) => value.AreFinite() && value.MaximumAbsolute() <= bound;
+    internal static bool IsDataError(Exception error) => error is IOException or UnauthorizedAccessException or JsonException or InvalidDataException or ArgumentException or NotSupportedException;
+
+    internal sealed class BoundedLineReader(StreamReader reader)
+    {
+        private readonly char[] _buffer = new char[4096];
+        private char[] _lineBuffer = new char[4096];
+        private int _offset;
+        private int _length;
+        internal async ValueTask<string?> ReadLineAsync(int maximum)
+        {
+            var lineLength = 0;
+            while (true)
+            {
+                if (_offset == _length)
+                {
+                    _length = await reader.ReadAsync(_buffer.AsMemory()).ConfigureAwait(false);
+                    _offset = 0;
+                    if (_length == 0) return lineLength == 0 ? null : Finish(lineLength);
+                }
+                var newline = Array.IndexOf(_buffer, '\n', _offset, _length - _offset);
+                var count = (newline < 0 ? _length : newline) - _offset;
+                if (count > maximum - lineLength) throw new InvalidDataException("A run record is too large.");
+                var required = lineLength + count;
+                if (required > _lineBuffer.Length)
+                    Array.Resize(ref _lineBuffer, Math.Min(maximum, Math.Max(required, _lineBuffer.Length * 2)));
+                Array.Copy(_buffer, _offset, _lineBuffer, lineLength, count);
+                lineLength = required;
+                _offset += count;
+                if (newline >= 0)
+                {
+                    _offset++;
+                    return Finish(lineLength);
+                }
+            }
+        }
+        private string Finish(int length)
+        {
+            while (length > 0 && _lineBuffer[length - 1] == '\r') length--;
+            return new string(_lineBuffer, 0, length);
+        }
+    }
+
+    private sealed class BoundedReadStream(Stream inner, long maximum) : Stream
+    {
+        private long _read;
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => _read; set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) => Count(inner.Read(buffer, offset, count));
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => Count(await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false));
+        private int Count(int count) { _read += count; if (_read > maximum) throw new InvalidDataException("The decoded run is too large."); return count; }
+        public override void Flush() => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}
+
+internal sealed class RunJournalStartReservation(RunStore owner, SemaphoreSlim gate) : IDisposable
+{
+    private RunStore? _owner = owner;
+    internal bool BelongsTo(RunStore store) => ReferenceEquals(Volatile.Read(ref _owner), store);
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _owner, null) is not null) gate.Release();
+    }
+}
+
+internal sealed class RunJournal : IAsyncDisposable
+{
+    private readonly string _path;
+    private readonly FileStream _file;
+    private readonly StreamWriter _writer;
+    private readonly Action _onClosed;
+    private int _disposed;
+    private long _decodedBytes;
+    internal RunJournal(string path, RecordedRun header, Action onClosed)
+    {
+        _path = path;
+        _onClosed = onClosed;
+        RunStore.CheckPath(path);
+        _file = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.Read, 65536, true);
+        _writer = new StreamWriter(_file, new System.Text.UTF8Encoding(false), 65536, leaveOpen: true);
+        try
+        {
+            var line = JsonSerializer.Serialize(header, RunStore.JsonOptions);
+            _decodedBytes = System.Text.Encoding.UTF8.GetByteCount(line) + System.Text.Encoding.UTF8.GetByteCount(_writer.NewLine);
+            _writer.WriteLine(line);
+        }
+        catch { _writer.Dispose(); _file.Dispose(); throw; }
+    }
+    internal async Task AppendAsync(RunSample sample)
+    {
+        await AppendLineAsync(JsonSerializer.Serialize(sample, RunStore.JsonOptions)).ConfigureAwait(false);
+    }
+    internal Task AppendMarkerAsync(RunMarker marker) => AppendLineAsync(JsonSerializer.Serialize(new RunJournalMarker(marker), RunStore.JsonOptions));
+
+    private async Task AppendLineAsync(string line)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetByteCount(line) + System.Text.Encoding.UTF8.GetByteCount(_writer.NewLine);
+        if (_decodedBytes + bytes > RunStore.MaximumJsonBytes) throw new InvalidDataException("The run reached its storage limit.");
+        await _writer.WriteLineAsync(line).ConfigureAwait(false);
+        _decodedBytes += bytes;
+    }
+    internal async Task FlushAsync()
+    {
+        await _writer.FlushAsync().ConfigureAwait(false);
+        _file.Flush(flushToDisk: true);
+    }
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        try { await _writer.DisposeAsync().ConfigureAwait(false); }
+        finally
+        {
+            try { await _file.DisposeAsync().ConfigureAwait(false); }
+            finally { _onClosed(); }
+        }
+    }
+    internal void RemoveAfterSave() { File.Delete(_path); }
+}
+
+internal sealed record RunJournalMarker(RunMarker Marker);
+
+internal sealed class RunLibraryFullException() : IOException("The run library is full. Export or remove a run before recording another.");

--- a/src/Wisp.App/Runs/RunsPage.xaml
+++ b/src/Wisp.App/Runs/RunsPage.xaml
@@ -1,0 +1,400 @@
+<UserControl x:Class="Wisp.App.Runs.RunsPage"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Wisp.App.Runs">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="RunVisibility" />
+        <local:RunChartHeightConverter x:Key="RunChartHeight" />
+        <Style TargetType="CheckBox" BasedOn="{StaticResource ToggleSwitchStyle}" />
+        <Style TargetType="ComboBoxItem">
+            <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+            <Setter Property="Padding" Value="9,7" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Template"><Setter.Value><ControlTemplate TargetType="ComboBoxItem">
+                <Border x:Name="ItemBorder" Background="Transparent" BorderBrush="Transparent" BorderThickness="1" Padding="{TemplateBinding Padding}" CornerRadius="5">
+                    <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                </Border>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsHighlighted" Value="True"><Setter TargetName="ItemBorder" Property="Background" Value="{DynamicResource RaisedBrush}" /></Trigger>
+                    <Trigger Property="IsSelected" Value="True"><Setter TargetName="ItemBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" /></Trigger>
+                    <Trigger Property="IsEnabled" Value="False"><Setter TargetName="ItemBorder" Property="Opacity" Value="0.45" /></Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate></Setter.Value></Setter>
+        </Style>
+        <Style TargetType="ComboBox">
+            <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+            <Setter Property="Background" Value="{DynamicResource InputBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource StrokeBrush}" />
+            <Setter Property="Padding" Value="9,6" />
+            <Setter Property="MinHeight" Value="34" />
+            <Setter Property="IsTextSearchEnabled" Value="True" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+            <Setter Property="Template"><Setter.Value><ControlTemplate TargetType="ComboBox">
+                <Grid x:Name="ComboRoot">
+                    <Border x:Name="ComboBorder" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1" CornerRadius="7">
+                        <Grid Margin="{TemplateBinding Padding}">
+                            <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="20" /></Grid.ColumnDefinitions>
+                            <ContentPresenter Margin="0,0,6,0" Content="{TemplateBinding SelectionBoxItem}" ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                              ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" VerticalAlignment="Center" IsHitTestVisible="False" />
+                            <Path Grid.Column="1" Data="M0,0 L4,4 L8,0" Stroke="{DynamicResource MutedBrush}" StrokeThickness="1.4" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Grid>
+                    </Border>
+                    <ToggleButton Focusable="False" IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" ClickMode="Press">
+                        <ToggleButton.Template><ControlTemplate TargetType="ToggleButton"><Border Background="Transparent" /></ControlTemplate></ToggleButton.Template>
+                    </ToggleButton>
+                    <Popup x:Name="PART_Popup" IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom" AllowsTransparency="True" Focusable="False">
+                        <Border MinWidth="{TemplateBinding ActualWidth}" MaxHeight="{TemplateBinding MaxDropDownHeight}" Background="{DynamicResource PanelBrush}"
+                                BorderBrush="{DynamicResource StrokeBrush}" BorderThickness="1" CornerRadius="7" Padding="3">
+                            <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                                <ItemsPresenter KeyboardNavigation.DirectionalNavigation="Contained" />
+                            </ScrollViewer>
+                        </Border>
+                    </Popup>
+                </Grid>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsKeyboardFocusWithin" Value="True"><Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" /></Trigger>
+                    <Trigger Property="IsMouseOver" Value="True"><Setter TargetName="ComboBorder" Property="BorderBrush" Value="{DynamicResource MutedBrush}" /></Trigger>
+                    <Trigger Property="IsEnabled" Value="False"><Setter TargetName="ComboRoot" Property="Opacity" Value="0.45" /></Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate></Setter.Value></Setter>
+        </Style>
+        <Style x:Key="RunHint" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+            <Setter Property="Foreground" Value="{DynamicResource MutedBrush}" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+            <Setter Property="LineHeight" Value="18" />
+        </Style>
+        <Style x:Key="RunCard" TargetType="Border" BasedOn="{StaticResource CardStyle}">
+            <Setter Property="Padding" Value="16" />
+            <Setter Property="Margin" Value="0,0,0,12" />
+        </Style>
+        <Style x:Key="RunGraphTab" TargetType="ListBoxItem">
+            <Setter Property="AutomationProperties.Name" Value="{Binding Label}" />
+            <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+            <Setter Property="Padding" Value="10,7" />
+            <Setter Property="Margin" Value="0,0,6,6" />
+            <Setter Property="Template"><Setter.Value><ControlTemplate TargetType="ListBoxItem">
+                <Border x:Name="TabBorder" Background="{DynamicResource InputBrush}" BorderBrush="{DynamicResource StrokeBrush}" BorderThickness="1" CornerRadius="7" Padding="{TemplateBinding Padding}">
+                    <ContentPresenter />
+                </Border>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsSelected" Value="True">
+                        <Setter TargetName="TabBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" />
+                        <Setter TargetName="TabBorder" Property="Background" Value="{DynamicResource RaisedBrush}" />
+                        <Setter Property="Foreground" Value="{DynamicResource AccentBrush}" />
+                    </Trigger>
+                    <Trigger Property="IsKeyboardFocusWithin" Value="True"><Setter TargetName="TabBorder" Property="BorderBrush" Value="{DynamicResource AccentBrush}" /></Trigger>
+                    <Trigger Property="IsMouseOver" Value="True"><Setter TargetName="TabBorder" Property="Background" Value="{DynamicResource RaisedBrush}" /></Trigger>
+                    <Trigger Property="IsEnabled" Value="False"><Setter TargetName="TabBorder" Property="Opacity" Value="0.45" /></Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate></Setter.Value></Setter>
+        </Style>
+    </UserControl.Resources>
+    <Grid>
+    <ScrollViewer Visibility="{Binding IsSummaryVisible, Converter={StaticResource RunVisibility}}" x:Name="RunsScroll" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+        <StackPanel Margin="0,0,4,22">
+            <Border Style="{StaticResource RunCard}">
+                <StackPanel>
+                    <TextBlock Text="Record a run" Style="{StaticResource SectionTitleStyle}" />
+                    <TextBlock Text="Record up to 10 minutes, then explore and compare your runs. Recording continues when you return to Forza."
+                               Style="{StaticResource RunHint}" Margin="0,6,0,12" />
+                    <WrapPanel>
+                        <Button x:Name="RunRecordButton" Content="{Binding RecordButtonText}" Command="{Binding ToggleRecordingCommand}"
+                                Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,12,6" AutomationProperties.Name="Start or stop recording a run" />
+                        <Button Content="Mark moment" Command="{Binding MarkMomentCommand}" Margin="0,0,12,6"
+                                Visibility="{Binding IsRecording, Converter={StaticResource RunVisibility}}" />
+                        <TextBlock Text="{Binding RecordingStatus}" TextWrapping="Wrap" VerticalAlignment="Center" Margin="0,0,0,6"
+                                   AutomationProperties.LiveSetting="Polite" />
+                    </WrapPanel>
+                    <TextBlock Text="{Binding MarkerStatus}" Style="{StaticResource RunHint}" FontSize="11" AutomationProperties.LiveSetting="Polite"
+                               Visibility="{Binding IsRecording, Converter={StaticResource RunVisibility}}" />
+                    <Expander x:Name="RecordingOptionsExpander" Header="Recording options and shortcuts" Margin="0,6,0,0">
+                        <StackPanel Margin="0,8,0,0">
+                        <WrapPanel IsEnabled="{Binding CanEditRecordingOptions}">
+                            <StackPanel Margin="0,0,12,10">
+                                <TextBlock Text="Start countdown" Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,4" />
+                                <ComboBox ItemsSource="{Binding CountdownOptions}" DisplayMemberPath="Label" SelectedValuePath="Seconds"
+                                          SelectedValue="{Binding CountdownSeconds, Mode=TwoWay}" MinWidth="130" AutomationProperties.Name="Recording countdown" />
+                            </StackPanel>
+                            <StackPanel Margin="0,0,12,10">
+                                <TextBlock Text="Stop after" Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,4" />
+                                <ComboBox ItemsSource="{Binding StopAfterOptions}" DisplayMemberPath="Label" SelectedValuePath="Seconds"
+                                          SelectedValue="{Binding StopAfterSeconds, Mode=TwoWay}" MinWidth="195" AutomationProperties.Name="Automatic recording duration" />
+                            </StackPanel>
+                            <StackPanel Margin="0,0,12,10">
+                                <TextBlock Text="Analysis focus" Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,4" />
+                                <ComboBox ItemsSource="{Binding Purposes}" SelectedItem="{Binding Purpose, Mode=TwoWay}" MinWidth="130" AutomationProperties.Name="Recording analysis purpose" />
+                            </StackPanel>
+                        </WrapPanel>
+                        <TextBlock Text="A countdown waits before recording. Mark moments during the run to find them afterward; each run can hold 128 markers."
+                                   Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,12" />
+                        <TextBlock Text="Record / stop / cancel countdown" FontWeight="SemiBold" Margin="0,0,0,6" />
+                        <WrapPanel>
+                            <CheckBox Content="Enable" IsChecked="{Binding HotkeyEnabled, Mode=OneWay}" Click="ShortcutEnabled_Click" AutomationProperties.Name="Enable recording keyboard shortcut"
+                                      Style="{StaticResource ToggleSwitchStyle}" VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <Button x:Name="ShortcutCaptureButton" Content="{Binding HotkeyText}" Click="CaptureShortcut_Click"
+                                    PreviewKeyDown="CaptureShortcut_KeyDown" Padding="12,6" Margin="0,0,12,0"
+                                    AutomationProperties.Name="Change recording keyboard shortcut" />
+                            <TextBlock Text="{Binding HotkeyStatus}" Style="{StaticResource RunHint}" VerticalAlignment="Center" />
+                        </WrapPanel>
+                        <TextBlock Text="Mark a moment while recording" FontWeight="SemiBold" Margin="0,14,0,6" />
+                        <WrapPanel>
+                            <CheckBox Content="Enable" IsChecked="{Binding MarkerHotkeyEnabled, Mode=OneWay}" Click="MarkerShortcutEnabled_Click" AutomationProperties.Name="Enable marker keyboard shortcut"
+                                      Style="{StaticResource ToggleSwitchStyle}" VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <Button x:Name="MarkerShortcutCaptureButton" Content="{Binding MarkerHotkeyText}" Click="CaptureMarkerShortcut_Click"
+                                    PreviewKeyDown="CaptureShortcut_KeyDown" Padding="12,6" Margin="0,0,12,0" AutomationProperties.Name="Change marker keyboard shortcut" />
+                            <TextBlock Text="{Binding MarkerHotkeyStatus}" Style="{StaticResource RunHint}" VerticalAlignment="Center" />
+                        </WrapPanel>
+                        </StackPanel>
+                    </Expander>
+                </StackPanel>
+            </Border>
+            <TextBlock Text="{Binding Status}" Style="{StaticResource RunHint}" Margin="2,0,2,8" AutomationProperties.LiveSetting="Polite" />
+            <Border BorderBrush="{DynamicResource WarningBrush}" BorderThickness="1" CornerRadius="8" Padding="12" Margin="0,0,0,12"
+                    Visibility="{Binding HasError, Converter={StaticResource RunVisibility}}">
+                <TextBlock Text="{Binding Error}" TextWrapping="Wrap" AutomationProperties.LiveSetting="Assertive" />
+            </Border>
+            <Border Style="{StaticResource RunCard}">
+                <StackPanel>
+                    <DockPanel LastChildFill="True">
+                        <Button DockPanel.Dock="Right" Content="Import run" Click="Import_Click" IsEnabled="{Binding CanManageLibrary}" Padding="10,6" Margin="8,0,0,0" />
+                        <Button DockPanel.Dock="Right" Content="Refresh" Command="{Binding RefreshLibraryCommand}" Padding="10,6" Margin="8,0,0,0" />
+                        <TextBlock Text="Saved runs" FontSize="17" FontWeight="SemiBold" VerticalAlignment="Center" />
+                    </DockPanel>
+                    <TextBlock Text="{Binding LibraryHelp}" Style="{StaticResource RunHint}" FontSize="11" Margin="0,8,0,0" />
+                    <TextBlock Text="Nothing recorded yet. A saved run will appear here after you stop recording."
+                               Style="{StaticResource RunHint}" Margin="0,10,0,0" Visibility="{Binding IsLibraryEmpty, Converter={StaticResource RunVisibility}}" />
+                    <ComboBox x:Name="SavedRunSelector" ItemsSource="{Binding Library}" SelectedItem="{Binding SelectedRun, Mode=TwoWay}"
+                              TextSearch.TextPath="Name"
+                              IsEnabled="{Binding CanManageLibrary}"
+                              Margin="0,10,0,0" MinHeight="46" MaxDropDownHeight="340" HorizontalContentAlignment="Stretch"
+                              AutomationProperties.Name="Choose a saved run">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type local:SavedRunItem}">
+                                <StackPanel Margin="2,3">
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Detail}" FontSize="10" Foreground="{DynamicResource MutedBrush}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Text="{Binding Tune}" FontSize="10" Foreground="{DynamicResource MutedBrush}" TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <Button Content="Undo removal" Click="UndoDelete_Click" HorizontalAlignment="Left" Margin="0,8,0,0" Padding="10,6"
+                            IsEnabled="{Binding CanManageLibrary}"
+                            Visibility="{Binding CanUndoDelete, Converter={StaticResource RunVisibility}}" />
+                </StackPanel>
+            </Border>
+            <StackPanel x:Name="RunReportSurface" Visibility="{Binding HasRun, Converter={StaticResource RunVisibility}}">
+                <Border Style="{StaticResource RunCard}">
+                    <StackPanel>
+                        <TextBlock x:Name="RunHeading" Text="{Binding RunALabel}" Foreground="{x:Static local:RunComparisonColors.RunA}" FontSize="17" FontWeight="SemiBold" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding RunBLabel}" Foreground="{x:Static local:RunComparisonColors.RunB}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,5,0,0" Visibility="{Binding HasComparison, Converter={StaticResource RunVisibility}}" />
+                        <TextBlock Text="{Binding RunDescription}" Style="{StaticResource RunHint}" FontSize="11" Margin="0,4,0,10" />
+                        <Expander Header="Name, tune and notes">
+                            <StackPanel Margin="0,10,0,0" IsEnabled="{Binding CanManageRun}">
+                                <TextBlock Text="Run name" Style="{StaticResource RunHint}" />
+                                <TextBox Text="{Binding Name, UpdateSourceTrigger=PropertyChanged}" MaxLength="80" Margin="0,4,0,10" AutomationProperties.Name="Run name" />
+                                <TextBlock Text="Tune label" Style="{StaticResource RunHint}" />
+                                <TextBox Text="{Binding Tune, UpdateSourceTrigger=PropertyChanged}" MaxLength="120" Margin="0,4,0,4" AutomationProperties.Name="Tune label" />
+                                <TextBlock Text="Your own label. Forza does not provide a tune identifier." Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,10" />
+                                <TextBlock Text="Notes" Style="{StaticResource RunHint}" />
+                                <TextBox Text="{Binding Notes, UpdateSourceTrigger=PropertyChanged}" MaxLength="2000" AcceptsReturn="True" TextWrapping="Wrap"
+                                         VerticalScrollBarVisibility="Auto" Height="84" Margin="0,4,0,10" AutomationProperties.Name="Run notes" />
+                                <Button Content="Save details" Command="{Binding SaveDetailsCommand}" HorizontalAlignment="Left" Style="{StaticResource PrimaryButtonStyle}" />
+                                <TextBlock Text="{Binding CarIdentifier}" Style="{StaticResource RunHint}" FontSize="10" Margin="0,10,0,0" />
+                                <WrapPanel Margin="0,10,0,0">
+                                    <Button Content="Export run" Click="Export_Click" IsEnabled="{Binding CanManageRun}" Padding="10,6" />
+                                    <Button Content="Remove run" Click="Delete_Click" IsEnabled="{Binding CanManageRun}" Margin="8,0,0,0" Padding="10,6" />
+                                </WrapPanel>
+                            </StackPanel>
+                        </Expander>
+                        <WrapPanel Margin="0,12,0,0">
+                            <Button x:Name="ShowGraphsButton" Content="Show graphs" Click="ViewGraphs_Click" Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,16,6" />
+                            <TextBlock Text="Analysis" VerticalAlignment="Center" Margin="0,0,8,0" />
+                            <ComboBox ItemsSource="{Binding Purposes}" SelectedItem="{Binding Purpose, Mode=TwoWay}" MinWidth="130" IsEnabled="{Binding CanEditRecordingOptions}" AutomationProperties.Name="Run analysis purpose" />
+                        </WrapPanel>
+                        <Expander x:Name="CompareExpander" Header="Compare with another run" Margin="0,14,0,0">
+                            <StackPanel>
+                                <TextBlock Text="Choose another drive or start with the previous saved run." Style="{StaticResource RunHint}" Margin="0,4,0,10" />
+                                <ComboBox ItemsSource="{Binding Library}" SelectedItem="{Binding ComparisonChoice, Mode=TwoWay}" DisplayMemberPath="Name"
+                                          IsEnabled="{Binding CanManageLibrary}"
+                                          MinHeight="32" AutomationProperties.Name="Choose comparison run" />
+                                <WrapPanel Margin="0,8,0,0">
+                                    <Button Content="Compare selected" Command="{Binding CompareCommand}" Margin="0,0,8,6" Padding="10,7" />
+                                    <Button Content="Compare previous" Command="{Binding ComparePreviousCommand}" Margin="0,0,8,6" Padding="10,7" />
+                                    <Button Content="Remove comparison" Command="{Binding RemoveComparisonCommand}" Margin="0,0,0,6" Padding="10,7"
+                                            Visibility="{Binding HasComparison, Converter={StaticResource RunVisibility}}" />
+                                </WrapPanel>
+                                <StackPanel Visibility="{Binding HasComparison, Converter={StaticResource RunVisibility}}">
+                                    <TextBlock Text="{Binding RunBLabel}" Foreground="{x:Static local:RunComparisonColors.RunB}" FontWeight="SemiBold" TextWrapping="Wrap" Margin="0,5,0,9" />
+                                    <CheckBox Content="Match an acceleration speed range" IsChecked="{Binding SameSpeed}" IsEnabled="{Binding CanEditRecordingOptions}" Margin="0,0,0,8" />
+                                    <WrapPanel IsEnabled="{Binding CanEditRecordingOptions}">
+                                        <TextBlock Text="From" VerticalAlignment="Center" Margin="0,0,6,0" />
+                                        <TextBox Text="{Binding FromSpeed, UpdateSourceTrigger=PropertyChanged}" Width="58" AutomationProperties.Name="Acceleration start speed" />
+                                        <TextBlock Text="to" VerticalAlignment="Center" Margin="8,0" />
+                                        <TextBox Text="{Binding ToSpeed, UpdateSourceTrigger=PropertyChanged}" Width="58" AutomationProperties.Name="Acceleration end speed" />
+                                        <TextBlock Text="{Binding SpeedUnitText}" VerticalAlignment="Center" Margin="8,0" />
+                                        <Button Content="Apply range" Command="{Binding ApplySpeedRangeCommand}" Padding="10,6" />
+                                    </WrapPanel>
+                                    <TextBlock Text="{Binding ComparisonNote}" Style="{StaticResource RunHint}" Margin="0,8,0,0" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Expander>
+                    </StackPanel>
+                </Border>
+                <TextBlock x:Name="FindingsHeading" Text="What stands out" FontSize="19" FontWeight="SemiBold" Margin="2,4,0,10" />
+                <ItemsControl ItemsSource="{Binding Findings}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type local:RunFindingItem}">
+                            <Border Style="{StaticResource RunCard}">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Title}" FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding Detail}" Style="{StaticResource RunHint}" Margin="0,6,0,0" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <TextBlock Text="{Binding QualityNote}" Style="{StaticResource RunHint}" Margin="2,0,2,14" />
+                <TextBlock Text="{Binding IntervalLabel}" FontSize="17" FontWeight="SemiBold" Margin="2,0,0,10" />
+                <ItemsControl ItemsSource="{Binding Metrics}" Margin="0,0,0,8">
+                    <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate DataType="{x:Type local:RunMetric}">
+                            <Border Style="{StaticResource RunCard}" Width="204" Margin="0,0,8,8" Padding="14">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Label}" Style="{StaticResource RunHint}" FontSize="11" />
+                                    <TextBlock Text="{Binding Value}" FontSize="22" FontWeight="SemiBold" Margin="0,5,0,0" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding Comparison, StringFormat=B · {0}}" Foreground="{x:Static local:RunComparisonColors.RunB}" Margin="0,4,0,0" TextWrapping="Wrap">
+                                        <TextBlock.Style><Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}"><Style.Triggers>
+                                            <DataTrigger Binding="{Binding Comparison}" Value="{x:Null}"><Setter Property="Visibility" Value="Collapsed" /></DataTrigger>
+                                        </Style.Triggers></Style></TextBlock.Style>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+    <Grid x:Name="GraphWorkspace" Visibility="{Binding IsGraphWorkspaceOpen, Converter={StaticResource RunVisibility}}">
+        <Grid.RowDefinitions><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="Auto" /><RowDefinition Height="*" /></Grid.RowDefinitions>
+        <DockPanel Margin="0,0,4,10">
+                <Button x:Name="BackToSummaryButton" Content="Back to summary" Click="RunSummary_Click" DockPanel.Dock="Left" Margin="0,0,14,0" Padding="10,6" />
+                <Button Content="Save image" Click="SaveImage_Click" IsEnabled="{Binding CanExportImage}" DockPanel.Dock="Right" Padding="10,6" />
+                <StackPanel VerticalAlignment="Center" Margin="0,0,10,0">
+                    <TextBlock Text="{Binding RunALabel}" Foreground="{x:Static local:RunComparisonColors.RunA}" ToolTip="{Binding RunALabel}" Style="{StaticResource RunHint}" TextWrapping="NoWrap" FontSize="11" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Text="{Binding RunBLabel}" Foreground="{x:Static local:RunComparisonColors.RunB}" ToolTip="{Binding RunBLabel}" Style="{StaticResource RunHint}" TextWrapping="NoWrap" FontSize="11" Visibility="{Binding HasComparison, Converter={StaticResource RunVisibility}}" TextTrimming="CharacterEllipsis" />
+                </StackPanel>
+        </DockPanel>
+        <ListBox x:Name="GraphPicker" Grid.Row="1" ItemsSource="{Binding GraphChoices}" SelectedItem="{Binding SelectedGraph, Mode=TwoWay}"
+                 SelectionChanged="GraphPicker_SelectionChanged" IsEnabled="{Binding CanEditRecordingOptions}" ItemContainerStyle="{StaticResource RunGraphTab}"
+                 Background="Transparent" BorderThickness="0" Padding="0" Margin="0,0,4,6" HorizontalContentAlignment="Stretch"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                 AutomationProperties.Name="Choose a graph">
+            <ListBox.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ListBox.ItemsPanel>
+            <ListBox.ItemTemplate><DataTemplate DataType="{x:Type local:RunGraphChoice}"><TextBlock Text="{Binding Label}" FontSize="12" /></DataTemplate></ListBox.ItemTemplate>
+        </ListBox>
+        <StackPanel Grid.Row="2" Margin="0,0,4,0">
+            <TextBlock x:Name="GraphActionError" Text="{Binding Error}" ToolTip="{Binding Error}" TextWrapping="Wrap"
+                       Foreground="{DynamicResource WarningBrush}" FontSize="12" Margin="0,0,0,8"
+                       Visibility="{Binding HasError, Converter={StaticResource RunVisibility}}" AutomationProperties.LiveSetting="Assertive" />
+            <TextBlock x:Name="GraphExportStatus" Text="{Binding Status}" FontSize="12" Foreground="{DynamicResource MutedBrush}"
+                       TextWrapping="Wrap" Margin="0,0,0,8" AutomationProperties.LiveSetting="Polite">
+                <TextBlock.Style><Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                    <Setter Property="Visibility" Value="Collapsed" />
+                    <Style.Triggers><DataTrigger Binding="{Binding Status}" Value="{x:Static local:RunsViewModel.ImageExportSavedMessage}">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger></Style.Triggers>
+                </Style></TextBlock.Style>
+            </TextBlock>
+        </StackPanel>
+        <ScrollViewer x:Name="GraphScroll" Grid.Row="3" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Margin="0,0,4,22">
+                <StackPanel x:Name="GraphsSurface">
+                    <ItemsControl x:Name="ChartPanels" ItemsSource="{Binding Charts}" Visibility="{Binding IsTimeGraph, Converter={StaticResource RunVisibility}}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type local:RunPlotPanel}">
+                                <Border Style="{StaticResource RunCard}" Padding="14">
+                                    <local:RunChartView Panel="{Binding}" Height="{Binding ViewportHeight, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource RunChartHeight}}" Loaded="Chart_Loaded" Unloaded="Chart_Unloaded"
+                                        StartSeconds="{Binding DataContext.ViewStart, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        EndSeconds="{Binding DataContext.ViewEnd, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CursorSeconds="{Binding DataContext.CursorSeconds, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        SelectionStart="{Binding DataContext.SelectionStart, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        SelectionEnd="{Binding DataContext.SelectionEnd, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        Markers="{Binding DataContext.PlotMarkers, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        AccentBrush="{x:Static local:RunComparisonColors.RunA}" TextBrush="{DynamicResource TextBrush}"
+                                        MutedBrush="{DynamicResource MutedBrush}" WarningBrush="{DynamicResource WarningBrush}"
+                                        AutomationProperties.Name="{Binding Title}" AutomationProperties.HelpText="Arrow keys move the cursor. Select time ranges with the controls below the graphs." />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <ItemsControl ItemsSource="{Binding AlternativeCharts}" Visibility="{Binding IsAlternativeGraph, Converter={StaticResource RunVisibility}}">
+                        <ItemsControl.ItemTemplate><DataTemplate DataType="{x:Type local:RunAlternativePlotPanel}">
+                            <Border Style="{StaticResource RunCard}" Padding="14">
+                                <local:RunAlternativePlotView Panel="{Binding}" Height="{Binding ViewportHeight, RelativeSource={RelativeSource AncestorType=ScrollViewer}, Converter={StaticResource RunChartHeight}}"
+                                    IsEnabled="{Binding DataContext.CanEditRecordingOptions, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                    Loaded="AlternativeChart_Loaded" Unloaded="AlternativeChart_Unloaded"
+                                    AccentBrush="{x:Static local:RunComparisonColors.RunA}" TextBrush="{DynamicResource TextBrush}" MutedBrush="{DynamicResource MutedBrush}"
+                                    AutomationProperties.Name="{Binding Title}" />
+                            </Border>
+                        </DataTemplate></ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+                <Border Style="{StaticResource RunCard}">
+                    <StackPanel>
+                        <TextBlock Text="{Binding GraphHelp}" Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,8" />
+                        <WrapPanel Visibility="{Binding IsRpmGraph, Converter={StaticResource RunVisibility}}" IsEnabled="{Binding CanEditRecordingOptions}" Margin="0,0,0,8">
+                            <CheckBox Content="Full throttle only" IsChecked="{Binding FullThrottleOnly}" VerticalAlignment="Center" Margin="0,0,12,8" />
+                            <ComboBox ItemsSource="{Binding GearOptions}" SelectedItem="{Binding GearFilter, Mode=TwoWay}" DisplayMemberPath="Label"
+                                      MinWidth="155" Margin="0,0,0,8" AutomationProperties.Name="Engine graph gear filter" />
+                        </WrapPanel>
+                        <Expander x:Name="GraphRangeExpander" Header="Time range and cursor">
+                            <StackPanel Margin="0,10,0,0">
+                                <TextBlock Text="{Binding IntervalLabel}" FontWeight="SemiBold" Margin="0,0,0,6" />
+                                <TextBlock Text="{Binding CursorText}" Margin="0,8,0,8" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding CursorVehicleContext}" Style="{StaticResource RunHint}" FontSize="11" Margin="0,0,0,8" />
+                                <TextBlock Text="{Binding SelectedPointContext}" Style="{StaticResource RunHint}" FontSize="11" TextWrapping="Wrap" Visibility="{Binding HasSelectedPoint, Converter={StaticResource RunVisibility}}" />
+                                <WrapPanel IsEnabled="{Binding CanEditRecordingOptions}">
+                                    <TextBlock Text="From" VerticalAlignment="Center" Margin="0,0,6,6" />
+                                    <TextBox Text="{Binding SelectionFrom, UpdateSourceTrigger=PropertyChanged}" Width="64" Margin="0,0,8,6" AutomationProperties.Name="Selected interval start in seconds" />
+                                    <TextBlock Text="to" VerticalAlignment="Center" Margin="0,0,6,6" />
+                                    <TextBox Text="{Binding SelectionTo, UpdateSourceTrigger=PropertyChanged}" Width="64" Margin="0,0,6,6" AutomationProperties.Name="Selected interval end in seconds" />
+                                    <TextBlock Text="seconds" VerticalAlignment="Center" Margin="0,0,8,6" />
+                                    <Button Content="Select" Command="{Binding ApplyIntervalCommand}" Padding="10,6" Margin="0,0,0,6" />
+                                </WrapPanel>
+                                <WrapPanel>
+                                    <Button Content="Zoom selection" Command="{Binding ZoomSelectionCommand}" Padding="10,6" Margin="0,0,8,0" />
+                                    <Button Content="Show whole run" Command="{Binding ResetViewCommand}" Padding="10,6" Margin="0,0,8,0" />
+                                    <Button Content="Clear selection" Command="{Binding ClearSelectionCommand}" Padding="10,6" />
+                                </WrapPanel>
+                            </StackPanel>
+                        </Expander>
+                    </StackPanel>
+                </Border>
+                <Expander x:Name="MarkersExpander" Header="Marked moments" Margin="0,0,0,12" Visibility="{Binding HasMarkers, Converter={StaticResource RunVisibility}}">
+                    <ItemsControl ItemsSource="{Binding Markers}">
+                        <ItemsControl.ItemTemplate><DataTemplate DataType="{x:Type local:RunMarkerItem}">
+                            <Border Style="{StaticResource RunCard}" Padding="12" Margin="0,6,0,0">
+                                <DockPanel><Button Content="Jump" Command="{Binding JumpCommand}" DockPanel.Dock="Right" Padding="10,6" Margin="10,0,0,0" />
+                                    <StackPanel><TextBlock Text="{Binding Label}" TextWrapping="Wrap">
+                                        <TextBlock.Style><Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                            <Setter Property="Foreground" Value="{x:Static local:RunComparisonColors.RunA}" />
+                                            <Style.Triggers><DataTrigger Binding="{Binding Comparison}" Value="True">
+                                                <Setter Property="Foreground" Value="{x:Static local:RunComparisonColors.RunB}" />
+                                            </DataTrigger></Style.Triggers>
+                                        </Style></TextBlock.Style>
+                                    </TextBlock><TextBlock Text="{Binding Time}" Style="{StaticResource RunHint}" FontSize="11" /></StackPanel>
+                                </DockPanel>
+                            </Border>
+                        </DataTemplate></ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Expander>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+    </Grid>
+</UserControl>

--- a/src/Wisp.App/Runs/RunsPage.xaml.cs
+++ b/src/Wisp.App/Runs/RunsPage.xaml.cs
@@ -1,0 +1,186 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Wisp.App.Runs;
+
+public partial class RunsPage : UserControl
+{
+    private bool _capturingShortcut;
+    private bool _capturingMarkerShortcut;
+    private Button ActiveShortcutButton => _capturingMarkerShortcut ? MarkerShortcutCaptureButton : ShortcutCaptureButton;
+    private RunsViewModel? Model => DataContext as RunsViewModel;
+    public RunsPage()
+    {
+        InitializeComponent();
+        Unloaded += (_, _) => FinishShortcut();
+        ShortcutCaptureButton.LostKeyboardFocus += (_, _) => FinishShortcut();
+        MarkerShortcutCaptureButton.LostKeyboardFocus += (_, _) => FinishShortcut();
+        IsVisibleChanged += (_, _) => Model?.SetPageVisible(IsVisible);
+        DataContextChanged += (_, change) =>
+        {
+            if (change.OldValue is RunsViewModel previous) { previous.ShortcutCaptureActive = false; previous.SetPageVisible(false); previous.FocusChartsRequested -= FocusCharts; previous.ReportOpened -= OpenReport; }
+            if (Model is { } current) { current.FocusChartsRequested += FocusCharts; current.ReportOpened += OpenReport; }
+            Model?.SetPageVisible(IsVisible);
+        };
+    }
+    private void FocusCharts(object? sender, EventArgs e)
+    {
+        Model?.ShowGraphs();
+        _ = Dispatcher.InvokeAsync(() => ScrollTo(GraphsSurface, GraphScroll));
+    }
+    private void ViewGraphs_Click(object sender, RoutedEventArgs e)
+    {
+        Model?.ShowGraphs();
+        _ = Dispatcher.InvokeAsync(() =>
+        {
+            GraphScroll.ScrollToHome();
+            if (Window.GetWindow(this)?.IsActive != true || Model?.IsGraphWorkspaceOpen != true) return;
+            GraphPicker.UpdateLayout();
+            if (GraphPicker.SelectedItem is { } selected && GraphPicker.ItemContainerGenerator.ContainerFromItem(selected) is ListBoxItem choice) choice.Focus();
+            else GraphPicker.Focus();
+        }, System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+    private void GraphPicker_SelectionChanged(object sender, SelectionChangedEventArgs e) => GraphScroll?.ScrollToHome();
+    private void RunSummary_Click(object sender, RoutedEventArgs e)
+    {
+        Model?.ShowSummary();
+        _ = Dispatcher.InvokeAsync(() =>
+        {
+            ScrollTo(RunHeading, RunsScroll);
+            if (Window.GetWindow(this)?.IsActive == true && Model?.IsSummaryVisible == true) ShowGraphsButton.Focus();
+        }, System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+    private void OpenReport(object? sender, EventArgs e)
+    {
+        Model?.ShowSummary();
+        if (!IsVisible) return;
+        _ = Dispatcher.InvokeAsync(() => { if (IsVisible) ScrollTo(RunHeading, RunsScroll); }, System.Windows.Threading.DispatcherPriority.Loaded);
+    }
+    private void ScrollTo(FrameworkElement target, ScrollViewer scroll)
+    {
+        if (!IsVisible) return;
+        scroll.UpdateLayout();
+        scroll.ScrollToVerticalOffset(scroll.VerticalOffset + target.TranslatePoint(new Point(), scroll).Y);
+    }
+    private void Chart_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is RunChartView chart) { chart.IntervalSelected -= SelectInterval; chart.IntervalSelected += SelectInterval; }
+    }
+    private void Chart_Unloaded(object sender, RoutedEventArgs e) { if (sender is RunChartView chart) chart.IntervalSelected -= SelectInterval; }
+    private void SelectInterval(double from, double to) => Model?.SelectInterval(from, to);
+    private void AlternativeChart_Loaded(object sender, RoutedEventArgs e)
+    { if (sender is RunAlternativePlotView chart) { chart.PointSelected -= SelectAlternativePoint; chart.PointSelected += SelectAlternativePoint; } }
+    private void AlternativeChart_Unloaded(object sender, RoutedEventArgs e)
+    { if (sender is RunAlternativePlotView chart) chart.PointSelected -= SelectAlternativePoint; }
+    private void SelectAlternativePoint(RunAlternativeSelection point) => Model?.SelectAlternativePoint(point);
+    private void ShortcutEnabled_Click(object sender, RoutedEventArgs e)
+    { if (Model is { } model && sender is CheckBox toggle) model.HotkeyEnabled = toggle.IsChecked == true; }
+    private void CaptureShortcut_Click(object sender, RoutedEventArgs e)
+    { BeginShortcut(marker: false); }
+    private void MarkerShortcutEnabled_Click(object sender, RoutedEventArgs e)
+    { if (Model is { } model && sender is CheckBox toggle) model.MarkerHotkeyEnabled = toggle.IsChecked == true; }
+    private void CaptureMarkerShortcut_Click(object sender, RoutedEventArgs e) => BeginShortcut(marker: true);
+    private void BeginShortcut(bool marker)
+    {
+        FinishShortcut(); _capturingMarkerShortcut = marker;
+        ActiveShortcutButton.Focus();
+        _capturingShortcut = true; if (Model is { } model) model.ShortcutCaptureActive = true;
+        ActiveShortcutButton.SetCurrentValue(ContentProperty, "Press shortcut…");
+    }
+    private void CaptureShortcut_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (!_capturingShortcut || Model is not { } model) return;
+        e.Handled = true;
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (key == Key.Escape) { FinishShortcut(); return; }
+        if (key is Key.LeftCtrl or Key.RightCtrl or Key.LeftAlt or Key.RightAlt or Key.LeftShift or Key.RightShift or Key.LWin or Key.RWin) return;
+        var modifiers = OverlayHotkeyModifiers.None;
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Control)) modifiers |= OverlayHotkeyModifiers.Control;
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt)) modifiers |= OverlayHotkeyModifiers.Alt;
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Shift)) modifiers |= OverlayHotkeyModifiers.Shift;
+        if (Keyboard.Modifiers.HasFlag(ModifierKeys.Windows)) modifiers |= OverlayHotkeyModifiers.Windows;
+        if (OverlayHotkeyChord.TryCreate(modifiers, key, out var chord, out var error))
+        {
+            if (_capturingMarkerShortcut) model.ConfigureMarkerHotkey(model.MarkerHotkeyEnabled, chord);
+            else model.ConfigureHotkey(model.HotkeyEnabled, chord);
+            FinishShortcut();
+        }
+        else ActiveShortcutButton.SetCurrentValue(ContentProperty, error);
+    }
+    private void FinishShortcut()
+    {
+        _capturingShortcut = false; if (Model is { } model) model.ShortcutCaptureActive = false;
+        ShortcutCaptureButton.GetBindingExpression(ContentProperty)?.UpdateTarget();
+        MarkerShortcutCaptureButton.GetBindingExpression(ContentProperty)?.UpdateTarget();
+    }
+    private async void Import_Click(object sender, RoutedEventArgs e)
+    {
+        if (Model is not { } model) return;
+        var dialog = new Microsoft.Win32.OpenFileDialog { Title = "Import a Wisp run", Filter = "Wisp run files (*.wisprun)|*.wisprun", CheckFileExists = true };
+        if (dialog.ShowDialog(Window.GetWindow(this)) == true) await model.ImportAsync(dialog.FileName);
+    }
+    private async void Export_Click(object sender, RoutedEventArgs e)
+    {
+        if (Model is not { } model) return;
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            Title = "Export this Wisp run to a new file",
+            Filter = "Wisp run file · re-import and compare (*.wisprun)|*.wisprun|CSV · all recorded telemetry (*.csv)|*.csv",
+            FileName = "wisp-run",
+            DefaultExt = ".wisprun",
+            AddExtension = true,
+            OverwritePrompt = false
+        };
+        dialog.FileOk += (_, cancel) =>
+        {
+            var extension = dialog.FilterIndex == 2 ? ".csv" : ".wisprun";
+            if (!System.IO.Path.GetExtension(dialog.FileName).Equals(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                cancel.Cancel = true;
+                MessageBox.Show(Window.GetWindow(this), "Use " + extension + " for the selected file type.", "Check file extension", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+            if (!System.IO.File.Exists(dialog.FileName)) return;
+            cancel.Cancel = true;
+            MessageBox.Show(Window.GetWindow(this), "Choose a new filename to keep the existing run file.", "File already exists", MessageBoxButton.OK, MessageBoxImage.Information);
+        };
+        if (dialog.ShowDialog(Window.GetWindow(this)) == true) await model.ExportSelectedAsync(dialog.FileName);
+    }
+    private async void SaveImage_Click(object sender, RoutedEventArgs e)
+    {
+        if (Model is not { CanExportImage: true } model) return;
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            Title = "Save the current report and graphs as an image",
+            Filter = "PNG image (*.png)|*.png",
+            FileName = "wisp-run-report",
+            DefaultExt = ".png",
+            AddExtension = true,
+            OverwritePrompt = false
+        };
+        dialog.FileOk += (_, cancel) =>
+        {
+            if (!System.IO.File.Exists(dialog.FileName)) return;
+            cancel.Cancel = true;
+            MessageBox.Show(Window.GetWindow(this), "Choose a new filename to keep the existing image.", "File already exists", MessageBoxButton.OK, MessageBoxImage.Information);
+        };
+        if (dialog.ShowDialog(Window.GetWindow(this)) == true) await model.ExportImageAsync(dialog.FileName);
+    }
+    private async void Delete_Click(object sender, RoutedEventArgs e)
+    {
+        if (Model is not { } model) return;
+        if (MessageBox.Show(Window.GetWindow(this), "Remove this run from your saved runs? You can undo the removal.",
+            "Remove run", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes) await model.DeleteSelectedAsync();
+    }
+    private async void UndoDelete_Click(object sender, RoutedEventArgs e) { if (Model is { } model) await model.UndoDeleteAsync(); }
+}
+
+public sealed class RunChartHeightConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is double height && double.IsFinite(height) && height > 0 ? Math.Clamp(height - 50, 180, 270) : 270d;
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/src/Wisp.App/Runs/RunsViewModel.Navigation.cs
+++ b/src/Wisp.App/Runs/RunsViewModel.Navigation.cs
@@ -1,0 +1,52 @@
+namespace Wisp.App.Runs;
+
+public sealed record RunGraphChoice(string Label, RunChartGroup Group, RunPlotMode Mode);
+
+public sealed partial class RunsViewModel
+{
+    private bool _isGraphWorkspaceOpen;
+    public bool IsGraphWorkspaceOpen => _isGraphWorkspaceOpen && HasRun;
+    public bool IsSummaryVisible => !IsGraphWorkspaceOpen;
+    public RunGraphChoice[] GraphChoices { get; } =
+    [
+        new("Speed", RunChartGroup.Speed, RunPlotMode.TimeSeries),
+        new("Driver inputs", RunChartGroup.Inputs, RunPlotMode.TimeSeries),
+        new("Engine", RunChartGroup.Engine, RunPlotMode.TimeSeries),
+        new("Power / torque vs RPM", RunChartGroup.Engine, RunPlotMode.PowerByRpm),
+        new("G-force over time", RunChartGroup.Handling, RunPlotMode.TimeSeries),
+        new("G-force plot", RunChartGroup.Handling, RunPlotMode.GForce),
+        new("Tire temperatures", RunChartGroup.Tires, RunPlotMode.TimeSeries),
+        new("Tire temp change", RunChartGroup.Tires, RunPlotMode.TireChange)
+    ];
+    public RunGraphChoice SelectedGraph
+    {
+        get => GraphChoices.First(choice => choice.Group == ChartGroup && choice.Mode == GraphView.Mode);
+        set
+        {
+            if (value is null || RecordingActive || !GraphChoices.Contains(value) || value == SelectedGraph) return;
+            // Select the channel and presentation together so one click prepares one view.
+            _chartGroup = value.Group;
+            _graphView = AvailableGraphViews.First(view => view.Mode == value.Mode);
+            OnChanged(nameof(ChartGroup));
+            NotifyGraphMode();
+            RequestCharts();
+        }
+    }
+    public void ShowGraphs()
+    {
+        if (!HasRun || _disposed) return;
+        _isGraphWorkspaceOpen = true;
+        NotifyNavigation();
+        if (Charts.Count + AlternativeCharts.Count == 0 && !_preparingCharts) RequestCharts();
+    }
+    public void ShowSummary()
+    {
+        _isGraphWorkspaceOpen = false;
+        NotifyNavigation();
+    }
+    private void NotifyNavigation()
+    {
+        OnChanged(nameof(IsGraphWorkspaceOpen));
+        OnChanged(nameof(IsSummaryVisible));
+    }
+}

--- a/src/Wisp.App/Runs/RunsViewModel.Options.cs
+++ b/src/Wisp.App/Runs/RunsViewModel.Options.cs
@@ -1,0 +1,238 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public sealed record RunTimeOption(int Seconds, string Label);
+public sealed record RunGraphViewOption(RunPlotMode Mode, string Label);
+public sealed record RunGearOption(TransmissionGear? Gear, string Label);
+public sealed record RunMarkerItem(string Label, string Time, bool Comparison, double Seconds, ICommand JumpCommand);
+
+public sealed partial class RunsViewModel
+{
+    public const string ImageExportSavedMessage = "Report image saved. Nothing was uploaded.";
+    private readonly TimeProvider _timeProvider;
+    private long? _countdownStartedAt;
+    private int _armedCountdownSeconds;
+    private TimeSpan? _activeStopAfter;
+    private string? _recordingNotice;
+    private string _markerHotkeyStatus;
+    private Func<bool, OverlayHotkeyChord, string?>? _applyMarkerHotkey;
+    private long _chartRevision;
+    private RunGraphViewOption _graphView = new(RunPlotMode.TimeSeries, "Over time");
+    private RunGearOption _gearFilter = new(null, "All forward gears");
+    private bool _fullThrottleOnly = true;
+    private bool _preparingCharts;
+    private RunFinding[] _imageFindings = [];
+    private string _selectedPointContext = "";
+    private RunPlotMarker[] _plotMarkers = [];
+
+    public RunTimeOption[] CountdownOptions { get; } = [new(0, "No countdown"), new(3, "3 seconds"), new(5, "5 seconds"), new(10, "10 seconds")];
+    public RunTimeOption[] StopAfterOptions { get; } = [new(0, "Until I stop · 10 min max"), new(30, "30 seconds"), new(60, "1 minute"), new(120, "2 minutes"), new(300, "5 minutes"), new(600, "10 minutes")];
+    public int CountdownSeconds
+    {
+        get => _settings.RecordingCountdownSeconds;
+        set
+        {
+            if (!CanEditRecordingOptions || value == CountdownSeconds || !CountdownOptions.Any(option => option.Seconds == value)) return;
+            _settings.RecordingCountdownSeconds = value; OnChanged(); PreferencesChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+    public int StopAfterSeconds
+    {
+        get => _settings.RecordingStopAfterSeconds;
+        set
+        {
+            if (!CanEditRecordingOptions || value == StopAfterSeconds || !StopAfterOptions.Any(option => option.Seconds == value)) return;
+            _settings.RecordingStopAfterSeconds = value; OnChanged(); PreferencesChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+    public bool IsCountingDown => _countdownStartedAt is not null;
+    private bool RecordingActive => IsCountingDown || _service.IsRecording || _service.IsPreparing;
+    public bool CanEditRecordingOptions => !RecordingActive;
+    public int CountdownRemainingSeconds => _countdownStartedAt is { } started
+        ? Math.Max(0, (int)Math.Ceiling(_armedCountdownSeconds - _timeProvider.GetElapsedTime(started).TotalSeconds)) : 0;
+    public bool CanMarkMoment => _service.IsRecording;
+    public string MarkerStatus => _service.MarkerStatus;
+    public ICommand MarkMomentCommand { get; }
+    public bool MarkMoment()
+    {
+        if (_disposed || !CanMarkMoment) return false;
+        var marked = _service.MarkMoment(); OnChanged(nameof(MarkerStatus)); return marked;
+    }
+    public void CancelCountdown(string reason = "Countdown canceled. Nothing was recorded.")
+    {
+        if (!IsCountingDown) return;
+        _countdownStartedAt = null; _recordingNotice = reason;
+        NotifyRecordingOptions(); OnChanged(nameof(RecordingStatus)); OnChanged(nameof(RecordButtonText));
+        OnChanged(nameof(CanToggleRecording)); OnChanged(nameof(CanManageLibrary)); OnChanged(nameof(CanManageRun)); OnChanged(nameof(LibraryHelp)); RaiseCommands();
+    }
+    private void RefreshCountdown()
+    {
+        if (!IsCountingDown) return;
+        if (!_service.CanStart)
+        {
+            CancelCountdown("Countdown canceled because live driving telemetry stopped. Return to free roam and try again.");
+            return;
+        }
+        if (CountdownRemainingSeconds > 0) return;
+        _countdownStartedAt = null;
+        try { StartNow(); }
+        catch (Exception error) when (error is not OutOfMemoryException)
+        { Fail("The recording could not start after the countdown. Check live telemetry and local storage, then try again."); }
+    }
+    private void StartNow()
+    {
+        _recordingNotice = null;
+        BeforeStart?.Invoke();
+        if (!_service.Start(new RunRecordingOptions(_activeStopAfter))) Error = _service.Error ?? _service.Status;
+    }
+    private void NotifyRecordingOptions()
+    {
+        foreach (var property in new[] { nameof(IsCountingDown), nameof(CountdownRemainingSeconds), nameof(CanEditRecordingOptions), nameof(CanMarkMoment), nameof(MarkerStatus), nameof(CanExportImage) }) OnChanged(property);
+    }
+    public bool MarkerHotkeyEnabled { get => _settings.MarkerShortcutEnabled; set => ConfigureMarkerHotkey(value, SavedMarkerChord); }
+    public string MarkerHotkeyText => SavedMarkerChord.ToString();
+    public string MarkerHotkeyStatus { get => _markerHotkeyStatus; private set => Set(ref _markerHotkeyStatus, value); }
+    private OverlayHotkeyChord SavedMarkerChord => new(_settings.MarkerShortcutModifiers, _settings.MarkerShortcutKey);
+    public void SetMarkerHotkeyHandler(Func<bool, OverlayHotkeyChord, string?> apply) => _applyMarkerHotkey = apply;
+    public bool ConfigureMarkerHotkey(bool enabled, OverlayHotkeyChord chord)
+    {
+        var error = _applyMarkerHotkey?.Invoke(enabled, chord) ?? (_applyMarkerHotkey is null ? "Available after Wisp starts." : null);
+        MarkerHotkeyStatus = error ?? (enabled ? "Ready while recording" : "Off");
+        OnChanged(nameof(MarkerHotkeyEnabled)); OnChanged(nameof(MarkerHotkeyText));
+        return error is null;
+    }
+    public void RefreshMarkerHotkey() => ConfigureMarkerHotkey(MarkerHotkeyEnabled, SavedMarkerChord);
+    public void SuspendMarkerHotkeyStatus() => MarkerHotkeyStatus = MarkerHotkeyEnabled ? "Paused" : "Off";
+
+    public ObservableCollection<RunAlternativePlotPanel> AlternativeCharts { get; } = [];
+    public bool IsPreparingCharts => _preparingCharts;
+    public string SelectedPointContext { get => _selectedPointContext; private set { if (Set(ref _selectedPointContext, value)) OnChanged(nameof(HasSelectedPoint)); } }
+    public bool HasSelectedPoint => SelectedPointContext.Length > 0;
+    public ObservableCollection<RunMarkerItem> Markers { get; } = [];
+    public bool HasMarkers => Markers.Count > 0;
+    public RunPlotMarker[] PlotMarkers { get => _plotMarkers; private set => Set(ref _plotMarkers, value); }
+    public RunGraphViewOption[] AvailableGraphViews => ChartGroup switch
+    {
+        RunChartGroup.Engine => [new(RunPlotMode.TimeSeries, "Over time"), new(RunPlotMode.PowerByRpm, "Power / torque vs RPM")],
+        RunChartGroup.Handling => [new(RunPlotMode.TimeSeries, "Over time"), new(RunPlotMode.GForce, "G-force circle")],
+        RunChartGroup.Tires => [new(RunPlotMode.TimeSeries, "Over time"), new(RunPlotMode.TireChange, "Temperature change")],
+        _ => [new(RunPlotMode.TimeSeries, "Over time")]
+    };
+    public RunGraphViewOption GraphView
+    {
+        get => _graphView;
+        set
+        {
+            if (RecordingActive || value is null || !AvailableGraphViews.Any(option => option.Mode == value.Mode) || !Set(ref _graphView, value)) return;
+            NotifyGraphMode(); RequestCharts();
+        }
+    }
+    public bool IsTimeGraph => GraphView.Mode == RunPlotMode.TimeSeries;
+    public bool IsAlternativeGraph => !IsTimeGraph;
+    public bool IsRpmGraph => GraphView.Mode == RunPlotMode.PowerByRpm;
+    public bool HasGraphViewChoice => AvailableGraphViews.Length > 1;
+    public bool FullThrottleOnly { get => _fullThrottleOnly; set { if (!RecordingActive && Set(ref _fullThrottleOnly, value)) RequestCharts(); } }
+    public RunGearOption[] GearOptions { get; } = [new(null, "All forward gears"), .. Enumerable.Range(1, 10).Select(value => new RunGearOption((TransmissionGear)value, $"Gear {value}"))];
+    public RunGearOption GearFilter { get => _gearFilter; set { if (!RecordingActive && value is not null && Set(ref _gearFilter, value)) RequestCharts(); } }
+    public string GraphHelp => GraphView.Mode switch
+    {
+        RunPlotMode.PowerByRpm => "Recorded engine power and torque by RPM. Filters apply to these plots only; report statistics keep the selected time range. Choose a point to inspect its moment over time.",
+        RunPlotMode.GForce => "Each point is a recorded braking, acceleration, or cornering load. Choose a point to inspect its moment over time.",
+        RunPlotMode.TireChange => "Temperature change compares the first and last valid readings in each run's selected range. Each bar shows one axle; missing temperatures remain unavailable.",
+        _ => "Move over a graph for shared readouts. Drag to select a section; shaded breaks mark missing data. Arrow keys move the cursor."
+    };
+    private void NotifyGraphMode()
+    {
+        if (Status == ImageExportSavedMessage) Status = "Report ready.";
+        SelectedPointContext = "";
+        if (!RecordingActive) { Charts.Clear(); AlternativeCharts.Clear(); }
+        foreach (var property in new[] { nameof(AvailableGraphViews), nameof(GraphView), nameof(IsTimeGraph), nameof(IsAlternativeGraph), nameof(IsRpmGraph), nameof(HasGraphViewChoice), nameof(GraphHelp) }) OnChanged(property);
+        OnChanged(nameof(RunALabel)); OnChanged(nameof(RunBLabel));
+        OnChanged(nameof(CanExportImage));
+        OnChanged(nameof(SelectedGraph));
+    }
+    private RunInterval? ReportBounds(bool comparison)
+    {
+        var bounds = comparison ? _matchedB : _matchedA;
+        var offset = comparison ? _offsetB : _offsetA;
+        if (_interval is not { } selected) return bounds;
+        return new(selected.StartSeconds + offset, Math.Min(selected.EndSeconds + offset, bounds?.EndSeconds ?? double.MaxValue));
+    }
+    private void RefreshMarkers()
+    {
+        Markers.Clear();
+        var plotMarkers = new List<RunPlotMarker>();
+        Add(_runA, false, _offsetA, _matchedA); Add(_runB, true, _offsetB, _matchedB);
+        PlotMarkers = plotMarkers.ToArray();
+        OnChanged(nameof(HasMarkers));
+        void Add(RecordedRun? run, bool comparison, double offset, RunInterval? bounds)
+        {
+            if (run is null) return;
+            foreach (var marker in run.Markers.Take(128))
+            {
+                if (!double.IsFinite(marker.ElapsedSeconds) || marker.ElapsedSeconds < 0 ||
+                    (bounds is { } range && (marker.ElapsedSeconds < range.StartSeconds || marker.ElapsedSeconds > range.EndSeconds))) continue;
+                var seconds = marker.ElapsedSeconds - offset;
+                plotMarkers.Add(new(seconds, marker.Label, comparison));
+                Markers.Add(new($"{(comparison ? "B" : "A")} · {marker.Label}", RunPresentation.Time(seconds), comparison, seconds,
+                    new RunUiCommand(() => { JumpToMoment(seconds); return Task.CompletedTask; }, () => !IsBusy && !RecordingActive, () => Fail("This marker could not be opened."))));
+            }
+        }
+    }
+    public void SelectAlternativePoint(RunAlternativeSelection point)
+    {
+        if (RecordingActive) return;
+        var run = point.Comparison ? _runB : _runA;
+        if (run is null || point.SampleIndex < 0 || point.SampleIndex >= run.Samples.Length) return;
+        var sample = run.Samples[point.SampleIndex];
+        var bounds = ReportBounds(point.Comparison);
+        if (!sample.IsDriving || !sample.State.IsRaceOn || Math.Abs(sample.ElapsedSeconds - point.SourceSeconds) > .000001 ||
+            (bounds is { } interval && (sample.ElapsedSeconds < interval.StartSeconds || sample.ElapsedSeconds > interval.EndSeconds))) return;
+        JumpToMoment(point.SourceSeconds - (point.Comparison ? _offsetB : _offsetA));
+        var gear = sample.State.Gear switch
+        {
+            TransmissionGear.Reverse => "reverse",
+            TransmissionGear.Neutral => "neutral",
+            >= TransmissionGear.First and <= TransmissionGear.Tenth => $"gear {(int)sample.State.Gear}",
+            _ => "gear unavailable"
+        };
+        SelectedPointContext = $"Selected point · {(point.Comparison ? "B" : "A")} · {sample.ElapsedSeconds:0.000}s in that run · {sample.State.EngineRpm:N0} RPM · {gear}";
+    }
+    private void JumpToMoment(double seconds)
+    {
+        if (_runA is null || !double.IsFinite(seconds)) return;
+        SelectedPointContext = "";
+        GraphView = AvailableGraphViews[0];
+        var end = Math.Max((_matchedA?.EndSeconds ?? _runA.Samples.LastOrDefault()?.ElapsedSeconds ?? 0) - _offsetA,
+            (_matchedB?.EndSeconds ?? _runB?.Samples.LastOrDefault()?.ElapsedSeconds ?? 0) - _offsetB);
+        CursorSeconds = Math.Clamp(seconds, 0, Math.Max(0, end));
+        ViewStart = Math.Max(0, CursorSeconds - 2); ViewEnd = Math.Max(ViewStart + .1, Math.Min(end, CursorSeconds + 2));
+        FocusChartsRequested?.Invoke(this, EventArgs.Empty);
+    }
+    public bool CanExportImage => CanManageRun && !_preparingCharts && Charts.Count + AlternativeCharts.Count > 0;
+    public async Task ExportImageAsync(string destination)
+    {
+        if (!CanExportImage) return;
+        Error = "";
+        Status = "Saving report image…";
+        var context = GraphView.Label + (IsTimeGraph ? $" · displayed {RunPresentation.Time(ViewStart)}–{RunPresentation.Time(ViewEnd)}." : ".") + " " + QualityNote + " " + ComparisonNote;
+        if (IsRpmGraph) context += $" · {GearFilter.Label} · {(FullThrottleOnly ? "Full throttle only" : "All throttle positions")}. Plot filters do not change report statistics.";
+        static string Label(RecordedRun run) => run.Name + (string.IsNullOrWhiteSpace(run.Tune) ? "" : " · " + run.Tune);
+        var snapshot = new RunImageSnapshot(Label(_runA!), _runB is null ? null : Label(_runB), "Report statistics: " + IntervalLabel, context,
+            _imageFindings.ToArray(), Metrics.ToArray(), Charts.ToArray(), AlternativeCharts.ToArray(), ViewStart, ViewEnd);
+        IsBusy = true;
+        try
+        {
+            var bitmap = RunImageExporter.Render(snapshot);
+            await StoreOperationAsync(() => RunImageExporter.WriteAsync(bitmap, destination));
+            Status = ImageExportSavedMessage;
+        }
+        catch (Exception error) when (error is not OutOfMemoryException)
+        { Fail("The report image could not be saved. Choose a new filename and try again."); }
+        finally { IsBusy = false; OnChanged(nameof(CanExportImage)); }
+    }
+}

--- a/src/Wisp.App/Runs/RunsViewModel.cs
+++ b/src/Wisp.App/Runs/RunsViewModel.cs
@@ -1,0 +1,602 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using System.Windows.Threading;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.App.Runs;
+
+public sealed record SavedRunItem(RunSummary Summary)
+{
+    public Guid Id => Summary.Id;
+    public string Name => Summary.Name;
+    public string Detail => $"{Summary.StartedAtUtc.ToLocalTime():MMM d, h:mm tt} · {RunPresentation.Time(Summary.DurationSeconds)}";
+    public string Tune => string.IsNullOrWhiteSpace(Summary.Tune) ? "No tune label" : Summary.Tune;
+    public string Quality => Summary.IsIncomplete ? "Partial recording" : "";
+}
+
+public sealed record RunFindingItem(string Title, string Detail, ICommand ShowCommand, bool CanShow);
+
+public sealed partial class RunsViewModel : INotifyPropertyChanged, IDisposable
+{
+    private readonly RunRecordingService _service;
+    private readonly AppSettings _settings;
+    private readonly Dispatcher _dispatcher;
+    private readonly List<RunUiCommand> _commands = [];
+    private readonly Dictionary<Guid, RecordedRun> _reviewRuns = [];
+    private SavedRunItem? _selectedRun, _comparisonChoice;
+    private SavedRunItem? _pendingSelection;
+    private RecordedRun? _pendingSavedRun;
+    private RecordedRun? _runA, _runB;
+    private RunReport? _reportA, _reportB;
+    private RunInterval? _interval;
+    private RunInterval? _matchedA, _matchedB;
+    private long _selectionRevision, _analysisRevision;
+    private int _storageOperations;
+    private bool _pendingLibraryRefresh;
+    private bool _initialized, _initializing, _busy, _pageVisible, _disposed, _sameSpeed, _pendingAnalysis, _wasRecording;
+    private string _status = "Record a drive, then explore what changed.", _error = "", _name = "", _tune = "", _notes = "";
+    private string _fromSpeed = "20", _toSpeed = "60", _selectionFrom = "0", _selectionTo = "0";
+    private string _quality = "", _comparisonNote = "", _hotkeyStatus;
+    private double _cursor, _viewStart, _viewEnd = 1, _offsetA, _offsetB, _selectionStart = double.NaN, _selectionEnd = double.NaN;
+    private RunChartGroup _chartGroup;
+    private SpeedUnit _lastSpeedUnit;
+    private TorqueUnit _lastTorqueUnit;
+    private TireTemperatureUnit _lastTemperatureUnit;
+    private BoostPressureUnit _lastBoostUnit;
+    private Func<bool, OverlayHotkeyChord, string?>? _applyHotkey;
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event EventHandler? PreferencesChanged;
+    public event EventHandler? FocusChartsRequested;
+    public event EventHandler? ReportOpened;
+    public Action? BeforeStart { get; set; }
+    internal bool ShortcutCaptureActive { get; set; }
+    public ObservableCollection<SavedRunItem> Library { get; } = [];
+    public ObservableCollection<RunFindingItem> Findings { get; } = [];
+    public ObservableCollection<RunMetric> Metrics { get; } = [];
+    public ObservableCollection<RunPlotPanel> Charts { get; } = [];
+    public RunPurpose[] Purposes { get; } = Enum.GetValues<RunPurpose>();
+    public RunChartGroup[] ChartGroups { get; } = Enum.GetValues<RunChartGroup>();
+    public ICommand ToggleRecordingCommand { get; }
+    public ICommand SaveDetailsCommand { get; }
+    public ICommand CompareCommand { get; }
+    public ICommand ComparePreviousCommand { get; }
+    public ICommand RemoveComparisonCommand { get; }
+    public ICommand ApplyIntervalCommand { get; }
+    public ICommand ZoomSelectionCommand { get; }
+    public ICommand ResetViewCommand { get; }
+    public ICommand ClearSelectionCommand { get; }
+    public ICommand ApplySpeedRangeCommand { get; }
+    public ICommand RefreshLibraryCommand { get; }
+    public RunsViewModel(RunRecordingService service, AppSettings settings, Dispatcher dispatcher, TimeProvider? timeProvider = null)
+    {
+        _service = service; _settings = settings; _dispatcher = dispatcher;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _markerHotkeyStatus = settings.MarkerShortcutEnabled ? "Not active" : "Off";
+        _lastSpeedUnit = settings.SpeedUnit; _lastTorqueUnit = settings.TorqueUnit;
+        _lastTemperatureUnit = settings.TireTemperatureUnit; _lastBoostUnit = settings.BoostPressureUnit;
+        _hotkeyStatus = settings.RecordingShortcutEnabled ? "Not active" : "Off";
+        ToggleRecordingCommand = Command(ToggleRecordingAsync, () => CanToggleRecording);
+        SaveDetailsCommand = Command(SaveDetailsAsync, () => CanManageRun);
+        CompareCommand = Command(CompareChosenAsync, () => CanManageRun && ComparisonChoice is not null && ComparisonChoice.Id != _runA?.Id);
+        ComparePreviousCommand = Command(ComparePreviousAsync, () => CanManageRun && PreviousRun() is not null);
+        RemoveComparisonCommand = Command(() => { _runB = null; _sameSpeed = false; _matchedA = _matchedB = _interval = null; _offsetA = _offsetB = 0; SelectionStart = SelectionEnd = double.NaN; ResetView(); OnChanged(nameof(SameSpeed)); NotifyRun(); RequestAnalysis(); return Task.CompletedTask; }, () => HasComparison && !IsBusy && !RecordingActive);
+        ApplyIntervalCommand = Command(() => { ApplyTypedInterval(); return Task.CompletedTask; }, () => HasRun && !IsBusy && !RecordingActive);
+        ZoomSelectionCommand = Command(() => { if (HasSelection) { ViewStart = SelectionStart; ViewEnd = SelectionEnd; } return Task.CompletedTask; }, () => HasSelection);
+        ResetViewCommand = Command(() => { ResetView(); return Task.CompletedTask; }, () => HasRun);
+        ClearSelectionCommand = Command(() => { _interval = null; SelectionStart = SelectionEnd = double.NaN; RequestAnalysis(); return Task.CompletedTask; }, () => HasSelection && !IsBusy && !RecordingActive);
+        ApplySpeedRangeCommand = Command(() => { _sameSpeed = true; _interval = null; SelectionStart = SelectionEnd = double.NaN; OnChanged(nameof(SameSpeed)); return AnalyzeAsync(); }, () => HasComparison && !IsBusy && !RecordingActive);
+        RefreshLibraryCommand = Command(LoadLibraryAsync, () => CanManageLibrary);
+        MarkMomentCommand = Command(() => { MarkMoment(); return Task.CompletedTask; }, () => CanMarkMoment);
+        _service.StateChanged += ServiceStateChanged;
+        _service.RunSaved += ServiceRunSaved;
+        if (settings.SpeedUnit != SpeedUnit.MilesPerHour) { _fromSpeed = "30"; _toSpeed = "100"; }
+    }
+
+    public SavedRunItem? SelectedRun
+    {
+        get => _selectedRun;
+        set { if (!RecordingActive && Set(ref _selectedRun, value) && value is not null) _ = LoadSelectionAsync(value); }
+    }
+    public SavedRunItem? ComparisonChoice { get => _comparisonChoice; set { if (RecordingActive) return; Set(ref _comparisonChoice, value); RaiseCommands(); } }
+    public string RecordButtonText => IsCountingDown ? "Cancel countdown" : _service.IsRecording ? "Stop recording" : _service.IsPreparing ? "Saving run…" : "Record run";
+    public bool CanToggleRecording => IsCountingDown || (!_service.IsPreparing && (_service.IsRecording || (_storageOperations == 0 && _service.CanStart)));
+    public bool IsRecording => _service.IsRecording;
+    public string RecordingStatus => IsCountingDown ? $"Recording starts in {CountdownRemainingSeconds}… Return to Forza; the shortcut can cancel."
+        : _service.IsRecording ? $"Recording · {RunPresentation.Time(_service.Elapsed.TotalSeconds)}" + (_activeStopAfter is { } stop ? $" · stops at {RunPresentation.Time(stop.TotalSeconds)}" : "")
+        : _recordingNotice is { } notice ? notice
+        : _storageOperations > 0 ? "Finishing library work before the next recording."
+        : !_service.CanStart && _service.Status == "Ready to record" && _service.Error is null
+            ? _service.Store.IsFull ? "The run library is full. Remove a saved run before recording another."
+                : "Open Forza and return to free roam with live telemetry to record a run."
+            : _service.Status;
+    public bool IsBusy { get => _busy; private set { Set(ref _busy, value); OnChanged(nameof(CanManageRun)); OnChanged(nameof(CanManageLibrary)); OnChanged(nameof(CanExportImage)); RaiseCommands(); } }
+    public bool CanManageRun => HasRun && CanManageLibrary;
+    public bool CanManageLibrary => !IsBusy && _storageOperations == 0 && !RecordingActive;
+    public string LibraryHelp => RecordingActive ? "Library changes resume after the recording is saved or canceled." : "Run files stay on this PC.";
+    public bool HasRun => _runA is not null;
+    public bool HasComparison => _runB is not null;
+    public bool HasSelection => double.IsFinite(SelectionStart) && double.IsFinite(SelectionEnd);
+    public bool IsLibraryEmpty => Library.Count == 0;
+    public string Status { get => _status; private set => Set(ref _status, value); }
+    public string Error { get => _error; private set { Set(ref _error, value); OnChanged(nameof(HasError)); } }
+    public bool HasError => !string.IsNullOrEmpty(Error);
+    public string Name { get => _name; set { if (!RecordingActive) Set(ref _name, value); } }
+    public string Tune { get => _tune; set { if (!RecordingActive) Set(ref _tune, value); } }
+    public string Notes { get => _notes; set { if (!RecordingActive) Set(ref _notes, value); } }
+    public string RunALabel => _runA is null ? "" : "A · " + _runA.Name;
+    public string RunBLabel => _runB is null ? "" : "B · " + _runB.Name;
+    public string RunDescription => _runA is null ? "" : $"{_runA.StartedAtUtc.ToLocalTime():f} · {RunPresentation.Time(_runA.Samples.LastOrDefault()?.ElapsedSeconds ?? 0)}";
+    public string CarIdentifier => _runA is null ? "" : $"Game car identifier: {_runA.Samples.FirstOrDefault()?.State.CarOrdinal}";
+    public string QualityNote { get => _quality; private set => Set(ref _quality, value); }
+    public string ComparisonNote { get => _comparisonNote; private set => Set(ref _comparisonNote, value); }
+    public string SpeedUnitText => RunPresentation.SpeedLabel(_settings.SpeedUnit);
+    public string IntervalLabel => HasSelection ? $"Selected: {RunPresentation.Time(SelectionStart)}–{RunPresentation.Time(SelectionEnd)}" : _matchedA is not null ? "Matched acceleration intervals" : "Whole run";
+    public RunPurpose Purpose
+    {
+        get => _settings.RunPurpose;
+        set { if (RecordingActive || _settings.RunPurpose == value) return; _settings.RunPurpose = value; OnChanged(); PreferencesChanged?.Invoke(this, EventArgs.Empty); RequestAnalysis(); }
+    }
+    public RunChartGroup ChartGroup { get => _chartGroup; set { if (!RecordingActive && Set(ref _chartGroup, value)) { _graphView = AvailableGraphViews[0]; NotifyGraphMode(); RequestCharts(); } } }
+    public bool SameSpeed { get => _sameSpeed; set { if (!RecordingActive && Set(ref _sameSpeed, value)) { _interval = null; SelectionStart = SelectionEnd = double.NaN; RequestAnalysis(); } } }
+    public string FromSpeed { get => _fromSpeed; set { if (!RecordingActive) Set(ref _fromSpeed, value); } }
+    public string ToSpeed { get => _toSpeed; set { if (!RecordingActive) Set(ref _toSpeed, value); } }
+    public string SelectionFrom { get => _selectionFrom; set { if (!RecordingActive) Set(ref _selectionFrom, value); } }
+    public string SelectionTo { get => _selectionTo; set { if (!RecordingActive) Set(ref _selectionTo, value); } }
+    public double CursorSeconds { get => _cursor; set { if (Set(ref _cursor, value)) SelectedPointContext = ""; OnChanged(nameof(CursorText)); OnChanged(nameof(CursorVehicleContext)); } }
+    public string CursorText => "Cursor · " + RunPresentation.Time(CursorSeconds);
+    public string CursorVehicleContext => _runA is null ? "" : RunCursor.Describe("A", _runA, CursorSeconds + _offsetA, _matchedA) +
+        (_runB is null ? "" : "   |   " + RunCursor.Describe("B", _runB, CursorSeconds + _offsetB, _matchedB));
+    public double ViewStart { get => _viewStart; private set => Set(ref _viewStart, value); }
+    public double ViewEnd { get => _viewEnd; private set => Set(ref _viewEnd, value); }
+    public double SelectionStart { get => _selectionStart; private set { Set(ref _selectionStart, value); OnChanged(nameof(HasSelection)); OnChanged(nameof(IntervalLabel)); RaiseCommands(); } }
+    public double SelectionEnd { get => _selectionEnd; private set { Set(ref _selectionEnd, value); OnChanged(nameof(HasSelection)); OnChanged(nameof(IntervalLabel)); RaiseCommands(); } }
+    public bool HotkeyEnabled { get => _settings.RecordingShortcutEnabled; set => ConfigureHotkey(value, SavedChord); }
+    public string HotkeyText => SavedChord.ToString();
+    public string HotkeyStatus { get => _hotkeyStatus; private set => Set(ref _hotkeyStatus, value); }
+    private OverlayHotkeyChord SavedChord => new(_settings.RecordingShortcutModifiers, _settings.RecordingShortcutKey);
+    public void SetHotkeyHandler(Func<bool, OverlayHotkeyChord, string?> apply) => _applyHotkey = apply;
+    public bool ConfigureHotkey(bool enabled, OverlayHotkeyChord chord)
+    {
+        var error = _applyHotkey?.Invoke(enabled, chord) ?? (_applyHotkey is null ? "Available after Wisp starts." : null);
+        HotkeyStatus = error ?? (enabled ? "Ready" : "Off");
+        OnChanged(nameof(HotkeyEnabled)); OnChanged(nameof(HotkeyText));
+        return error is null;
+    }
+    public void RefreshHotkey() => ConfigureHotkey(HotkeyEnabled, SavedChord);
+    public void SuspendHotkeyStatus() { CancelCountdown("Countdown canceled because Wisp was paused."); HotkeyStatus = HotkeyEnabled ? "Paused" : "Off"; }
+
+    public async Task InitializeAsync()
+    {
+        if (_initialized || _initializing || _disposed) return;
+        _initializing = true;
+        try { await LoadLibraryAsync(); _initialized = true; }
+        finally { _initializing = false; RefreshStatus(); }
+    }
+    public void RefreshStatus()
+    {
+        if (_disposed) return;
+        RefreshCountdown();
+        if (_lastSpeedUnit != _settings.SpeedUnit || _lastTorqueUnit != _settings.TorqueUnit ||
+            _lastTemperatureUnit != _settings.TireTemperatureUnit || _lastBoostUnit != _settings.BoostPressureUnit)
+        {
+            var conversion = RunPresentation.SpeedFactor(_settings.SpeedUnit) / RunPresentation.SpeedFactor(_lastSpeedUnit);
+            if (double.TryParse(FromSpeed, out var from) && double.IsFinite(from)) Set(ref _fromSpeed, (from * conversion).ToString("0.##", CultureInfo.CurrentCulture), nameof(FromSpeed));
+            if (double.TryParse(ToSpeed, out var to) && double.IsFinite(to)) Set(ref _toSpeed, (to * conversion).ToString("0.##", CultureInfo.CurrentCulture), nameof(ToSpeed));
+            _lastSpeedUnit = _settings.SpeedUnit; _lastTorqueUnit = _settings.TorqueUnit;
+            _lastTemperatureUnit = _settings.TireTemperatureUnit; _lastBoostUnit = _settings.BoostPressureUnit;
+            RequestAnalysis();
+        }
+        if (_service.IsRecording && !_wasRecording)
+        {
+            _pendingAnalysis |= IsBusy || _preparingCharts; ++_analysisRevision; ++_chartRevision; _preparingCharts = false; IsBusy = false;
+        }
+        _wasRecording = _service.IsRecording;
+        if (!RecordingActive)
+        {
+            if (_pendingSavedRun is { } saved)
+            {
+                _pendingSavedRun = null; _pendingLibraryRefresh = false; _pendingAnalysis = false;
+                _ = ShowSavedAsync(saved);
+            }
+            else
+            {
+                if (_pendingLibraryRefresh) { _pendingLibraryRefresh = false; _ = LoadLibraryAsync(); }
+                if (_pendingSelection is { } selection) { _pendingSelection = null; _pendingAnalysis = false; _ = LoadSelectionAsync(selection); }
+                else if (_pendingAnalysis) { _pendingAnalysis = false; RequestAnalysis(); }
+            }
+        }
+        OnChanged(nameof(RecordButtonText)); OnChanged(nameof(CanToggleRecording)); OnChanged(nameof(IsRecording)); OnChanged(nameof(RecordingStatus));
+        OnChanged(nameof(CanManageRun)); OnChanged(nameof(CanManageLibrary));
+        OnChanged(nameof(LibraryHelp));
+        NotifyRecordingOptions();
+        OnChanged(nameof(SpeedUnitText)); RaiseCommands();
+    }
+    public async Task ToggleRecordingAsync()
+    {
+        if (_disposed || _service.IsPreparing) return;
+        Error = "";
+        try
+        {
+            if (IsCountingDown) { CancelCountdown(); }
+            else if (_service.IsRecording) { Status = "Saving your run…"; await _service.StopAsync(); }
+            else
+            {
+                if (_storageOperations > 0) { Error = "Let the current library action finish, then start recording."; return; }
+                _recordingNotice = null;
+                if (!_service.CanStart) { Error = RecordingStatus; return; }
+                _activeStopAfter = StopAfterSeconds == 0 ? null : TimeSpan.FromSeconds(StopAfterSeconds);
+                if (CountdownSeconds > 0)
+                {
+                    _countdownStartedAt = _timeProvider.GetTimestamp(); _armedCountdownSeconds = CountdownSeconds;
+                    _pendingAnalysis |= IsBusy || _preparingCharts; ++_analysisRevision; ++_chartRevision; _preparingCharts = false; OnChanged(nameof(IsPreparingCharts)); IsBusy = false;
+                }
+                else StartNow();
+            }
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("The run could not be started or saved. Check local storage and try again."); }
+        finally { RefreshStatus(); }
+    }
+    public void SetPageVisible(bool visible)
+    {
+        _pageVisible = visible;
+        if (visible)
+        {
+            var revision = _analysisRevision;
+            RefreshStatus();
+            if (revision == _analysisRevision) RequestCharts();
+        }
+    }
+    private void ServiceStateChanged(object? sender, EventArgs e) => OnUi(RefreshStatus);
+    private void ServiceRunSaved(RecordedRun run) => OnUi(() => _ = ShowSavedAsync(run));
+    private async Task ShowSavedAsync(RecordedRun run)
+    {
+        if (RecordingActive) { _pendingSavedRun = run; _pendingLibraryRefresh = true; return; }
+        try
+        {
+            await LoadLibraryAsync();
+            if (RecordingActive) { _pendingSavedRun = run; _pendingLibraryRefresh = true; return; }
+            var item = Library.FirstOrDefault(item => item.Id == run.Id);
+            if (item is not null) { _selectedRun = item; OnChanged(nameof(SelectedRun)); await LoadSelectionAsync(item, run); }
+            Status = "Run saved. Open Runs to explore it.";
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("The run was saved, but its report could not be opened. Refresh the run list."); }
+        finally { RefreshStatus(); }
+    }
+    private async Task LoadLibraryAsync()
+    {
+        if (RecordingActive) { _pendingLibraryRefresh = true; return; }
+        try
+        {
+            var summaries = await StoreOperationAsync(() => _service.Store.ListAsync());
+            var selectedId = _selectedRun?.Id; var comparisonId = _comparisonChoice?.Id;
+            Library.Clear();
+            foreach (var summary in summaries.OrderByDescending(item => item.StartedAtUtc)) Library.Add(new(summary));
+            _selectedRun = Library.FirstOrDefault(item => item.Id == selectedId);
+            _comparisonChoice = Library.FirstOrDefault(item => item.Id == comparisonId);
+            OnChanged(nameof(SelectedRun)); OnChanged(nameof(ComparisonChoice));
+            OnChanged(nameof(IsLibraryEmpty)); RaiseCommands();
+            if (_service.Store.Warning is { } warning) Error = warning;
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("Saved runs could not be read. Check local storage, then refresh."); }
+    }
+    private async Task LoadSelectionAsync(SavedRunItem selected, RecordedRun? knownRun = null)
+    {
+        if (RecordingActive)
+        {
+            if (knownRun is not null) _pendingSavedRun = knownRun;
+            else _pendingSelection = selected;
+            Status = "Stop recording to open the selected run. Your current report stays available."; return;
+        }
+        var revision = ++_selectionRevision;
+        ++_analysisRevision;
+        IsBusy = true; Error = "";
+        try
+        {
+            var run = knownRun is { } saved && saved.Id == selected.Id ? saved : _reviewRuns.TryGetValue(selected.Id, out var review) ? review : await StoreOperationAsync(() => _service.Store.LoadAsync(selected.Id));
+            if (revision != _selectionRevision || _disposed) return;
+            _runA = run; _runB = null; _matchedA = _matchedB = _interval = null; _sameSpeed = false; _offsetA = _offsetB = 0;
+            Findings.Clear(); Metrics.Clear(); Charts.Clear(); AlternativeCharts.Clear();
+            Name = run.Name; Tune = run.Tune; Notes = run.Notes;
+            SelectionStart = SelectionEnd = double.NaN; OnChanged(nameof(SameSpeed));
+            ComparisonChoice = Library.FirstOrDefault(item => item.Id != run.Id);
+            ResetView(); NotifyRun(); await AnalyzeAsync();
+            if (revision == _selectionRevision) { ShowSummary(); ReportOpened?.Invoke(this, EventArgs.Empty); }
+        }
+        catch (Exception error) when (error is not OutOfMemoryException)
+        {
+            if (revision == _selectionRevision)
+            {
+                _selectedRun = Library.FirstOrDefault(item => item.Id == _runA?.Id);
+                OnChanged(nameof(SelectedRun));
+                Fail("This run could not be opened. The file may be incomplete or unavailable.");
+            }
+        }
+        finally { if (revision == _selectionRevision) IsBusy = false; }
+    }
+    public async Task SaveDetailsAsync()
+    {
+        if (_runA is null || !CanManageRun) return;
+        if (string.IsNullOrWhiteSpace(Name)) { Fail("Give this run a name before saving."); return; }
+        var id = _runA.Id;
+        IsBusy = true;
+        try
+        {
+            var updated = await StoreOperationAsync(() => _service.Store.UpdateMetadataAsync(id, Name.Trim(), Tune.Trim(), Notes.Trim()));
+            if (_runA?.Id == id) { _runA = _runA with { Name = updated.Name, Tune = updated.Tune, Notes = updated.Notes }; NotifyRun(); }
+            await LoadLibraryAsync(); Status = "Run details saved."; Error = "";
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("Details could not be saved. Keep this page open and try again."); }
+        finally { IsBusy = false; }
+    }
+    private async Task CompareChosenAsync()
+    {
+        if (_runA is null || !CanManageRun || ComparisonChoice is null || ComparisonChoice.Id == _runA.Id) return;
+        var id = _runA.Id;
+        IsBusy = true;
+        try
+        {
+            var selected = ComparisonChoice;
+            var run = _reviewRuns.TryGetValue(selected.Id, out var review) ? review : await StoreOperationAsync(() => _service.Store.LoadAsync(selected.Id));
+            if (_runA?.Id != id) return;
+            _runB = run; Findings.Clear(); Metrics.Clear(); Charts.Clear(); ResetView(); NotifyRun(); await AnalyzeAsync();
+            ShowSummary(); ReportOpened?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("The comparison run could not be opened. Choose another run or try again."); }
+        finally { if (_runA?.Id == id) IsBusy = false; }
+    }
+    private Task ComparePreviousAsync()
+    {
+        if (!CanManageRun || PreviousRun() is not { } previous) return Task.CompletedTask;
+        ComparisonChoice = previous;
+        return CompareChosenAsync();
+    }
+    private SavedRunItem? PreviousRun() => Library.FirstOrDefault(item => item.Id != _runA?.Id && item.Summary.StartedAtUtc < _runA?.StartedAtUtc);
+    private void RequestAnalysis() { if (_runA is not null && !_disposed) _ = AnalyzeAsync(); }
+    private async Task AnalyzeAsync()
+    {
+        if (_runA is null || _disposed) return;
+        var revision = ++_analysisRevision;
+        if (RecordingActive)
+        { _pendingAnalysis = true; IsBusy = false; Status = "Stop recording to prepare the changed report. Recording is still running."; return; }
+        var a = _runA; var b = _runB; var purpose = Purpose; var interval = _interval;
+        bool sameSpeed = SameSpeed && b is not null;
+        if (!double.TryParse(FromSpeed, out var from) || !double.TryParse(ToSpeed, out var to) || !double.IsFinite(from) || !double.IsFinite(to) || from < 0 || to <= from)
+        { if (sameSpeed) { IsBusy = false; Fail("Choose a speed range, with the ending speed above the starting speed."); return; } from = 20; to = 60; }
+        from /= RunPresentation.SpeedFactor(_settings.SpeedUnit); to /= RunPresentation.SpeedFactor(_settings.SpeedUnit);
+        IsBusy = true; Status = "Preparing the report…";
+        try
+        {
+            var result = await Task.Run(() =>
+            {
+                if (revision != Volatile.Read(ref _analysisRevision)) throw new OperationCanceledException();
+                RunSpeedRange? accelerationA = sameSpeed ? RunAnalysis.MeasureAcceleration(a, from, to) : null;
+                RunSpeedRange? accelerationB = sameSpeed && b is not null ? RunAnalysis.MeasureAcceleration(b, from, to) : null;
+                bool matched = accelerationA is not null && accelerationB is not null;
+                RunInterval? rangeA = matched ? accelerationA!.Interval : null;
+                RunInterval? rangeB = matched ? accelerationB!.Interval : null;
+                if (revision != Volatile.Read(ref _analysisRevision)) throw new OperationCanceledException();
+                RunInterval? SelectRange(RunInterval? range) => interval is { } selected ? range is { } matchedRange
+                    ? new(Math.Min(matchedRange.EndSeconds, matchedRange.StartSeconds + selected.StartSeconds),
+                        Math.Min(matchedRange.EndSeconds, matchedRange.StartSeconds + selected.EndSeconds)) : selected : range;
+                var selectedA = SelectRange(rangeA); var selectedB = SelectRange(rangeB);
+                var comparisonPurpose = matched && interval is not null && purpose == RunPurpose.Acceleration ? RunPurpose.General : purpose;
+                var comparison = b is null ? null : RunAnalysis.Compare(a, b, comparisonPurpose, selectedA, selectedB, from, to);
+                var report = comparison?.RunA ?? RunAnalysis.BuildReport(a, purpose, selectedA);
+                return (Report: report, Comparison: comparison, RangeA: rangeA, RangeB: rangeB, AccelerationA: accelerationA, AccelerationB: accelerationB);
+            });
+            if (revision != _analysisRevision || _disposed) return;
+            _reportA = result.Report; _reportB = result.Comparison?.RunB;
+            var changedAlignment = _matchedA != result.RangeA || _matchedB != result.RangeB;
+            _matchedA = result.RangeA; _matchedB = result.RangeB;
+            _offsetA = _matchedA?.StartSeconds ?? 0; _offsetB = _matchedB?.StartSeconds ?? 0;
+            ComparisonNote = "";
+            if (sameSpeed && result is { RangeA: not null, RangeB: not null, AccelerationA: { } accelerationA, AccelerationB: { } accelerationB })
+            {
+                ComparisonNote = $"{FromSpeed}–{ToSpeed} {SpeedUnitText}: A {accelerationA.DurationSeconds:0.00}s · B {accelerationB.DurationSeconds:0.00}s. Each chart starts at its own crossing and ends at the target speed. Times are estimates from telemetry; routes and conditions may differ.";
+            }
+            else if (sameSpeed)
+            { _sameSpeed = false; OnChanged(nameof(SameSpeed)); ComparisonNote = "That range is unavailable in one or both runs. Matching is off; the report and charts use elapsed time. Choose a different range to try again."; }
+            if (b is not null && !sameSpeed) ComparisonNote = "Compare selected sections; routes and starting conditions may differ. Acceleration times are estimates from telemetry.";
+            if (changedAlignment) ResetView();
+            QualityNote = result.Report.QualityNote + (result.Comparison is null || result.Comparison.RunB.QualityNote == result.Report.QualityNote ? "" : "  B: " + result.Comparison.RunB.QualityNote);
+            Metrics.Clear(); foreach (var metric in RunPresentation.Metrics(_reportA, _reportB, _settings.SpeedUnit, _settings.TorqueUnit)) Metrics.Add(metric);
+            Findings.Clear();
+            var findings = result.Comparison?.Findings ?? result.Report.Findings;
+            _imageFindings = findings.Take(3).ToArray();
+            foreach (var finding in findings.Take(3))
+            {
+                var captured = finding;
+                Findings.Add(new(finding.Title, finding.Detail, new RunUiCommand(() =>
+                {
+                    if (captured.Interval is { } range)
+                    {
+                        ChartGroup = captured.EvidenceView switch { RunEvidenceView.Inputs => RunChartGroup.Inputs, RunEvidenceView.Tires => RunChartGroup.Tires, _ => RunChartGroup.Speed };
+                        GraphView = AvailableGraphViews[0];
+                        SelectInterval(range.StartSeconds - _offsetA, range.EndSeconds - _offsetA);
+                        if (HasSelection) { ViewStart = SelectionStart; ViewEnd = SelectionEnd; FocusChartsRequested?.Invoke(this, EventArgs.Empty); }
+                    }
+                    return Task.CompletedTask;
+                }, () => !IsBusy && !RecordingActive, () => Fail("That section could not be selected.")), finding.Interval is not null));
+            }
+            Status = "Report ready."; Error = ""; NotifyRun(); await BuildChartsAsync(revision);
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { if (revision == _analysisRevision) Fail("The report could not be prepared. Select the run again to retry."); }
+        finally { if (revision == _analysisRevision) IsBusy = false; }
+    }
+    private void RequestCharts() { if (_pageVisible && _runA is not null && !_disposed) _ = BuildChartsAsync(_analysisRevision); }
+    private async Task BuildChartsAsync(long revision)
+    {
+        if (!_pageVisible || _runA is null) return;
+        if (RecordingActive) { _pendingAnalysis = true; Status = "The changed charts will be prepared after recording is saved or canceled."; return; }
+        var chartRevision = ++_chartRevision;
+        _preparingCharts = true; OnChanged(nameof(IsPreparingCharts)); OnChanged(nameof(CanExportImage));
+        var a = _runA; var b = _runB; var group = ChartGroup;
+        var mode = GraphView.Mode; var fullThrottle = FullThrottleOnly; var gear = GearFilter.Gear;
+        var speed = _settings.SpeedUnit; var temperature = _settings.TireTemperatureUnit;
+        var torque = _settings.TorqueUnit; var boost = _settings.BoostPressureUnit;
+        var offsetA = _offsetA; var offsetB = _offsetB;
+        var boundsA = _matchedA; var boundsB = _matchedB;
+        var alternativeBoundsA = ReportBounds(false); var alternativeBoundsB = ReportBounds(true);
+        try
+        {
+            var prepared = await Task.Run(() =>
+            {
+                if (chartRevision != Volatile.Read(ref _chartRevision) || revision != Volatile.Read(ref _analysisRevision)) throw new OperationCanceledException();
+                return mode == RunPlotMode.TimeSeries
+                    ? (Time: RunPresentation.Charts(a, b, group, speed, temperature, offsetA, offsetB, boundsA, boundsB, torque, boost), Alternative: Array.Empty<RunAlternativePlotPanel>())
+                    : (Time: Array.Empty<RunPlotPanel>(), Alternative: RunAlternativePlots.Build(a, b, mode, temperature, torque, alternativeBoundsA, alternativeBoundsB, fullThrottle, gear));
+            });
+            if (chartRevision != _chartRevision || revision != _analysisRevision || !_pageVisible || _disposed || RecordingActive || group != ChartGroup || !ReferenceEquals(a, _runA) || !ReferenceEquals(b, _runB)) return;
+            Charts.Clear(); foreach (var panel in prepared.Time) Charts.Add(panel);
+            AlternativeCharts.Clear(); foreach (var panel in prepared.Alternative) AlternativeCharts.Add(panel);
+            RefreshMarkers();
+        }
+        catch (Exception error) when (error is not OutOfMemoryException)
+        { if (chartRevision == _chartRevision && revision == _analysisRevision && !_disposed) Fail("The chart could not be prepared. Choose the chart view again to retry."); }
+        finally { if (chartRevision == _chartRevision) { _preparingCharts = false; OnChanged(nameof(IsPreparingCharts)); OnChanged(nameof(CanExportImage)); } }
+    }
+    public void SelectInterval(double from, double to)
+    {
+        if (RecordingActive || _runA is null || !double.IsFinite(from) || !double.IsFinite(to)) return;
+        var end = _matchedA is { } a && _matchedB is { } b ? Math.Min(a.EndSeconds - a.StartSeconds, b.EndSeconds - b.StartSeconds)
+            : Math.Max(0, (_runA.Samples.LastOrDefault()?.ElapsedSeconds ?? 0) - _offsetA);
+        from = Math.Clamp(from, 0, end); to = Math.Clamp(to, 0, end);
+        if (to <= from) { Fail("The selection must end after it starts."); return; }
+        SelectionStart = from; SelectionEnd = to; SelectionFrom = from.ToString("0.00", CultureInfo.CurrentCulture); SelectionTo = to.ToString("0.00", CultureInfo.CurrentCulture);
+        _interval = new(from, to); RequestAnalysis();
+    }
+    private void ApplyTypedInterval()
+    {
+        if (double.TryParse(SelectionFrom, out var from) && double.TryParse(SelectionTo, out var to)) SelectInterval(from, to);
+        else Fail("Enter the start and end as seconds, for example 12.5 and 18.");
+    }
+    private void ResetView()
+    {
+        ViewStart = 0;
+        ViewEnd = Math.Max(1, Math.Max((_matchedA?.EndSeconds ?? _runA?.Samples.LastOrDefault()?.ElapsedSeconds ?? 0) - _offsetA,
+            (_matchedB?.EndSeconds ?? _runB?.Samples.LastOrDefault()?.ElapsedSeconds ?? 0) - _offsetB));
+        CursorSeconds = ViewStart;
+    }
+    public async Task DeleteSelectedAsync()
+    {
+        if (_runA is null || !CanManageRun) return;
+        var id = _runA.Id;
+        IsBusy = true;
+        try
+        {
+            await StoreOperationAsync(() => _service.Store.DeleteAsync(id)); ++_analysisRevision; ++_selectionRevision; _runA = _runB = null; _selectedRun = null;
+            Findings.Clear(); Metrics.Clear(); Charts.Clear(); AlternativeCharts.Clear(); NotifyRun(); OnChanged(nameof(SelectedRun));
+            await LoadLibraryAsync(); Status = "Run removed. You can undo this removal."; LastDeletedId = id; OnChanged(nameof(CanUndoDelete));
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("The run could not be removed. Try again."); }
+        finally { IsBusy = false; }
+    }
+    private Guid? LastDeletedId { get; set; }
+    public bool CanUndoDelete => LastDeletedId is not null;
+    public async Task UndoDeleteAsync()
+    {
+        if (LastDeletedId is not Guid id || !CanManageLibrary) return;
+        IsBusy = true;
+        try { await StoreOperationAsync(() => _service.Store.RestoreAsync(id)); LastDeletedId = null; OnChanged(nameof(CanUndoDelete)); await LoadLibraryAsync(); Status = "Run restored."; }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("The run could not be restored. Its recovery copy has been kept."); }
+        finally { IsBusy = false; }
+    }
+    public async Task ExportSelectedAsync(string destination)
+    {
+        if (_runA is null || !CanManageRun) return;
+        IsBusy = true;
+        try
+        {
+            var run = _runA;
+            await StoreOperationAsync(() => System.IO.Path.GetExtension(destination).Equals(".csv", StringComparison.OrdinalIgnoreCase)
+                ? RunCsvExporter.WriteAsync(run, destination) : _service.Store.ExportAsync(run.Id, destination));
+            Status = "Run exported. Nothing was uploaded.";
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("Export failed. Choose a new filename and try again."); }
+        finally { IsBusy = false; }
+    }
+    public async Task ImportAsync(string source)
+    {
+        if (!CanManageLibrary) return;
+        IsBusy = true;
+        try
+        {
+            var summary = await StoreOperationAsync(() => _service.Store.ImportAsync(source)); await LoadLibraryAsync();
+            if (Library.FirstOrDefault(item => item.Id == summary.Id) is { } imported)
+            { _selectedRun = imported; OnChanged(nameof(SelectedRun)); await LoadSelectionAsync(imported); }
+            Status = "Run imported.";
+        }
+        catch (Exception error) when (error is not OutOfMemoryException) { Fail("This file could not be imported. Choose a complete Wisp run file."); }
+        finally { IsBusy = false; }
+    }
+    internal async Task ShowReviewAsync(RecordedRun a, RecordedRun? b = null, RunPurpose purpose = RunPurpose.General)
+    {
+        _reviewRuns.Clear(); _sameSpeed = false; _matchedA = _matchedB = _interval = null; _offsetA = _offsetB = 0;
+        SelectionStart = SelectionEnd = double.NaN; OnChanged(nameof(SameSpeed));
+        _reviewRuns[a.Id] = a; if (b is not null) _reviewRuns[b.Id] = b;
+        Library.Clear(); Library.Add(new(Summary(a))); if (b is not null) Library.Add(new(Summary(b)));
+        _selectedRun = Library[0]; _runA = a; _runB = b; _settings.RunPurpose = purpose;
+        _pageVisible = true; Name = a.Name; Tune = a.Tune; Notes = a.Notes;
+        ResetView(); NotifyRun(); OnChanged(nameof(Purpose)); OnChanged(nameof(SelectedRun)); OnChanged(nameof(IsLibraryEmpty)); await AnalyzeAsync();
+        ShowSummary(); ReportOpened?.Invoke(this, EventArgs.Empty);
+    }
+    private static RunSummary Summary(RecordedRun run) => new(run.Id, run.Name, run.Tune, run.Notes, run.StartedAtUtc,
+        run.Samples.LastOrDefault()?.ElapsedSeconds ?? 0, run.Samples.Length, run.Samples.FirstOrDefault()?.State.CarOrdinal ?? 0, run.IsIncomplete, run.FinishReason);
+    private void NotifyRun()
+    {
+        if (!HasRun) ShowSummary();
+        NotifyNavigation();
+        SelectedPointContext = "";
+        foreach (var property in new[] { nameof(HasRun), nameof(HasComparison), nameof(CanManageRun), nameof(RunALabel), nameof(RunBLabel), nameof(RunDescription), nameof(CarIdentifier), nameof(IntervalLabel), nameof(CursorVehicleContext) }) OnChanged(property);
+        RefreshMarkers();
+        RaiseCommands();
+    }
+    private void Fail(string message) { Error = message; Status = "Needs attention"; }
+    private async Task<T> StoreOperationAsync<T>(Func<Task<T>> operation)
+    {
+        _storageOperations++; NotifyStorage();
+        try { return await operation(); }
+        finally { _storageOperations--; NotifyStorage(); }
+    }
+    private Task StoreOperationAsync(Func<Task> operation) => StoreOperationAsync(async () => { await operation(); return true; });
+    private void NotifyStorage()
+    {
+        OnChanged(nameof(CanToggleRecording)); OnChanged(nameof(RecordingStatus)); OnChanged(nameof(CanManageRun)); OnChanged(nameof(CanManageLibrary)); OnChanged(nameof(CanExportImage)); RaiseCommands();
+    }
+    private void OnUi(Action action) { if (_disposed || _dispatcher.HasShutdownStarted) return; if (_dispatcher.CheckAccess()) action(); else _ = _dispatcher.BeginInvoke(action); }
+    private RunUiCommand Command(Func<Task> execute, Func<bool>? canExecute = null)
+    {
+        var command = new RunUiCommand(execute, canExecute ?? (() => true), () => Fail("The action could not finish. Try again."));
+        _commands.Add(command); return command;
+    }
+    private void RaiseCommands()
+    {
+        foreach (var command in _commands) command.RaiseCanExecuteChanged();
+        foreach (var finding in Findings) if (finding.ShowCommand is RunUiCommand command) command.RaiseCanExecuteChanged();
+        foreach (var marker in Markers) if (marker.JumpCommand is RunUiCommand command) command.RaiseCanExecuteChanged();
+    }
+    private bool Set<T>(ref T field, T value, [CallerMemberName] string? property = null)
+    { if (EqualityComparer<T>.Default.Equals(field, value)) return false; field = value; OnChanged(property); return true; }
+    private void OnChanged([CallerMemberName] string? property = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+    public void Dispose() { CancelCountdown(); ShortcutCaptureActive = false; _pendingSavedRun = null; _disposed = true; _analysisRevision++; _chartRevision++; _selectionRevision++; _service.StateChanged -= ServiceStateChanged; _service.RunSaved -= ServiceRunSaved; }
+}
+
+internal sealed class RunUiCommand(Func<Task> execute, Func<bool> canExecute, Action failed) : ICommand
+{
+    private bool _running;
+    public event EventHandler? CanExecuteChanged;
+    public bool CanExecute(object? parameter) => !_running && canExecute();
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter)) return;
+        _running = true; RaiseCanExecuteChanged();
+        try { await execute(); }
+        catch (Exception error) when (error is not OutOfMemoryException) { failed(); }
+        finally { _running = false; RaiseCanExecuteChanged(); }
+    }
+    internal void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.1.4</Version>
-    <FileVersion>1.1.4.0</FileVersion>
-    <AssemblyVersion>1.1.4.0</AssemblyVersion>
+    <Version>1.2.0</Version>
+    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.1.4.0" name="Wisp.App" />
+  <assemblyIdentity version="1.2.0.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.Core/Runs/RunAnalysis.cs
+++ b/src/Wisp.Core/Runs/RunAnalysis.cs
@@ -1,0 +1,485 @@
+using System.Globalization;
+
+namespace Wisp.Core.Runs;
+
+public static class RunAnalysis
+{
+    public const double MaximumContinuousGapSeconds = 0.25;
+    public const byte FullThrottleMinimum = 250;
+    public const byte BrakingMinimum = 13;
+    private const double Epsilon = 1e-7;
+    private const double Gravity = 9.80665;
+
+    public static bool AreContinuous(RunSample previous, RunSample current)
+    {
+        if (!Valid(previous) || !Valid(current)) return false;
+        var elapsed = current.ElapsedSeconds - previous.ElapsedSeconds;
+        var gameElapsed = unchecked(current.State.GameTimestampMilliseconds - previous.State.GameTimestampMilliseconds);
+        return elapsed > Epsilon && elapsed <= MaximumContinuousGapSeconds + Epsilon && gameElapsed > 0 && gameElapsed <= 250 &&
+            Math.Abs(elapsed - gameElapsed / 1000d) <= 0.001 + Epsilon &&
+            current.Segment == previous.Segment && current.State.CarOrdinal == previous.State.CarOrdinal &&
+            current.State.Drivetrain == previous.State.Drivetrain;
+    }
+
+    public static RunReport BuildReport(RecordedRun run, RunPurpose purpose = RunPurpose.General, RunInterval? interval = null)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        var selection = Select(run, interval);
+        var statistics = Calculate(selection);
+        var findings = new List<RunFinding>();
+        if (statistics.RecordedSeconds <= Epsilon)
+        {
+            findings.Add(new("There is not enough continuous driving data", "Record a longer section with live telemetry to measure changes over time."));
+        }
+        else
+        {
+            if (purpose == RunPurpose.Acceleration)
+            {
+                var excess = LongestStretch(selection, WheelSpeedAhead, 0.5);
+                if (excess is { } evidence)
+                    findings.Add(new("Wheel speed ran ahead of car speed", $"For {Seconds(Length(evidence))}, driven-wheel speed stayed above car speed with high throttle and little steering.", evidence));
+            }
+            if (purpose == RunPurpose.Drifting && FindSpeedDrop(selection) is { } drop)
+                findings.Add(new("Car speed fell as throttle decreased", "Car speed and throttle both fell in this section. Inspect the input chart alongside speed.", drop, RunEvidenceView.Inputs));
+
+            var throttle = LongestStretch(selection,
+                static s => s.A.State.Accelerator >= FullThrottleMinimum && s.B.State.Accelerator >= FullThrottleMinimum, 1);
+            if (throttle is { } full)
+                findings.Add(new("Longest full-throttle stretch", $"Full throttle totaled {Seconds(statistics.FullThrottleSeconds)} in this selection. The longest uninterrupted stretch lasted {Seconds(Length(full))}.", full, RunEvidenceView.Inputs));
+
+            if (statistics.StartingRearTemperatureFahrenheit is { } start && statistics.EndingRearTemperatureFahrenheit is { } end && Math.Abs(end - start) >= 5)
+                findings.Add(new(end > start ? "Rear tires ended warmer" : "Rear tires ended cooler",
+                    "Rear tire temperatures changed between the first and last readings in this selection.", selection.Interval, RunEvidenceView.Tires));
+
+            var braking = LongestStretch(selection,
+                static s => s.A.State.Brake >= BrakingMinimum && s.B.State.Brake >= BrakingMinimum, 0.5);
+            if (braking is { } brake)
+                findings.Add(new("Longest braking stretch", $"Brake input stayed above a light press for {Seconds(Length(brake))}.", brake, RunEvidenceView.Inputs));
+
+            if (findings.Count == 0)
+                findings.Add(new("Your run is ready to review", "The charts show recorded car speed and driver inputs. Select a section or compare another run to inspect a specific maneuver.", selection.Interval));
+        }
+        return new(selection.Interval, statistics, findings.Take(3).ToArray(), Quality(run, selection, statistics));
+    }
+
+    public static RunComparison Compare(RecordedRun a, RecordedRun b, RunPurpose purpose = RunPurpose.General,
+        RunInterval? intervalA = null, RunInterval? intervalB = null,
+        double speedFromMetersPerSecond = 8.9408, double speedToMetersPerSecond = 26.8224)
+    {
+        ArgumentNullException.ThrowIfNull(a);
+        ArgumentNullException.ThrowIfNull(b);
+        ValidateSpeeds(speedFromMetersPerSecond, speedToMetersPerSecond);
+        var reportA = BuildReport(a, purpose, intervalA);
+        var reportB = BuildReport(b, purpose, intervalB);
+        var selectionA = Select(a, intervalA);
+        var selectionB = Select(b, intervalB);
+        var accelerationA = Measure(selectionA, speedFromMetersPerSecond, speedToMetersPerSecond);
+        var accelerationB = Measure(selectionB, speedFromMetersPerSecond, speedToMetersPerSecond);
+        var findings = new List<RunFinding>();
+        var conditions = Conditions(a, b, selectionA, selectionB, reportA.Statistics, reportB.Statistics);
+        if (conditions.Count > 0)
+            findings.Add(new("Check the starting conditions", string.Join(" ", conditions)));
+
+        if (purpose == RunPurpose.Acceleration)
+        {
+            if (accelerationA is not null && accelerationB is not null)
+            {
+                var difference = accelerationB.DurationSeconds - accelerationA.DurationSeconds;
+                findings.Add(new(Math.Abs(difference) < 0.01 ? "Speed-range times were close" : difference < 0 ? "Run B crossed the speed range sooner" : "Run A crossed the speed range sooner",
+                    $"The quickest complete pass through the same speed range took {Seconds(accelerationA.DurationSeconds)} in Run A and {Seconds(accelerationB.DurationSeconds)} in Run B."));
+            }
+            else
+            {
+                var missing = accelerationA is null && accelerationB is null ? "Both Run A and Run B need" : accelerationA is null ? "Run A needs" : "Run B needs";
+                findings.Add(new("A matching acceleration interval is missing", $"{missing} a complete crossing of the selected speed range in forward gear, without a telemetry gap. Adjust the sections or the speed range."));
+            }
+        }
+
+        RunFinding? wheelFinding = null;
+        if (SameCalibration(selectionA, selectionB) &&
+            reportA.Statistics.AverageWheelSpeedExcessMetersPerSecond is { } excessA &&
+            reportB.Statistics.AverageWheelSpeedExcessMetersPerSecond is { } excessB && Math.Abs(excessA - excessB) >= 0.5)
+            wheelFinding = new(excessB < excessA ? "Run B had less wheel-speed excess" : "Run A had less wheel-speed excess",
+                "Driven-wheel speed ran closer to car speed over the calibrated portions of this selection.");
+        if (purpose == RunPurpose.Acceleration && wheelFinding is not null)
+            findings.Add(wheelFinding);
+
+        if (reportA.Statistics.AverageSpeedMetersPerSecond is { } averageA && reportB.Statistics.AverageSpeedMetersPerSecond is { } averageB)
+        {
+            var difference = averageB - averageA;
+            findings.Add(new(Math.Abs(difference) < 0.2 ? "Average car speed was similar" : difference > 0 ? "Run B carried more car speed on average" : "Run A carried more car speed on average",
+                "Averages use each selected section and exclude missing data."));
+        }
+        else
+            findings.Add(new("There is not enough data to compare car speed", "At least one selection has no continuous driving interval. Missing readings are excluded rather than treated as stopped driving."));
+
+        if (purpose != RunPurpose.Acceleration && wheelFinding is not null)
+            findings.Add(wheelFinding);
+
+        return new(reportA, reportB, findings.Take(3).ToArray(), accelerationA, accelerationB);
+    }
+
+    /// <summary>Returns the quickest complete crossing wholly contained in a continuous forward-driving interval.</summary>
+    public static RunSpeedRange? MeasureAcceleration(RecordedRun run, double fromMps, double toMps, RunInterval? interval = null)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        ValidateSpeeds(fromMps, toMps);
+        return Measure(Select(run, interval), fromMps, toMps);
+    }
+
+    private static RunSpeedRange? Measure(Selection selection, double from, double to)
+    {
+        RunSpeedRange? best = null;
+        double? started = null;
+        Span? previous = null;
+        foreach (var span in selection.Spans)
+        {
+            if (previous is null || !Continues(previous, span) || !Forward(span.A) || !Forward(span.B))
+                started = null;
+            previous = span;
+            if (!Forward(span.A) || !Forward(span.B))
+                continue;
+            var speedA = span.Speed(span.Start);
+            var speedB = span.Speed(span.End);
+            if (speedA > to)
+                started = null;
+            if (speedA < from - Epsilon)
+                started = null;
+            if (started is null && speedA <= from + Epsilon && speedB > from && speedB > speedA)
+                started = Cross(span, from, speedA, speedB);
+            if (started is { } start && speedA <= to && speedB >= to && speedB > speedA)
+            {
+                var end = Cross(span, to, speedA, speedB);
+                var candidate = new RunSpeedRange(from, to, end - start, new(start, end));
+                if (candidate.DurationSeconds > Epsilon && (best is null || candidate.DurationSeconds < best.DurationSeconds))
+                    best = candidate;
+                started = null;
+            }
+            if (speedB < from - Epsilon)
+                started = null;
+        }
+        return best;
+    }
+
+    private static double Cross(Span span, double speed, double a, double b) => span.Start + (span.End - span.Start) * Math.Clamp((speed - a) / (b - a), 0, 1);
+
+    private static void ValidateSpeeds(double from, double to)
+    {
+        if (!double.IsFinite(from) || !double.IsFinite(to) || from < 0 || to <= from)
+            throw new ArgumentOutOfRangeException(nameof(from), "Use two finite, increasing nonnegative speeds.");
+    }
+
+    private static Selection Select(RecordedRun run, RunInterval? requested)
+    {
+        if (requested is { } range && (!double.IsFinite(range.StartSeconds) || !double.IsFinite(range.EndSeconds) || range.EndSeconds < range.StartSeconds))
+            throw new ArgumentOutOfRangeException(nameof(requested), "Use a finite interval with its end after its start.");
+        var source = run.Samples ?? [];
+        var times = source.Where(static s => s is not null && double.IsFinite(s.ElapsedSeconds) && s.ElapsedSeconds >= 0).Select(static s => s.ElapsedSeconds);
+        var first = times.DefaultIfEmpty(0).Min();
+        var last = times.DefaultIfEmpty(0).Max();
+        var interval = requested is { } chosen
+            ? new RunInterval(Math.Clamp(chosen.StartSeconds, first, last), Math.Clamp(chosen.EndSeconds, first, last))
+            : new RunInterval(first, last);
+        var result = new Selection(interval);
+        RunSample? previous = null;
+        double latestTime = double.NegativeInfinity;
+        foreach (var sample in source)
+        {
+            if (!Valid(sample))
+            {
+                previous = null;
+                continue;
+            }
+            if (sample.ElapsedSeconds < latestTime - Epsilon)
+            {
+                previous = null;
+                continue;
+            }
+            latestTime = sample.ElapsedSeconds;
+            if (!sample.State.IsElectric && float.IsFinite(sample.State.BoostPressurePsi) && sample.State.BoostPressurePsi > 0)
+                result.BoostedCars.Add(sample.State.CarOrdinal);
+            if (sample.ElapsedSeconds >= interval.StartSeconds && sample.ElapsedSeconds <= interval.EndSeconds)
+                result.Points.Add(sample);
+            if (previous is not null)
+            {
+                if (AreContinuous(previous, sample))
+                {
+                    var start = Math.Max(previous.ElapsedSeconds, interval.StartSeconds);
+                    var end = Math.Min(sample.ElapsedSeconds, interval.EndSeconds);
+                    if (end > start + Epsilon)
+                        result.Spans.Add(new(previous, sample, start, end));
+                }
+            }
+            previous = sample;
+        }
+        var cursor = interval.StartSeconds;
+        foreach (var span in result.Spans)
+        {
+            if (span.Start > cursor + Epsilon)
+                result.Gaps++;
+            cursor = Math.Max(cursor, span.End);
+        }
+        if (interval.EndSeconds > cursor + Epsilon)
+            result.Gaps++;
+        return result;
+    }
+
+    private static bool Valid(RunSample? sample) => sample is not null && sample.State is not null && sample.IsDriving && sample.State.IsRaceOn &&
+        double.IsFinite(sample.ElapsedSeconds) && sample.ElapsedSeconds >= 0 &&
+        float.IsFinite(sample.State.GroundSpeedMetersPerSecond) && sample.State.GroundSpeedMetersPerSecond >= 0;
+
+    private static RunStatistics Calculate(Selection selection)
+    {
+        double seconds = 0, distance = 0, throttle = 0, braking = 0, wheelSeconds = 0, wheelIntegral = 0;
+        double? peakSpeed = null, peakPower = null, peakTorque = null, peakBoost = null, peakLateral = null, peakLongitudinal = null;
+        double? startFront = null, startRear = null, endFront = null, endRear = null;
+        var firstTime = double.PositiveInfinity;
+        var lastTime = double.NegativeInfinity;
+
+        void Observe(double time, double speed, double? power, double? torque, double? boost, double? lateral, double? longitudinal, double? front, double? rear)
+        {
+            peakSpeed = Max(peakSpeed, speed);
+            peakPower = Max(peakPower, power);
+            peakTorque = Max(peakTorque, torque);
+            peakBoost = Max(peakBoost, boost);
+            peakLateral = Max(peakLateral, lateral is { } lat ? Math.Abs(lat) : null);
+            peakLongitudinal = Max(peakLongitudinal, longitudinal is { } longitudinalValue ? Math.Abs(longitudinalValue) : null);
+            if (time <= firstTime)
+            {
+                firstTime = time;
+                startFront = front;
+                startRear = rear;
+            }
+            if (time >= lastTime)
+            {
+                lastTime = time;
+                endFront = front;
+                endRear = rear;
+            }
+        }
+
+        double? BoostValue(RunSample sample) => Boost(sample, selection.BoostedCars);
+        void ObserveSpan(Span span, double time) => Observe(time, span.Speed(time), span.Value(Power, time), span.Value(Torque, time),
+            span.Value(BoostValue, time), span.Value(Lateral, time), span.Value(Longitudinal, time), span.Value(FrontTemperature, time), span.Value(RearTemperature, time));
+        foreach (var span in selection.Spans)
+        {
+            var dt = span.End - span.Start;
+            seconds += dt;
+            distance += (span.Speed(span.Start) + span.Speed(span.End)) * 0.5 * dt;
+            throttle += AboveDuration(span.Lerp(span.A.State.Accelerator, span.B.State.Accelerator, span.Start), span.Lerp(span.A.State.Accelerator, span.B.State.Accelerator, span.End), FullThrottleMinimum, dt);
+            braking += AboveDuration(span.Lerp(span.A.State.Brake, span.B.State.Brake, span.Start), span.Lerp(span.A.State.Brake, span.B.State.Brake, span.End), BrakingMinimum, dt);
+            if (HasSameCalibration(span.A, span.B) && Wheel(span.A) is { } wheelA && Wheel(span.B) is { } wheelB)
+            {
+                var excessA = span.Lerp(wheelA - span.A.State.GroundSpeedMetersPerSecond, wheelB - span.B.State.GroundSpeedMetersPerSecond, span.Start);
+                var excessB = span.Lerp(wheelA - span.A.State.GroundSpeedMetersPerSecond, wheelB - span.B.State.GroundSpeedMetersPerSecond, span.End);
+                wheelIntegral += PositiveIntegral(excessA, excessB, dt);
+                wheelSeconds += dt;
+            }
+            ObserveSpan(span, span.Start);
+            ObserveSpan(span, span.End);
+        }
+        foreach (var point in selection.Points)
+            Observe(point.ElapsedSeconds, point.State.GroundSpeedMetersPerSecond, Power(point), Torque(point), BoostValue(point), Lateral(point), Longitudinal(point), FrontTemperature(point), RearTemperature(point));
+        selection.WheelSeconds = wheelSeconds;
+        return new()
+        {
+            SampleCount = selection.Points.Count,
+            DurationSeconds = Length(selection.Interval),
+            RecordedSeconds = seconds,
+            GapCount = selection.Gaps,
+            AverageSpeedMetersPerSecond = seconds > Epsilon ? distance / seconds : null,
+            PeakSpeedMetersPerSecond = peakSpeed,
+            DistanceMeters = distance,
+            FullThrottleSeconds = throttle,
+            BrakingSeconds = braking,
+            PeakPowerWatts = peakPower,
+            PeakTorqueNm = peakTorque,
+            PeakBoostPsi = peakBoost,
+            PeakLateralG = peakLateral,
+            PeakLongitudinalG = peakLongitudinal,
+            StartingFrontTemperatureFahrenheit = startFront,
+            StartingRearTemperatureFahrenheit = startRear,
+            EndingFrontTemperatureFahrenheit = endFront,
+            EndingRearTemperatureFahrenheit = endRear,
+            AverageWheelSpeedExcessMetersPerSecond = wheelSeconds > Epsilon ? wheelIntegral / wheelSeconds : null
+        };
+    }
+
+    private static string Quality(RecordedRun run, Selection selection, RunStatistics statistics)
+    {
+        var notes = new List<string>();
+        if (run.IsIncomplete)
+            notes.Add("This recording ended before it was complete.");
+        if (run.DroppedDatagrams > 0)
+            notes.Add("Some samples were lost while recording.");
+        if (run.RejectedDatagrams > 0)
+            notes.Add("Some telemetry packets could not be read.");
+        if (statistics.GapCount > 0)
+            notes.Add("Sections without continuous driving data are excluded from time-based statistics.");
+        if (statistics.RecordedSeconds <= Epsilon)
+            notes.Add("There is not enough continuous data for averages or acceleration times.");
+        if (selection.WheelSeconds <= Epsilon && statistics.RecordedSeconds > Epsilon)
+            notes.Add("No continuous section has trusted, unchanged tire calibration and available wheel readings.");
+        else if (selection.WheelSeconds + Epsilon < statistics.RecordedSeconds)
+            notes.Add("Wheel-speed results cover only sections with trusted, unchanged tire calibration and available wheel readings.");
+        if (statistics.StartingFrontTemperatureFahrenheit is null || statistics.StartingRearTemperatureFahrenheit is null ||
+            statistics.EndingFrontTemperatureFahrenheit is null || statistics.EndingRearTemperatureFahrenheit is null)
+            notes.Add("Some starting or ending tire temperatures are unavailable.");
+        return notes.Count == 0 ? "Calculated from recorded telemetry; peak readings are instantaneous observations." : string.Join(" ", notes);
+    }
+
+    private static List<string> Conditions(RecordedRun a, RecordedRun b, Selection sa, Selection sb, RunStatistics sta, RunStatistics stb)
+    {
+        var notes = new List<string>();
+        var carsA = ContextPoints(sa).Select(static s => s.State.CarOrdinal).Distinct().ToArray();
+        var carsB = ContextPoints(sb).Select(static s => s.State.CarOrdinal).Distinct().ToArray();
+        if (carsA.Length != 1 || carsB.Length != 1 || carsA[0] != carsB[0])
+            notes.Add("The selections do not identify the same single car.");
+        if (!SameCalibration(sa, sb))
+            notes.Add("Wheel-speed calibration differs or is incomplete.");
+        if (sta.StartingRearTemperatureFahrenheit is { } rearA && stb.StartingRearTemperatureFahrenheit is { } rearB && Math.Abs(rearA - rearB) >= 5 ||
+            sta.StartingFrontTemperatureFahrenheit is { } frontA && stb.StartingFrontTemperatureFahrenheit is { } frontB && Math.Abs(frontA - frontB) >= 5)
+            notes.Add("The tires started at different temperatures.");
+        else if (sta.StartingRearTemperatureFahrenheit is null || stb.StartingRearTemperatureFahrenheit is null ||
+                 sta.StartingFrontTemperatureFahrenheit is null || stb.StartingFrontTemperatureFahrenheit is null)
+            notes.Add("Starting tire temperatures are not available for both runs.");
+        if (Math.Abs(sta.DurationSeconds - stb.DurationSeconds) > Math.Max(1, Math.Min(sta.DurationSeconds, stb.DurationSeconds) * 0.1))
+            notes.Add("The selected sections have different durations.");
+        if (a.IsIncomplete || b.IsIncomplete || a.DroppedDatagrams > 0 || b.DroppedDatagrams > 0 || a.RejectedDatagrams > 0 || b.RejectedDatagrams > 0 || sta.GapCount > 0 || stb.GapCount > 0)
+            notes.Add("At least one selection comes from an incomplete recording or has gaps.");
+        return notes;
+    }
+
+    private static bool SameCalibration(Selection a, Selection b)
+    {
+        var pointsA = ContextPoints(a);
+        var pointsB = ContextPoints(b);
+        var referenceA = pointsA.FirstOrDefault();
+        var referenceB = pointsB.FirstOrDefault();
+        return referenceA is not null && referenceB is not null && HasSameCalibration(referenceA, referenceB) &&
+               pointsA.All(p => Wheel(p) is not null && HasSameCalibration(referenceA, p)) &&
+               pointsB.All(p => Wheel(p) is not null && HasSameCalibration(referenceB, p));
+    }
+
+    private static IEnumerable<RunSample> ContextPoints(Selection selection) => selection.Points.Concat(selection.Spans.SelectMany(static s => new[] { s.A, s.B }));
+
+    private static bool WheelSpeedAhead(Span span)
+    {
+        return Forward(span.A) && Forward(span.B) && HasSameCalibration(span.A, span.B) &&
+            Ahead(span.A) && Ahead(span.B);
+
+        static bool Ahead(RunSample s) => Wheel(s) is { } wheel && s.State.Accelerator >= FullThrottleMinimum &&
+            Math.Abs((int)s.State.Steering) <= 8 && Math.Abs(s.State.LateralAccelerationMetersPerSecondSquared) <= 2 &&
+            s.State.GroundSpeedMetersPerSecond >= 1 && wheel - s.State.GroundSpeedMetersPerSecond >= Math.Max(3, s.State.GroundSpeedMetersPerSecond * 0.15);
+    }
+
+    private static RunInterval? LongestStretch(Selection selection, Func<Span, bool> predicate, double minimum)
+    {
+        RunInterval? best = null;
+        Span? previous = null;
+        double? start = null;
+        foreach (var span in selection.Spans)
+        {
+            if (previous is null || !Continues(previous, span) || !predicate(span))
+                start = null;
+            if (predicate(span))
+            {
+                start ??= span.Start;
+                var current = new RunInterval(start.Value, span.End);
+                if (Length(current) >= minimum && (best is null || Length(current) > Length(best.Value)))
+                    best = current;
+            }
+            previous = span;
+        }
+        return best;
+    }
+
+    private static RunInterval? FindSpeedDrop(Selection selection)
+    {
+        RunInterval? best = null;
+        double largestDrop = 2;
+        int window = 0, blockStart = 0;
+        for (var i = 0; i < selection.Spans.Count; i++)
+        {
+            var end = selection.Spans[i];
+            if (i == 0 || !Continues(selection.Spans[i - 1], end))
+                blockStart = window = i;
+            var startTime = end.End - 1;
+            if (startTime < selection.Spans[blockStart].Start)
+                continue;
+            while (window < i && selection.Spans[window].End < startTime)
+                window++;
+            var start = selection.Spans[window];
+            var drop = start.Speed(startTime) - end.Speed(end.End);
+            var throttleStart = start.Lerp(start.A.State.Accelerator, start.B.State.Accelerator, startTime);
+            var throttleEnd = end.Lerp(end.A.State.Accelerator, end.B.State.Accelerator, end.End);
+            if (drop > largestDrop && throttleStart >= 128 && throttleEnd <= 64)
+            {
+                largestDrop = drop;
+                best = new(startTime, end.End);
+            }
+        }
+        return best;
+    }
+
+    private static bool Continues(Span previous, Span next) => Math.Abs(previous.End - next.Start) <= Epsilon && previous.B.Segment == next.A.Segment && previous.B.State.CarOrdinal == next.A.State.CarOrdinal;
+    private static bool Forward(RunSample sample) => sample.State.Gear >= TransmissionGear.First && sample.State.Gear <= TransmissionGear.Tenth;
+    private static double Length(RunInterval interval) => Math.Max(0, interval.EndSeconds - interval.StartSeconds);
+    private static string Seconds(double value) => value.ToString("0.00", CultureInfo.InvariantCulture) + " seconds";
+    private static double? Finite(double value) => double.IsFinite(value) ? value : null;
+    private static double? Max(double? a, double? b) => b is null ? a : a is null ? b : Math.Max(a.Value, b.Value);
+    private static double? Power(RunSample p) => Finite(p.State.PowerWatts);
+    private static double? Torque(RunSample p) => Finite(p.State.TorqueNm);
+    private static double? Lateral(RunSample p) => Finite(p.State.LateralAccelerationMetersPerSecondSquared / Gravity);
+    private static double? Longitudinal(RunSample p) => Finite(p.State.LongitudinalAccelerationMetersPerSecondSquared / Gravity);
+    private static double? Boost(RunSample p, HashSet<int> boosted) => !p.State.IsElectric && boosted.Contains(p.State.CarOrdinal) ? Finite(p.State.BoostPressurePsi) : null;
+    private static double? FrontTemperature(RunSample p) => AxleTemperature(p.State.TireTemperatureFahrenheit.FrontLeft, p.State.TireTemperatureFahrenheit.FrontRight);
+    private static double? RearTemperature(RunSample p) => AxleTemperature(p.State.TireTemperatureFahrenheit.RearLeft, p.State.TireTemperatureFahrenheit.RearRight);
+    private static double? AxleTemperature(float a, float b) => float.IsFinite(a) && float.IsFinite(b) && a > 0 && b > 0 ? ((double)a + b) * 0.5 : null;
+
+    private static double? Wheel(RunSample p) => TrustedCalibration(p) && p.WheelSpeedMetersPerSecond is { } speed && double.IsFinite(speed) && speed >= 0 ? speed : null;
+    private static bool Radius(double? radius) => radius is { } value && double.IsFinite(value) && value > 0;
+    private static bool TrustedCalibration(RunSample p) => p.State.Drivetrain switch
+    {
+        DrivetrainType.FrontWheelDrive => Radius(p.FrontRadiusMeters),
+        DrivetrainType.RearWheelDrive => Radius(p.RearRadiusMeters),
+        DrivetrainType.AllWheelDrive => Radius(p.FrontRadiusMeters) && Radius(p.RearRadiusMeters),
+        _ => false
+    };
+    private static bool HasSameCalibration(RunSample a, RunSample b) => TrustedCalibration(a) && TrustedCalibration(b) && a.State.Drivetrain == b.State.Drivetrain &&
+        (a.State.Drivetrain == DrivetrainType.RearWheelDrive || Math.Abs(a.FrontRadiusMeters!.Value - b.FrontRadiusMeters!.Value) <= 1e-6) &&
+        (a.State.Drivetrain == DrivetrainType.FrontWheelDrive || Math.Abs(a.RearRadiusMeters!.Value - b.RearRadiusMeters!.Value) <= 1e-6);
+
+    private static double AboveDuration(double a, double b, double threshold, double dt)
+    {
+        if (a >= threshold && b >= threshold) return dt;
+        if (a < threshold && b < threshold) return 0;
+        var crossing = Math.Clamp((threshold - a) / (b - a), 0, 1);
+        return dt * (a >= threshold ? crossing : 1 - crossing);
+    }
+
+    private static double PositiveIntegral(double a, double b, double dt)
+    {
+        if (a >= 0 && b >= 0) return (a + b) * 0.5 * dt;
+        if (a <= 0 && b <= 0) return 0;
+        var positive = Math.Max(a, b);
+        return 0.5 * positive * positive / Math.Abs(b - a) * dt;
+    }
+
+    private sealed class Selection(RunInterval interval)
+    {
+        public RunInterval Interval { get; } = interval;
+        public List<RunSample> Points { get; } = [];
+        public List<Span> Spans { get; } = [];
+        public HashSet<int> BoostedCars { get; } = [];
+        public int Gaps { get; set; }
+        public double WheelSeconds { get; set; }
+    }
+
+    private sealed record Span(RunSample A, RunSample B, double Start, double End)
+    {
+        public double Lerp(double a, double b, double time) => a + (b - a) * Math.Clamp((time - A.ElapsedSeconds) / (B.ElapsedSeconds - A.ElapsedSeconds), 0, 1);
+        public double Speed(double time) => Lerp(A.State.GroundSpeedMetersPerSecond, B.State.GroundSpeedMetersPerSecond, time);
+        public double? Value(Func<RunSample, double?> selector, double time) => selector(A) is { } a && selector(B) is { } b ? Lerp(a, b, time) : null;
+    }
+}

--- a/src/Wisp.Core/Runs/RunModels.cs
+++ b/src/Wisp.Core/Runs/RunModels.cs
@@ -1,0 +1,64 @@
+namespace Wisp.Core.Runs;
+
+public enum RunPurpose { General, Acceleration, Drifting }
+public enum RunEvidenceView { Speed, Inputs, Tires }
+
+public sealed record RunSample
+{
+    public double ElapsedSeconds { get; init; }
+    public int Segment { get; init; }
+    public bool IsDriving { get; init; }
+    public required VehicleState State { get; init; }
+    public double? WheelSpeedMetersPerSecond { get; init; }
+    public double? FrontRadiusMeters { get; init; }
+    public double? RearRadiusMeters { get; init; }
+}
+
+public sealed record RecordedRun
+{
+    public const int CurrentSchemaVersion = 1;
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Name { get; init; } = "Untitled run";
+    public string Tune { get; init; } = string.Empty;
+    public string Notes { get; init; } = string.Empty;
+    public DateTimeOffset StartedAtUtc { get; init; }
+    public string FinishReason { get; init; } = string.Empty;
+    public bool IsIncomplete { get; init; }
+    public long RejectedDatagrams { get; init; }
+    public long DroppedDatagrams { get; init; }
+    public RunMarker[] Markers { get; init; } = [];
+    public RunSample[] Samples { get; init; } = [];
+}
+
+public sealed record RunMarker(double ElapsedSeconds, string Label);
+public readonly record struct RunInterval(double StartSeconds, double EndSeconds);
+public sealed record RunFinding(string Title, string Detail, RunInterval? Interval = null,
+    RunEvidenceView EvidenceView = RunEvidenceView.Speed);
+
+public sealed record RunStatistics
+{
+    public int SampleCount { get; init; }
+    public double DurationSeconds { get; init; }
+    public double RecordedSeconds { get; init; }
+    public int GapCount { get; init; }
+    public double? AverageSpeedMetersPerSecond { get; init; }
+    public double? PeakSpeedMetersPerSecond { get; init; }
+    public double DistanceMeters { get; init; }
+    public double FullThrottleSeconds { get; init; }
+    public double BrakingSeconds { get; init; }
+    public double? PeakPowerWatts { get; init; }
+    public double? PeakTorqueNm { get; init; }
+    public double? PeakBoostPsi { get; init; }
+    public double? PeakLateralG { get; init; }
+    public double? PeakLongitudinalG { get; init; }
+    public double? StartingFrontTemperatureFahrenheit { get; init; }
+    public double? StartingRearTemperatureFahrenheit { get; init; }
+    public double? EndingFrontTemperatureFahrenheit { get; init; }
+    public double? EndingRearTemperatureFahrenheit { get; init; }
+    public double? AverageWheelSpeedExcessMetersPerSecond { get; init; }
+}
+
+public sealed record RunReport(RunInterval Interval, RunStatistics Statistics, RunFinding[] Findings, string QualityNote);
+public sealed record RunSpeedRange(double FromMetersPerSecond, double ToMetersPerSecond, double DurationSeconds, RunInterval Interval);
+public sealed record RunComparison(RunReport RunA, RunReport RunB, RunFinding[] Findings, RunSpeedRange? AccelerationA, RunSpeedRange? AccelerationB);

--- a/src/Wisp.Telemetry/RunDatagramCapture.cs
+++ b/src/Wisp.Telemetry/RunDatagramCapture.cs
@@ -1,0 +1,77 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace Wisp.Telemetry;
+
+public readonly record struct RunDatagram(ReadOnlyMemory<byte> Bytes, long Timestamp, long Sequence);
+
+// The receiver only copies into preallocated slots. Parsing and storage belong to its single reader.
+public sealed class RunDatagramCapture
+{
+    private readonly Channel<byte[]> _available;
+    private readonly Channel<(byte[] Buffer, int Length, long Timestamp, long Sequence)> _pending;
+    private long _sequence;
+    private long _dropped;
+    private int _completed;
+
+    internal RunDatagramCapture(int capacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 2);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(capacity, 8192);
+        _available = Channel.CreateBounded<byte[]>(capacity);
+        _pending = Channel.CreateBounded<(byte[], int, long, long)>(new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = true,
+            AllowSynchronousContinuations = false
+        });
+        for (var index = 0; index < capacity; index++)
+            _available.Writer.TryWrite(new byte[Fh6PacketLayout.PacketLength]);
+    }
+
+    public long DroppedDatagrams => Interlocked.Read(ref _dropped);
+    public long ObservedDatagrams => Interlocked.Read(ref _sequence);
+    public string CompletionReason { get; private set; } = "Recording stopped";
+
+    internal void Capture(ReadOnlySpan<byte> bytes, long timestamp)
+    {
+        if (Volatile.Read(ref _completed) != 0) return;
+        var sequence = Interlocked.Increment(ref _sequence);
+        if (!_available.Reader.TryRead(out var buffer))
+        {
+            Interlocked.Increment(ref _dropped);
+            return;
+        }
+        var length = bytes.Length == Fh6PacketLayout.PacketLength ? bytes.Length : 0;
+        bytes[..length].CopyTo(buffer);
+        if (!_pending.Writer.TryWrite((buffer, length, timestamp, sequence)))
+        {
+            _available.Writer.TryWrite(buffer);
+            Interlocked.Increment(ref _dropped);
+        }
+    }
+
+    internal void Complete(string reason)
+    {
+        if (Interlocked.Exchange(ref _completed, 1) != 0) return;
+        CompletionReason = reason;
+        _pending.Writer.TryComplete();
+    }
+
+    public async IAsyncEnumerable<RunDatagram> ReadAllAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var packet in _pending.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            try
+            {
+                yield return new RunDatagram(packet.Buffer.AsMemory(0, packet.Length), packet.Timestamp, packet.Sequence);
+            }
+            finally
+            {
+                _available.Writer.TryWrite(packet.Buffer);
+            }
+        }
+    }
+}

--- a/src/Wisp.Telemetry/TelemetryUdpReceiver.cs
+++ b/src/Wisp.Telemetry/TelemetryUdpReceiver.cs
@@ -33,6 +33,7 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
     private int _lastParseError;
     private string? _listenerError;
     private int _disposed;
+    private RunDatagramCapture? _runCapture;
 
     public TelemetryUdpReceiver(Fh6PacketParser? parser = null)
     {
@@ -49,6 +50,21 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
     public long ReceivedDatagrams => Interlocked.Read(ref _receivedDatagrams);
     public long DrainedDatagrams => Interlocked.Read(ref _drainedDatagrams);
     public long LastDatagramTimestamp => Interlocked.Read(ref _lastDatagramTimestamp);
+
+    public RunDatagramCapture BeginRunCapture(int capacity = 4096)
+    {
+        ThrowIfDisposed();
+        var capture = new RunDatagramCapture(capacity);
+        if (Interlocked.CompareExchange(ref _runCapture, capture, null) is not null)
+            throw new InvalidOperationException("A run is already being recorded.");
+        return capture;
+    }
+
+    public void EndRunCapture(RunDatagramCapture capture, string reason = "Recording stopped")
+    {
+        if (Interlocked.CompareExchange(ref _runCapture, null, capture) == capture)
+            capture.Complete(reason);
+    }
 
     public bool IsRunning => Volatile.Read(ref _session)?.ReceiveTask is { IsCompleted: false };
 
@@ -273,6 +289,7 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
                     cancellationToken).ConfigureAwait(false);
 
                 RecordDatagram(drained: false);
+                CaptureRunDatagram(buffer.AsSpan(0, result.ReceivedBytes));
                 ObserveDatagram(buffer.AsSpan(0, result.ReceivedBytes), TelemetryPacketDiagnosticKind.Received);
 
                 var receivedBytes = DrainToNewestDatagram(
@@ -332,6 +349,7 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
                 SocketFlags.None,
                 ref remoteEndpoint);
             RecordDatagram(drained: true);
+            CaptureRunDatagram(buffer.AsSpan(0, receivedBytes));
             ObserveDatagram(buffer.AsSpan(0, receivedBytes), TelemetryPacketDiagnosticKind.Drained);
         }
 
@@ -346,6 +364,14 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
             Interlocked.Increment(ref _drainedDatagrams);
         }
         Interlocked.Exchange(ref _lastDatagramTimestamp, Stopwatch.GetTimestamp());
+    }
+
+    private void CaptureRunDatagram(ReadOnlySpan<byte> bytes)
+    {
+        var capture = Volatile.Read(ref _runCapture);
+        if (capture is null) return;
+        try { capture.Capture(bytes, LastDatagramTimestamp); }
+        catch { EndRunCapture(capture, "Recording capture stopped after an error"); }
     }
 
     private void ObserveDatagram(ReadOnlySpan<byte> bytes, TelemetryPacketDiagnosticKind kind)
@@ -401,6 +427,7 @@ public sealed class TelemetryUdpReceiver : IAsyncDisposable
 
     private void ResetSessionState()
     {
+        Interlocked.Exchange(ref _runCapture, null)?.Complete("Telemetry listener changed");
         Volatile.Write(ref _latest, null);
         lock (_statisticsGate)
         {

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.1.4</Version>
-    <FileVersion>1.1.4.0</FileVersion>
-    <AssemblyVersion>1.1.4.0</AssemblyVersion>
+    <Version>1.2.0</Version>
+    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -21,13 +21,12 @@ public sealed class ApplicationVersionInfoTests
     [Fact]
     public void CurrentVersionLabelsShareTheAssemblyVersion()
     {
-        Assert.Equal("1.1.4", ApplicationVersionInfo.MachineVersion);
-        Assert.Equal("1.1.4", ApplicationVersionInfo.DisplayVersion);
+        Assert.Equal("1.2.0", ApplicationVersionInfo.MachineVersion);
+        Assert.Equal("1.2", ApplicationVersionInfo.DisplayVersion);
         Assert.Null(ApplicationVersionInfo.DiagnosticBuildId);
         Assert.Null(ApplicationVersionInfo.DiagnosticBuildLabel);
-        Assert.EndsWith(" 1.1.4", ApplicationVersionInfo.FooterText);
-        Assert.DoesNotContain("private", ApplicationVersionInfo.FooterText);
-        Assert.Contains("current 1.1.4 entry", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.EndsWith("PANEL 1.2", ApplicationVersionInfo.FooterText);
+        Assert.Contains("The current 1.2 entry covers this release.", ApplicationVersionInfo.ReleaseHistoryIntroduction);
         Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
     }
 }

--- a/tests/Wisp.App.Tests/CalmSidebarTests.cs
+++ b/tests/Wisp.App.Tests/CalmSidebarTests.cs
@@ -15,7 +15,7 @@ public sealed class CalmSidebarTests
 {
     private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
     private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
-    private static readonly string[] PageNames = ["Dashboard", "Appearance", "Diagnostics", "Profiles", "Setup", "Extras", "Release Notes"];
+    private static readonly string[] PageNames = ["Dashboard", "Runs", "Appearance", "Diagnostics", "Profiles", "Setup", "Extras", "Release Notes"];
 
     [Fact]
     public void EverySidebarPageUsesTheSameUnbrokenRowSpacing()

--- a/tests/Wisp.App.Tests/InstallerPackagingContractTests.cs
+++ b/tests/Wisp.App.Tests/InstallerPackagingContractTests.cs
@@ -257,7 +257,7 @@ public sealed class InstallerPackagingContractTests
         Assert.Contains("$artifactVersion = $projectVersion", packaging, StringComparison.Ordinal);
         Assert.Contains("& $innoExecutable \"/O$stageDirectory\" $innoScript", packaging, StringComparison.Ordinal);
         Assert.Contains("Write-BuildProvenance $repository $publishFullPath", packaging, StringComparison.Ordinal);
-        Assert.Contains("#define MyAppVersion \"1.1.4\"", inno, StringComparison.Ordinal);
+        Assert.Contains("#define MyAppVersion \"1.2.0\"", inno, StringComparison.Ordinal);
         Assert.Contains("#define MyAppOutputVersion MyAppVersion", inno, StringComparison.Ordinal);
         Assert.Contains("UpdatingExistingInstallation := UpdateSwitchPresent() and ExistingInstallationPresent();", inno,
             StringComparison.Ordinal);

--- a/tests/Wisp.App.Tests/RecordingSettingsTests.cs
+++ b/tests/Wisp.App.Tests/RecordingSettingsTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using System.Windows.Input;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RecordingSettingsTests
+{
+    [Fact]
+    public void ExistingSettingsKeepTheirLayoutAndReceiveAnOptInShortcut()
+    {
+        var settings = JsonSerializer.Deserialize<AppSettings>(
+            "{\"SettingsRevision\":9,\"Smoothing\":0.4,\"OverlayOpacity\":0.8}")!;
+        settings.MigrateSettings();
+        Assert.Equal(9, settings.SettingsRevision);
+        Assert.Equal(0.4, settings.Smoothing);
+        Assert.Equal(0.8, settings.OverlayOpacity);
+        Assert.False(settings.RecordingShortcutEnabled);
+        Assert.Equal(Key.R, settings.RecordingShortcutKey);
+        Assert.Equal(RunPurpose.General, settings.RunPurpose);
+        Assert.Equal(0, settings.RecordingCountdownSeconds);
+        Assert.Equal(0, settings.RecordingStopAfterSeconds);
+        Assert.False(settings.MarkerShortcutEnabled);
+        Assert.Equal(Key.M, settings.MarkerShortcutKey);
+    }
+
+    [Fact]
+    public void InvalidPurposeAndShortcutNormalizeWithoutChangingOverlayShortcut()
+    {
+        var settings = new AppSettings
+        {
+            RunPurpose = (RunPurpose)999,
+            RecordingShortcutEnabled = true,
+            RecordingShortcutModifiers = OverlayHotkeyModifiers.None,
+            RecordingShortcutKey = Key.None,
+            RecordingCountdownSeconds = -1,
+            RecordingStopAfterSeconds = 601,
+            MarkerShortcutEnabled = true,
+            MarkerShortcutModifiers = OverlayHotkeyModifiers.None,
+            MarkerShortcutKey = Key.None,
+            OverlayHotkeyEnabled = true
+        };
+        settings.MigrateSettings();
+        Assert.Equal(RunPurpose.General, settings.RunPurpose);
+        Assert.False(settings.RecordingShortcutEnabled);
+        Assert.Equal(OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Shift, settings.RecordingShortcutModifiers);
+        Assert.Equal(Key.R, settings.RecordingShortcutKey);
+        Assert.Equal(0, settings.RecordingCountdownSeconds);
+        Assert.Equal(0, settings.RecordingStopAfterSeconds);
+        Assert.False(settings.MarkerShortcutEnabled);
+        Assert.Equal(Key.M, settings.MarkerShortcutKey);
+        Assert.True(settings.OverlayHotkeyEnabled);
+        Assert.Equal(Key.H, settings.OverlayHotkeyKey);
+    }
+
+    [Fact]
+    public void RecordingPreferencesRoundTripBesideExistingPreferences()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "Wisp-recording-settings", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var store = new SettingsService(Path.Combine(directory, "settings.json"));
+            store.Save(new AppSettings
+            {
+                RunPurpose = RunPurpose.Drifting,
+                RecordingShortcutEnabled = true,
+                RecordingShortcutModifiers = OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Alt,
+                RecordingShortcutKey = Key.F8,
+                RecordingCountdownSeconds = 5,
+                RecordingStopAfterSeconds = 120,
+                MarkerShortcutEnabled = true,
+                MarkerShortcutModifiers = OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Alt,
+                MarkerShortcutKey = Key.F9,
+                OverlayOpacity = 0.65
+            });
+            var settings = store.Load();
+            Assert.Equal(RunPurpose.Drifting, settings.RunPurpose);
+            Assert.True(settings.RecordingShortcutEnabled);
+            Assert.Equal(Key.F8, settings.RecordingShortcutKey);
+            Assert.Equal(OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Alt, settings.RecordingShortcutModifiers);
+            Assert.Equal(0.65, settings.OverlayOpacity);
+            Assert.Equal(5, settings.RecordingCountdownSeconds);
+            Assert.Equal(120, settings.RecordingStopAfterSeconds);
+            Assert.True(settings.MarkerShortcutEnabled);
+            Assert.Equal(Key.F9, settings.MarkerShortcutKey);
+            Assert.Equal(OverlayHotkeyModifiers.Control | OverlayHotkeyModifiers.Alt, settings.MarkerShortcutModifiers);
+            Assert.Equal(9, settings.SettingsRevision);
+        }
+        finally
+        {
+            if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.1.4", "1.1.3", "1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.2", "1.1.4", "1.1.3", "1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));

--- a/tests/Wisp.App.Tests/RunAlternativePlotsTests.cs
+++ b/tests/Wisp.App.Tests/RunAlternativePlotsTests.cs
@@ -1,0 +1,177 @@
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunAlternativePlotsTests
+{
+    private static RunSample Sample(double seconds, float rpm = 4000, byte throttle = 255, TransmissionGear gear = TransmissionGear.Third) =>
+        RunPresentationTests.Sample(seconds, rpm) with
+        {
+            State = RunPresentationTests.Sample(seconds, rpm).State with
+            { PowerWatts = 74569.9872f, TorqueNm = 500, Accelerator = throttle, Gear = gear }
+        };
+    private static RunAlternativePlotPanel[] Plot(RecordedRun a, RecordedRun? b = null, RunPlotMode mode = RunPlotMode.PowerByRpm,
+        bool fullThrottle = true, TransmissionGear? gear = null, RunInterval? intervalA = null, RunInterval? intervalB = null,
+        TorqueUnit torque = TorqueUnit.NewtonMeters) => RunAlternativePlots.Build(a, b, mode, TireTemperatureUnit.Celsius, torque, intervalA, intervalB, fullThrottle, gear);
+
+    [Fact]
+    public void PowerAndTorqueUseOriginalReadingsWithSelectedUnits()
+    {
+        var panels = Plot(new() { Samples = [Sample(1)] }, torque: TorqueUnit.PoundFeet);
+        Assert.Equal(2, panels.Length);
+        var power = Assert.Single(Assert.Single(panels[0].Series).Points);
+        var torque = Assert.Single(Assert.Single(panels[1].Series).Points);
+        Assert.Equal(100, power.Y, 4); Assert.Equal(500 * .7375621493, torque.Y, 6);
+        Assert.Equal(4000, power.X); Assert.Equal(1, power.SourceSeconds); Assert.Equal(0, power.SampleIndex);
+        Assert.Equal("hp", panels[0].YUnit); Assert.Equal("lb-ft", panels[1].YUnit);
+    }
+
+    [Fact]
+    public void PowerFiltersExcludeMenuReverseUnknownRpmAndOnlyTheirOwnMode()
+    {
+        RunSample[] samples = [Sample(0), Sample(.1, throttle: 180), Sample(.2, gear: TransmissionGear.Fourth),
+            Sample(.3, gear: TransmissionGear.Reverse), Sample(.4, rpm: 0), Sample(.5) with { IsDriving = false }];
+        var run = new RecordedRun { Samples = samples };
+        var filtered = Plot(run, gear: TransmissionGear.Third)[0].Series[0];
+        Assert.Equal(0, Assert.Single(filtered.Points).SampleIndex);
+        Assert.Equal(3, Plot(run, fullThrottle: false)[0].Series[0].Points.Length);
+        Assert.Equal(5, Plot(run, mode: RunPlotMode.GForce, gear: TransmissionGear.Third)[0].Series[0].Points.Length);
+    }
+
+    [Fact]
+    public void EachComparisonIntervalUsesItsOwnSourceTimeWithoutInventedBoundaryDots()
+    {
+        var a = new RecordedRun { Samples = [Sample(0), Sample(.1), Sample(.2)] };
+        var b = new RecordedRun { Samples = [Sample(10), Sample(10.1), Sample(10.2)] };
+        var panel = Plot(a, b, intervalA: new(.05, .15), intervalB: new(10.05, 10.15))[0];
+        Assert.Equal(.1, Assert.Single(panel.Series[0].Points).SourceSeconds);
+        Assert.Equal(10.1, Assert.Single(panel.Series[1].Points).SourceSeconds);
+        Assert.True(panel.Series[1].Comparison);
+    }
+
+    [Fact]
+    public void ElectricAndNaturallyAspiratedSamplesDoNotInventEngineOrBoostData()
+    {
+        var ev = Sample(0, 0) with { State = Sample(0, 0).State with { NumCylinders = 0, BoostPressurePsi = -10 } };
+        var na = Sample(.1) with { State = Sample(.1).State with { BoostPressurePsi = -12 } };
+        var run = new RecordedRun { Samples = [ev, na] };
+        var panel = Plot(run)[0];
+        Assert.Equal(1, Assert.Single(panel.Series[0].Points).SampleIndex);
+        Assert.DoesNotContain(Plot(run), p => p.YUnit.Contains("PSI"));
+        var unknownPower = na with { State = na.State with { PowerWatts = float.NaN } };
+        var missing = Plot(new() { Samples = [unknownPower] });
+        Assert.Empty(missing[0].Series[0].Points); Assert.Single(missing[1].Series[0].Points);
+    }
+
+    [Fact]
+    public void GForceSharesSymmetricAxesAcrossBothRunsAndPreservesSigns()
+    {
+        var a = Sample(0) with { State = Sample(0).State with { LateralAccelerationMetersPerSecondSquared = 9.80665f, LongitudinalAccelerationMetersPerSecondSquared = -19.6133f } };
+        var b = Sample(0) with { State = Sample(0).State with { LateralAccelerationMetersPerSecondSquared = -29.41995f, LongitudinalAccelerationMetersPerSecondSquared = 9.80665f } };
+        var panel = Assert.Single(Plot(new() { Samples = [a] }, new() { Samples = [b] }, RunPlotMode.GForce));
+        Assert.True(panel.EqualAxes); Assert.Equal(-panel.XMaximum, panel.XMinimum);
+        Assert.Equal(panel.XMinimum, panel.YMinimum); Assert.Equal(panel.XMaximum, panel.YMaximum);
+        Assert.Equal(-2, panel.Series[0].Points[0].Y, 5); Assert.Equal(-3, panel.Series[1].Points[0].X, 5);
+        Assert.Contains("+Y acceleration", panel.Description); Assert.Contains("−Y braking", panel.Description);
+    }
+
+    [Fact]
+    public void BoundedReductionPreservesActualExtremaIndicesAndDuplicateTimes()
+    {
+        var points = Enumerable.Range(0, 180_000).Select(i => new RunAlternativePoint(i == 1001 ? 9900 : 3000,
+            i == 9001 ? 900 : i == 8001 ? -50 : 100, i / 100d, i, i / 7, TransmissionGear.Third)).ToArray();
+        var reduced = RunAlternativePlots.Reduce(points);
+        Assert.InRange(reduced.Length, 1, RunAlternativePlots.MaximumSeriesPoints);
+        Assert.Contains(points[1001], reduced); Assert.Contains(points[9001], reduced); Assert.Contains(points[8001], reduced);
+        Assert.Equal(points[0], reduced[0]); Assert.Equal(points[^1], reduced[^1]);
+        Assert.All(reduced, point => Assert.Equal(points[point.SampleIndex], point));
+        var duplicate = Plot(new() { Samples = [Sample(0, 1000), Sample(0, 1500), Sample(.1, 2000) with { Segment = 1 }] })[0];
+        Assert.Equal(3, duplicate.Series[0].Points.Length); Assert.Equal(1, duplicate.Series[0].Points[2].Segment);
+    }
+
+    [Fact]
+    public void TireBarsMatchSelectedCoreStatisticsAndOmitMissingAxles()
+    {
+        var a = Sample(0) with { State = Sample(0).State with { TireTemperatureFahrenheit = new(32, 32, 0, 0) } };
+        var b = Sample(.2) with { State = Sample(.2).State with { TireTemperatureFahrenheit = new(212, 212, 0, 0) } };
+        var panel = Assert.Single(Plot(new() { Samples = [a, b] }, mode: RunPlotMode.TireChange, intervalA: new(.05, .15)));
+        Assert.Equal(2, panel.Bars.Length); Assert.Equal(25, panel.Bars[0].Value, 6); Assert.Equal(75, panel.Bars[1].Value, 6);
+        Assert.All(panel.Bars, bar => Assert.True(bar.Category < 2));
+        Assert.Equal(.05, panel.Bars[0].SourceSeconds); Assert.Equal(.15, panel.Bars[1].SourceSeconds);
+        Assert.Equal("°C", panel.YUnit);
+    }
+
+    [Fact]
+    public void InvalidBoundsAndGearFailAndTimeSeriesKeepsExistingPath()
+    {
+        var run = new RecordedRun { Samples = [Sample(0)] };
+        Assert.Throws<ArgumentOutOfRangeException>(() => Plot(run, intervalA: new(1, 0)));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Plot(run, gear: TransmissionGear.Neutral));
+        Assert.Empty(Plot(run, mode: RunPlotMode.TimeSeries));
+    }
+
+    [Fact]
+    public void TireBarsNeverRelabelALaterOrEarlierReadingAsABoundaryInsideAGap()
+    {
+        var run = new RecordedRun { Samples = [Sample(0), Sample(1), Sample(2)] };
+        var startsInGap = Assert.Single(Plot(run, mode: RunPlotMode.TireChange, intervalA: new(.5, 1)));
+        Assert.Equal(2, startsInGap.Bars.Length);
+        Assert.All(startsInGap.Bars, bar => { Assert.True(bar.Category % 2 == 1); Assert.Equal(1, bar.SourceSeconds); });
+        var endsInGap = Assert.Single(Plot(run, mode: RunPlotMode.TireChange, intervalA: new(1, 1.5)));
+        Assert.Equal(2, endsInGap.Bars.Length);
+        Assert.All(endsInGap.Bars, bar => { Assert.True(bar.Category % 2 == 0); Assert.Equal(1, bar.SourceSeconds); });
+    }
+
+    [Fact]
+    public void OffscreenViewsRenderDataWithoutCreatingAWindow()
+    {
+        OnSta(() =>
+        {
+            var run = new RecordedRun { Samples = [Sample(0), Sample(.1, 4500)] };
+            foreach (var panel in Plot(run).Concat(Plot(run, mode: RunPlotMode.GForce)).Concat(Plot(run, mode: RunPlotMode.TireChange)))
+            {
+                var view = new RunAlternativePlotView { Panel = panel, Width = 700, Height = 360, AccentBrush = Brushes.Red, TextBrush = Brushes.White, MutedBrush = Brushes.Gray };
+                Assert.False(view.IsVisible);
+                Assert.True(RenderContainsRed(view));
+            }
+            var chart = new RunChartView
+            {
+                Panel = RunPresentation.Charts(run, null, RunChartGroup.Engine, SpeedUnit.MilesPerHour, TireTemperatureUnit.Fahrenheit)[0],
+                Width = 700,
+                Height = 360,
+                StartSeconds = 0,
+                EndSeconds = .1,
+                AccentBrush = Brushes.Red,
+                RenderOffscreen = true,
+                Markers = [new(.05, "Shift", false)]
+            };
+            Assert.True(RenderContainsRed(chart));
+        });
+    }
+
+    private static bool RenderContainsRed(FrameworkElement view)
+    {
+        view.Measure(new Size(700, 360)); view.Arrange(new Rect(0, 0, 700, 360)); view.UpdateLayout();
+        var bitmap = new RenderTargetBitmap(700, 360, 96, 96, PixelFormats.Pbgra32); bitmap.Render(view);
+        var pixels = new byte[700 * 360 * 4]; bitmap.CopyPixels(pixels, 700 * 4, 0);
+        for (var y = 90; y < 290; y++) for (var x = 65; x < 680; x++)
+            { var i = (y * 700 + x) * 4; if (pixels[i + 2] > 100 && pixels[i + 1] < 50 && pixels[i] < 50) return true; }
+        return false;
+    }
+
+    private static void OnSta(Action action)
+    {
+        Exception? error = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception ex) { error = ex; } }) { IsBackground = true };
+        thread.SetApartmentState(ApartmentState.STA); thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(15)), "Offscreen plot rendering exceeded its deadline.");
+        if (error is not null) ExceptionDispatchInfo.Capture(error).Throw();
+    }
+}

--- a/tests/Wisp.App.Tests/RunChartVisibilityTests.cs
+++ b/tests/Wisp.App.Tests/RunChartVisibilityTests.cs
@@ -1,0 +1,106 @@
+using System.Runtime.ExceptionServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using Wisp.App.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunChartVisibilityTests
+{
+    [Fact]
+    public void OpeningACollapsedGraphPaneDrawsWithoutChangingItsData() => OnSta(() =>
+    {
+        var panel = new RunPlotPanel("Recorded speed", "mph",
+            [new("A · Ground", false, 0, [new(0, 20, false), new(1, 50, false)])], 0, 60);
+        var chart = new RunChartView
+        {
+            Panel = panel,
+            Width = 700,
+            Height = 360,
+            StartSeconds = 0,
+            EndSeconds = 1,
+            AccentBrush = Brushes.Red
+        };
+        chart.Measure(new Size(700, 360));
+        chart.Arrange(new Rect(0, 0, 700, 360));
+        var initial = new RenderTargetBitmap(700, 360, 96, 96, PixelFormats.Pbgra32);
+        initial.Render(chart);
+        Assert.False(chart.IsVisible);
+
+        var pane = new Grid { Visibility = Visibility.Collapsed, Width = 700, Height = 360 };
+        pane.Children.Add(chart);
+        // A hidden, non-activating presentation source supplies WPF visibility semantics without showing a window.
+        using var source = new HwndSource(new HwndSourceParameters("Wisp graph visibility test")
+        {
+            WindowStyle = unchecked((int)0x80000000),
+            ExtendedWindowStyle = 0x08000080,
+            Width = 700,
+            Height = 360,
+            PositionX = -20000,
+            PositionY = -20000
+        });
+        source.RootVisual = pane;
+        Settle(pane);
+        Assert.False(chart.IsVisible);
+
+        pane.Visibility = Visibility.Visible;
+        Settle(pane);
+        Assert.True(chart.IsVisible);
+        Assert.Same(panel, chart.Panel);
+        AssertGraphDrawing(chart);
+
+        pane.Visibility = Visibility.Collapsed;
+        Settle(pane);
+        pane.Visibility = Visibility.Visible;
+        Settle(pane);
+        AssertGraphDrawing(chart);
+        source.RootVisual = null;
+    });
+
+    private static void AssertGraphDrawing(RunChartView chart)
+    {
+        var drawing = VisualTreeHelper.GetDrawing(chart);
+        Assert.NotNull(drawing);
+        var content = Drawings(drawing).ToArray();
+        Assert.Contains(content, item => item is GlyphRunDrawing);
+        Assert.Contains(content, item => item is GeometryDrawing { Pen.Brush: SolidColorBrush brush } && brush.Color == Colors.Red);
+    }
+
+    private static IEnumerable<Drawing> Drawings(Drawing drawing)
+    {
+        yield return drawing;
+        if (drawing is DrawingGroup group)
+            foreach (var child in group.Children)
+                foreach (var descendant in Drawings(child)) yield return descendant;
+    }
+
+    private static void Settle(FrameworkElement pane)
+    {
+        pane.Measure(new Size(700, 360));
+        pane.Arrange(new Rect(0, 0, 700, 360));
+        pane.UpdateLayout();
+        pane.Dispatcher.Invoke(static () => { }, DispatcherPriority.ContextIdle);
+        pane.UpdateLayout();
+    }
+
+    private static void OnSta(Action action)
+    {
+        Exception? error = null;
+        var thread = new Thread(() =>
+        {
+            try { action(); }
+            catch (Exception exception) { error = exception; }
+            finally { Dispatcher.CurrentDispatcher.InvokeShutdown(); }
+        })
+        { IsBackground = true };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(15)), "Graph visibility regression exceeded its bounded deadline.");
+        if (error is not null) ExceptionDispatchInfo.Capture(error).Throw();
+    }
+}

--- a/tests/Wisp.App.Tests/RunCsvExporterTests.cs
+++ b/tests/Wisp.App.Tests/RunCsvExporterTests.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using System.IO;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunCsvExporterTests
+{
+    [Fact]
+    public async Task RawCsvPreservesSourceValuesDuplicatesAndMissingCellsWithoutPrivateMetadata()
+    {
+        var directory = TemporaryDirectory(); var oldCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var first = RunPresentationTests.Sample(.1, 4000) with
+            {
+                RearRadiusMeters = .333,
+                WheelSpeedMetersPerSecond = 12.5,
+                State = RunPresentationTests.Sample(.1, 4000).State with { BoostPressurePsi = -12, PowerWatts = float.NaN, Steering = -128, NumCylinders = 8 }
+            };
+            var second = first with
+            {
+                IsDriving = false,
+                Segment = 1,
+                RearRadiusMeters = null,
+                WheelSpeedMetersPerSecond = null,
+                State = first.State with { NumCylinders = 0, EngineRpm = 0, TireTemperatureFahrenheit = new(float.NaN, 212, 212, 212) }
+            };
+            var run = new RecordedRun { Name = "=FORMULA()", Tune = "+COMMAND", Notes = "private note", Samples = [first, second] };
+            var path = Path.Combine(directory, "raw.csv");
+            await RunCsvExporter.WriteAsync(run, path, TestContext.Current.CancellationToken);
+            var lines = await File.ReadAllLinesAsync(path, TestContext.Current.CancellationToken);
+            Assert.Equal(3, lines.Length); var headers = lines[0].Split(','); Assert.Equal(43, headers.Length);
+            var a = headers.Zip(lines[1].Split(',')).ToDictionary(pair => pair.First, pair => pair.Second);
+            var b = headers.Zip(lines[2].Split(',')).ToDictionary(pair => pair.First, pair => pair.Second);
+            Assert.Equal("0.1", a["time_s"]); Assert.Equal(a["time_s"], b["time_s"]);
+            Assert.Equal("12.5", a["wheel_speed_mps"]); Assert.Equal("", b["wheel_speed_mps"]);
+            Assert.Equal("", a["power_w"]); Assert.Equal("", b["tire_temperature_fl_f"]);
+            Assert.Equal("-12", a["boost_psi"]); Assert.Equal("-12", b["boost_psi"]);
+            Assert.Equal("1", a["is_driving"]); Assert.Equal("0", b["is_driving"]); Assert.Equal("1", b["segment"]);
+            Assert.Equal("-128", a["steering_raw"]); Assert.Equal("0", b["num_cylinders"]);
+            foreach (var line in lines.Skip(1))
+            {
+                var columns = line.Split(','); Assert.Equal(headers.Length, columns.Length);
+                Assert.All(columns.Where(value => value.Length > 0), value => Assert.True(double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _)));
+            }
+            Assert.DoesNotContain("private", string.Join('\n', lines)); Assert.DoesNotContain("FORMULA", string.Join('\n', lines));
+            Assert.DoesNotContain(headers, header => header.Contains("utc") || header.Contains("received"));
+            Assert.Single(Directory.GetFiles(directory));
+        }
+        finally { CultureInfo.CurrentCulture = oldCulture; Directory.Delete(directory, true); }
+    }
+
+    [Fact]
+    public async Task ExistingFileAndConcurrentExportAreNeverOverwritten()
+    {
+        var directory = TemporaryDirectory();
+        try
+        {
+            var run = new RecordedRun { Samples = [RunPresentationTests.Sample(0, 4000)] };
+            var path = Path.Combine(directory, "run.csv");
+            var tasks = new[] { RunCsvExporter.WriteAsync(run, path, TestContext.Current.CancellationToken), RunCsvExporter.WriteAsync(run, path, TestContext.Current.CancellationToken) };
+            var outcomes = await Task.WhenAll(tasks.Select(async task => { try { await task; return true; } catch (IOException) { return false; } }));
+            Assert.Single(outcomes, success => success);
+            var original = await File.ReadAllBytesAsync(path, TestContext.Current.CancellationToken);
+            await Assert.ThrowsAsync<IOException>(() => RunCsvExporter.WriteAsync(new RecordedRun(), path, TestContext.Current.CancellationToken));
+            Assert.Equal(original, await File.ReadAllBytesAsync(path, TestContext.Current.CancellationToken));
+            Assert.Single(Directory.GetFiles(directory));
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+
+    [Fact]
+    public async Task CancelledExportCannotLeaveAPartialFinalFile()
+    {
+        var directory = TemporaryDirectory();
+        try
+        {
+            using var cancellation = new CancellationTokenSource(); cancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => RunCsvExporter.WriteAsync(new RecordedRun(), Path.Combine(directory, "run.csv"), cancellation.Token));
+            Assert.Empty(Directory.GetFiles(directory));
+        }
+        finally { Directory.Delete(directory, true); }
+    }
+
+    private static string TemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "WispCsvTests-" + Guid.NewGuid().ToString("N")); Directory.CreateDirectory(path); return path;
+    }
+}

--- a/tests/Wisp.App.Tests/RunCursorTests.cs
+++ b/tests/Wisp.App.Tests/RunCursorTests.cs
@@ -1,0 +1,41 @@
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunCursorTests
+{
+    [Fact]
+    public void CursorShowsTheRecordedGearWithoutInventingValuesAcrossAShift()
+    {
+        var first = RunPresentationTests.Sample(0, 6200);
+        var next = RunPresentationTests.Sample(.1, 4500);
+        var run = new RecordedRun
+        {
+            Samples = [first with { State = first.State with { Gear = TransmissionGear.Second } }, next]
+        };
+        Assert.Contains("gear 2", RunCursor.Describe("A", run, .04));
+        Assert.Contains("gear 3", RunCursor.Describe("A", run, .06));
+    }
+
+    [Fact]
+    public void GapsAndMatchedRangeBoundariesKeepContextUnavailable()
+    {
+        var run = new RecordedRun { Samples = [RunPresentationTests.Sample(0, 3000), RunPresentationTests.Sample(1, 6000)] };
+        Assert.Equal("A · Reading unavailable", RunCursor.Describe("A", run, .5));
+        Assert.Equal("B · Reading unavailable", RunCursor.Describe("B", run, 1, new(0, .8)));
+    }
+
+    [Theory]
+    [InlineData(TransmissionGear.Neutral, "neutral")]
+    [InlineData(TransmissionGear.Reverse, "reverse")]
+    [InlineData(TransmissionGear.Unknown, "gear unavailable")]
+    public void NonDrivingGearsHavePlainLabels(TransmissionGear gear, string expected)
+    {
+        var sample = RunPresentationTests.Sample(0, 1200);
+        var run = new RecordedRun { Samples = [sample with { State = sample.State with { Gear = gear } }] };
+        Assert.Contains(expected, RunCursor.Describe("A", run, 0));
+    }
+}

--- a/tests/Wisp.App.Tests/RunImageExporterTests.cs
+++ b/tests/Wisp.App.Tests/RunImageExporterTests.cs
@@ -1,0 +1,85 @@
+using System.Runtime.ExceptionServices;
+using System.Windows.Media.Imaging;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunImageExporterTests
+{
+    [Fact]
+    public void ExportsARealOffscreenGraphAndKeepsExistingFilesIntact() => OnSta(() =>
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "Wisp.ImageExportTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var run = ExampleRun();
+            var report = RunAnalysis.BuildReport(run);
+            var snapshot = new RunImageSnapshot("Example run", null, "Full recording · 0–2 seconds", report.QualityNote,
+                report.Findings.ToArray(), RunPresentation.Metrics(report, null, SpeedUnit.MilesPerHour, TorqueUnit.NewtonMeters),
+                RunPresentation.Charts(run, null, RunChartGroup.Speed, SpeedUnit.MilesPerHour, TireTemperatureUnit.Fahrenheit), [], 0, 2);
+            var image = RunImageExporter.Render(snapshot);
+            Assert.True(image.IsFrozen);
+            Assert.Equal(1280, image.PixelWidth);
+            Assert.InRange(image.PixelHeight, 500, RunImageExporter.MaximumImageHeight);
+            // The lower section must contain the actual accent graph, not just a blank card or header text.
+            var pixels = new byte[image.PixelWidth * image.PixelHeight * 4];
+            image.CopyPixels(pixels, image.PixelWidth * 4, 0);
+            var accentPixels = 0;
+            for (var y = Math.Max(0, image.PixelHeight - 350); y < image.PixelHeight - 100; y++)
+                for (var x = 110; x < 1180; x++)
+                {
+                    var index = (y * image.PixelWidth + x) * 4;
+                    if (pixels[index + 1] > 180 && pixels[index + 2] < 150 && pixels[index] > 150) accentPixels++;
+                }
+            Assert.True(accentPixels > 50, "The exported graph did not render its recorded speed line.");
+            var path = Path.Combine(directory, "report.png");
+            RunImageExporter.WriteAsync(image, path, TestContext.Current.CancellationToken).GetAwaiter().GetResult();
+            var original = File.ReadAllBytes(path);
+            Assert.Equal(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }, original[..8]);
+            Assert.Throws<IOException>(() => RunImageExporter.WriteAsync(image, path, TestContext.Current.CancellationToken).GetAwaiter().GetResult());
+            Assert.Equal(original, File.ReadAllBytes(path));
+            using var canceled = new CancellationTokenSource(); canceled.Cancel();
+            Assert.ThrowsAny<OperationCanceledException>(() => RunImageExporter.WriteAsync(image, Path.Combine(directory, "canceled.png"), canceled.Token).GetAwaiter().GetResult());
+            Assert.Single(Directory.GetFiles(directory));
+        }
+        finally { Directory.Delete(directory, recursive: true); }
+    });
+
+    [Fact]
+    public void AlternativeComparisonAndLongLabelsStayWithinTheImageBudget() => OnSta(() =>
+    {
+        var a = ExampleRun(); var b = ExampleRun();
+        var report = RunAnalysis.BuildReport(a);
+        foreach (var mode in new[] { RunPlotMode.PowerByRpm, RunPlotMode.GForce, RunPlotMode.TireChange })
+        {
+            var panels = RunAlternativePlots.Build(a, b, mode, TireTemperatureUnit.Celsius, TorqueUnit.PoundFeet, fullThrottleOnly: false);
+            var image = RunImageExporter.Render(new RunImageSnapshot(new string('A', 120), new string('B', 120), "Selected interval · 0–2 seconds",
+                report.QualityNote, report.Findings.ToArray(), RunPresentation.Metrics(report, report, SpeedUnit.KilometersPerHour, TorqueUnit.PoundFeet),
+                [], panels, 0, 2));
+            Assert.InRange(image.PixelHeight, 500, RunImageExporter.MaximumImageHeight);
+            Assert.True(image.IsFrozen);
+        }
+    });
+
+    private static RecordedRun ExampleRun() => new()
+    {
+        Samples = Enumerable.Range(0, 201).Select(index =>
+        {
+            var sample = RunPresentationTests.Sample(index / 100d, 1000 + index * 20);
+            return sample with { State = sample.State with { GroundSpeedMetersPerSecond = index / 10f } };
+        }).ToArray()
+    };
+
+    private static void OnSta(Action action)
+    {
+        Exception? error = null;
+        var thread = new Thread(() => { try { action(); } catch (Exception exception) { error = exception; } }) { IsBackground = true };
+        thread.SetApartmentState(ApartmentState.STA); thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(20)), "Offscreen image export exceeded its bounded deadline.");
+        if (error is not null) ExceptionDispatchInfo.Capture(error).Throw();
+    }
+}

--- a/tests/Wisp.App.Tests/RunLineReaderTests.cs
+++ b/tests/Wisp.App.Tests/RunLineReaderTests.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using Wisp.App.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunLineReaderTests
+{
+    [Theory]
+    [InlineData(4095)]
+    [InlineData(4096)]
+    [InlineData(4097)]
+    [InlineData(8192)]
+    public async Task BoundarySizedLinesKeepFollowingLinesAndEof(int length)
+    {
+        var text = new string('x', length);
+        using var input = Input(text + "\nsecond\r\n\nlast\r\r");
+        var lines = new RunStore.BoundedLineReader(input);
+        Assert.Equal(text, await lines.ReadLineAsync(8192));
+        Assert.Equal("second", await lines.ReadLineAsync(8192));
+        Assert.Equal("", await lines.ReadLineAsync(8192));
+        Assert.Equal("last", await lines.ReadLineAsync(8192));
+        Assert.Null(await lines.ReadLineAsync(8192));
+    }
+
+    [Fact]
+    public async Task CrLfAcrossReadBoundaryAndUnicodeRemainIntact()
+    {
+        var first = new string('x', 4095);
+        var second = new string('\u4E00', 8191);
+        using var input = Input(first + "\r\n" + second + "\n");
+        var lines = new RunStore.BoundedLineReader(input);
+        Assert.Equal(first, await lines.ReadLineAsync(8192));
+        Assert.Equal(second, await lines.ReadLineAsync(8192));
+        Assert.Null(await lines.ReadLineAsync(8192));
+    }
+
+    [Theory]
+    [InlineData(8192, "\r\n")]
+    [InlineData(8193, "\n")]
+    [InlineData(8193, "")]
+    public async Task LineLimitIncludesCrAndAppliesBeforeEof(int length, string ending)
+    {
+        using var input = Input(new string('x', length) + ending);
+        var lines = new RunStore.BoundedLineReader(input);
+        await Assert.ThrowsAsync<InvalidDataException>(async () => await lines.ReadLineAsync(8192));
+    }
+
+    [Fact]
+    public async Task LargeHeaderDoesNotRelaxFollowingSampleLimit()
+    {
+        var header = new string('h', 131072);
+        using var input = Input(header + "\n" + new string('s', 8193));
+        var lines = new RunStore.BoundedLineReader(input);
+        Assert.Equal(header, await lines.ReadLineAsync(131072));
+        await Assert.ThrowsAsync<InvalidDataException>(async () => await lines.ReadLineAsync(8192));
+    }
+
+    [Fact]
+    public async Task HeaderAboveItsOwnLimitIsRejected()
+    {
+        using var input = Input(new string('h', 131073));
+        var lines = new RunStore.BoundedLineReader(input);
+        await Assert.ThrowsAsync<InvalidDataException>(async () => await lines.ReadLineAsync(131072));
+    }
+
+    [Theory]
+    [InlineData("", null)]
+    [InlineData("\n", "")]
+    [InlineData("\r", "")]
+    public async Task EmptyAndCrOnlyEofMatchExistingFormat(string text, string? expected)
+    {
+        using var input = Input(text);
+        var lines = new RunStore.BoundedLineReader(input);
+        Assert.Equal(expected, await lines.ReadLineAsync(8192));
+        Assert.Null(await lines.ReadLineAsync(8192));
+    }
+
+    private static StreamReader Input(string text) => new(new MemoryStream(Encoding.UTF8.GetBytes(text)), Encoding.UTF8);
+}

--- a/tests/Wisp.App.Tests/RunMarkerStoreTests.cs
+++ b/tests/Wisp.App.Tests/RunMarkerStoreTests.cs
@@ -1,0 +1,112 @@
+using System.IO.Compression;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Wisp.App.Runs;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunMarkerStoreTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "Wisp.RunMarkerTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task FullUnicodeMarkerSetSurvivesSaveExportAndImport()
+    {
+        var run = RunTestData.CreateRun() with
+        {
+            Markers = Enumerable.Range(0, RunStore.MaximumMarkers).Select(_ => new RunMarker(.1, new string('\u4E00', 80))).ToArray()
+        };
+        var store = new RunStore(Path.Combine(_directory, "library"));
+        await store.SaveAsync(run);
+        Assert.Equal(run.Markers, (await store.LoadAsync(run.Id)).Markers);
+        var export = Path.Combine(_directory, "shared.wisprun");
+        await store.ExportAsync(run.Id, export);
+        var imported = await store.ImportAsync(export);
+        Assert.NotEqual(run.Id, imported.Id);
+        Assert.Equal(run.Markers, (await store.LoadAsync(imported.Id)).Markers);
+    }
+
+    [Fact]
+    public async Task SchemaOneFileWithoutMarkersStillImports()
+    {
+        var run = RunTestData.CreateRun();
+        var path = await WriteInput(run, omitMarkers: true);
+        var store = new RunStore(Path.Combine(_directory, "library"));
+        var imported = await store.ImportAsync(path);
+        Assert.Empty((await store.LoadAsync(imported.Id)).Markers);
+    }
+
+    [Theory]
+    [InlineData("negative")]
+    [InlineData("past_end")]
+    [InlineData("nonfinite")]
+    [InlineData("long_label")]
+    [InlineData("control")]
+    [InlineData("too_many")]
+    [InlineData("unordered")]
+    [InlineData("missing")]
+    public async Task InvalidMarkerInputCannotEnterTheLibrary(string invalid)
+    {
+        var run = RunTestData.CreateRun();
+        var markers = invalid switch
+        {
+            "negative" => new[] { new RunMarker(-1, "Moment") },
+            "past_end" => [new RunMarker(.2, "Moment")],
+            "nonfinite" => [new RunMarker(double.NaN, "Moment")],
+            "long_label" => [new RunMarker(0, new string('x', 81))],
+            "control" => [new RunMarker(0, "hidden\0text")],
+            "too_many" => Enumerable.Range(0, 129).Select(_ => new RunMarker(0, "Moment")).ToArray(),
+            "unordered" => [new RunMarker(.1, "Later"), new RunMarker(0, "Earlier")],
+            _ => [null!]
+        };
+        var path = await WriteInput(run with { Markers = markers });
+        var store = new RunStore(Path.Combine(_directory, "library"));
+        var error = await Record.ExceptionAsync(() => store.ImportAsync(path));
+        Assert.True(error is InvalidDataException or JsonException);
+        Assert.Empty(await store.ListAsync());
+    }
+
+    [Fact]
+    public async Task RecoveryKeepsDurableMarkersAndDiscardsAnIncompleteTrailingMarker()
+    {
+        var run = RunTestData.CreateRun();
+        var store = new RunStore(_directory);
+        await using (var journal = store.CreateJournal(run with { Samples = [] }))
+        {
+            await journal.AppendAsync(run.Samples[0]);
+            await journal.AppendMarkerAsync(new(0, "Launch"));
+            await journal.AppendAsync(run.Samples[1]);
+            await journal.AppendMarkerAsync(new(.1, "Shift"));
+            await journal.FlushAsync();
+        }
+        await File.AppendAllTextAsync(Path.Combine(_directory, $"{run.Id:N}.partial"), "{\"marker\":{", TestContext.Current.CancellationToken);
+        var recovery = new RunStore(_directory);
+        Assert.Single(await recovery.ListAsync());
+        var restored = await recovery.LoadAsync(run.Id);
+        Assert.True(restored.IsIncomplete);
+        Assert.Equal(new[] { new RunMarker(0, "Launch"), new RunMarker(.1, "Shift") }, restored.Markers);
+        Assert.Equal(run.Samples, restored.Samples);
+    }
+
+    private async Task<string> WriteInput(RecordedRun run, bool omitMarkers = false)
+    {
+        Directory.CreateDirectory(_directory);
+        var path = Path.Combine(_directory, "input.wisprun");
+        var options = new JsonSerializerOptions(RunStore.JsonOptions)
+        {
+            NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals
+        };
+        var header = JsonSerializer.SerializeToNode(run with { Samples = [] }, options)!.AsObject();
+        if (omitMarkers) header.Remove("markers");
+        await using var file = File.Create(path);
+        await using var gzip = new GZipStream(file, CompressionLevel.Fastest);
+        await using var writer = new StreamWriter(gzip);
+        await writer.WriteLineAsync(header.ToJsonString(options));
+        foreach (var sample in run.Samples) await writer.WriteLineAsync(JsonSerializer.Serialize(sample, options));
+        return path;
+    }
+
+    public void Dispose() { if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true); }
+}

--- a/tests/Wisp.App.Tests/RunPresentationTests.cs
+++ b/tests/Wisp.App.Tests/RunPresentationTests.cs
@@ -1,0 +1,178 @@
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunPresentationTests
+{
+    [Fact]
+    public void LongRunsKeepExtremaWithinTheGeometryBudget()
+    {
+        var samples = Enumerable.Range(0, 180_000).Select(i => Sample(i / 100d, i == 72001 ? 9000 : 1000)).ToArray();
+        var points = RunPresentation.PreparePoints(samples, s => s.State.EngineRpm, 0);
+        Assert.InRange(points.Length, 2, RunPresentation.MaximumSeriesPoints);
+        Assert.Equal(0, points[0].Seconds);
+        Assert.Equal(samples[^1].ElapsedSeconds, points[^1].Seconds);
+        Assert.Contains(points, point => point.Value == 9000);
+    }
+
+    [Fact]
+    public void NumerousInterruptionsCannotGrowTheGeometryBudgetOrJoinSegments()
+    {
+        var samples = Enumerable.Range(0, 12_000).Select(i => Sample(i / 100d, 1000) with { Segment = i }).ToArray();
+        var points = RunPresentation.PreparePoints(samples, s => s.State.EngineRpm, 0);
+        Assert.InRange(points.Length, 1, RunPresentation.MaximumSeriesPoints);
+        Assert.All(points, point => Assert.True(point.BreakBefore));
+    }
+
+    [Fact]
+    public void AShortMissingSectionInsideOneBucketStillBreaksTheLine()
+    {
+        var samples = Enumerable.Range(0, 12_000).Select(i => Sample(i / 100d, 1000)).ToArray();
+        samples[19] = samples[19] with { IsDriving = false };
+        var points = RunPresentation.PreparePoints(samples, s => s.State.EngineRpm, 0);
+        Assert.Contains(points, point => point.Seconds > .19 && point.Seconds < .4 && point.BreakBefore);
+    }
+
+    [Fact]
+    public void DuplicatedGameTimeKeepsTheLatestReadingWithoutPaintingAGap()
+    {
+        RunSample[] samples = [Sample(0, 1000), Sample(.01, 2000), Sample(.01, 2400), Sample(.02, 3000)];
+        var points = RunPresentation.PreparePoints(samples, s => s.State.EngineRpm, 0);
+        Assert.Single(points, point => point.BreakBefore);
+        Assert.Equal(2400, RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, .01));
+    }
+
+    [Theory]
+    [InlineData(.003, 1000)]
+    [InlineData(.008, 2000)]
+    public void CursorReturnsARecordedValueRatherThanAnInterpolatedValue(double seconds, double expected)
+    {
+        RunSample[] samples = [Sample(0, 1000), Sample(.01, 2000), Sample(.02, 3000)];
+        Assert.Equal(expected, RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, seconds));
+    }
+
+    [Fact]
+    public void CursorDoesNotInventDataInsideAnInterruption()
+    {
+        RunSample[] samples = [Sample(0, 1000), Sample(1, 2000)];
+        Assert.Null(RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, .5));
+        Assert.Null(RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, -1));
+        Assert.Null(RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, 2));
+    }
+
+    [Fact]
+    public void NativeMenuContextIsExcludedFromBothGeometryAndReadouts()
+    {
+        RunSample[] samples = [Sample(0, 1000), Sample(.01, 8000) with { IsDriving = false }, Sample(.02, 1200)];
+        var points = RunPresentation.PreparePoints(samples, s => s.State.EngineRpm, 0);
+        Assert.DoesNotContain(points, point => point.Value == 8000);
+        Assert.True(points[^1].BreakBefore);
+        Assert.Null(RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, .01));
+    }
+
+    [Fact]
+    public void CursorNeverReadsAValueOutsideTheMatchedInterval()
+    {
+        RunSample[] samples = [Sample(.04, 1000), Sample(.05, 2000), Sample(.06, 3000)];
+        Assert.Equal(2000, RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, .044, new(.044, .055)));
+        Assert.Equal(2000, RunPresentation.RecordedValueAt(samples, s => s.State.EngineRpm, .055, new(.044, .055)));
+    }
+
+    [Fact]
+    public void GapShadingUsesOriginalEdgesRatherThanReducedVertexTimes()
+    {
+        var samples = Enumerable.Range(0, 12_000).Select(i => Sample(i / 100d, 1000)).ToArray();
+        samples[19] = samples[19] with { IsDriving = false };
+        var gap = Assert.Single(RunPresentation.PrepareGaps(samples, s => s.State.EngineRpm, 0));
+        Assert.Equal(.18, gap.StartSeconds, 6);
+        Assert.Equal(.20, gap.EndSeconds, 6);
+    }
+
+    [Fact]
+    public void UnknownTemperatureAndNaturallyAspiratedVacuumAreUnavailable()
+    {
+        var sample = Sample(0, 1000);
+        var run = new RecordedRun { Samples = [sample with { State = sample.State with { TireTemperatureFahrenheit = default, BoostPressurePsi = -12, NumCylinders = 8 } }] };
+        var tires = RunPresentation.Charts(run, null, RunChartGroup.Tires, SpeedUnit.MilesPerHour, TireTemperatureUnit.Celsius);
+        Assert.All(tires[0].Series, series => Assert.Empty(series.Points));
+        var boost = Assert.Single(RunPresentation.Charts(run, null, RunChartGroup.Engine, SpeedUnit.MilesPerHour, TireTemperatureUnit.Fahrenheit), panel => panel.Unit == "PSI");
+        Assert.All(boost.Series, series => Assert.Empty(series.Points));
+    }
+
+    [Fact]
+    public void SteeringEndpointsFitThePercentageScale()
+    {
+        var sample = Sample(0, 1000);
+        var run = new RecordedRun
+        {
+            Samples = [sample with { State = sample.State with { Steering = -128 } },
+            Sample(.01, 1000) with { State = sample.State with { Steering = 127, GameTimestampMilliseconds = 10 } }]
+        };
+        var panel = Assert.Single(RunPresentation.Charts(run, null, RunChartGroup.Inputs, SpeedUnit.MilesPerHour, TireTemperatureUnit.Fahrenheit), chart => chart.Unit == "%");
+        var steering = Assert.Single(panel.Series, series => series.ColorIndex == 2);
+        Assert.Equal(-100, steering.Points[0].Value);
+        Assert.Equal(100, steering.Points[1].Value);
+    }
+
+    [Fact]
+    public void MatchedChartsEndAtEachRunsOwnTargetCrossing()
+    {
+        var a = new RecordedRun { Samples = Enumerable.Range(0, 1001).Select(i => Sample(i / 100d, 1000)).ToArray() };
+        var b = a with { Id = Guid.NewGuid() };
+        var chart = Assert.Single(RunPresentation.Charts(a, b, RunChartGroup.Engine, SpeedUnit.MilesPerHour,
+            TireTemperatureUnit.Fahrenheit, 2, 4, new(2, 5), new(4, 6)), p => p.Unit == "RPM");
+        var lineA = Assert.Single(chart.Series, series => !series.Comparison);
+        var lineB = Assert.Single(chart.Series, series => series.Comparison);
+        Assert.All(lineA.Points, point => Assert.InRange(point.Seconds, 0, 3));
+        Assert.All(lineB.Points, point => Assert.InRange(point.Seconds, 0, 2));
+        Assert.Null(lineB.ReadRecordedValue!(2.1));
+        Assert.Equal(1000, lineA.ReadRecordedValue!(2.1));
+    }
+
+    [Fact]
+    public void SpeedAndTemperatureChartsLabelAndConvertTheSelectedUnits()
+    {
+        var run = new RecordedRun { Samples = [Sample(0, 1000)] };
+        var speed = Assert.Single(RunPresentation.Charts(run, null, RunChartGroup.Speed,
+            SpeedUnit.KilometersPerHour, TireTemperatureUnit.Celsius));
+        Assert.Equal("km/h", speed.Unit);
+        Assert.Equal(36, speed.Series[0].Points[0].Value, 3);
+        var temperature = Assert.Single(RunPresentation.Charts(run, null, RunChartGroup.Tires,
+            SpeedUnit.KilometersPerHour, TireTemperatureUnit.Celsius), panel => panel.Unit == "°C");
+        Assert.Equal("°C", temperature.Unit);
+        Assert.Equal(100, temperature.Series[0].Points[0].Value, 3);
+    }
+
+    internal static RunSample Sample(double seconds, float rpm) => new()
+    {
+        ElapsedSeconds = seconds,
+        Segment = 0,
+        IsDriving = true,
+        State = new VehicleState
+        {
+            IsRaceOn = true,
+            GameTimestampMilliseconds = (uint)Math.Round(seconds * 1000),
+            ReceivedAtUtc = DateTimeOffset.UnixEpoch.AddSeconds(seconds),
+            CarOrdinal = 1,
+            NumCylinders = 8,
+            Drivetrain = DrivetrainType.RearWheelDrive,
+            GroundSpeedMetersPerSecond = 10,
+            WheelRotationRadiansPerSecond = default,
+            TireSlipRatio = default,
+            TireSlipAngle = default,
+            NormalizedSuspensionTravel = default,
+            LateralAccelerationMetersPerSecondSquared = 0,
+            LongitudinalAccelerationMetersPerSecondSquared = 0,
+            EngineRpm = rpm,
+            EngineMaximumRpm = 9000,
+            Gear = TransmissionGear.Third,
+            Steering = 0,
+            Accelerator = 255,
+            Brake = 0,
+            TireTemperatureFahrenheit = new(212, 212, 212, 212)
+        }
+    };
+}

--- a/tests/Wisp.App.Tests/RunRecordingOptionsTests.cs
+++ b/tests/Wisp.App.Tests/RunRecordingOptionsTests.cs
@@ -1,0 +1,180 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Wisp.Telemetry;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunRecordingOptionsTests
+{
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(601)]
+    public async Task InvalidDurationNeverAttachesCapture(double seconds)
+    {
+        await using var fixture = await RecordingFixture.CreateAsync();
+        Assert.False(fixture.Service.Start(new(TimeSpan.FromSeconds(seconds))));
+        Assert.Contains("above zero", fixture.Service.Status);
+        Assert.False(fixture.Service.IsRecording);
+        var probe = fixture.Receiver.BeginRunCapture(2);
+        fixture.Receiver.EndRunCapture(probe);
+    }
+
+    [Fact]
+    public async Task TimedRecordingStopsAtItsDeadlineAndSavesWithoutUserStop()
+    {
+        await using var fixture = await RecordingFixture.CreateAsync();
+        var saved = new TaskCompletionSource<RecordedRun>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Service.RunSaved += run => saved.TrySetResult(run);
+        Assert.True(fixture.Service.Start(new(TimeSpan.FromMilliseconds(250))));
+        for (var index = 1; index <= 100 && fixture.Service.IsRecording; index++)
+        {
+            await fixture.SendAsync(index * 10);
+            fixture.Service.RefreshStatus();
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+        var run = await saved.Task.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        Assert.Equal("Timed recording completed", run.FinishReason);
+        Assert.False(run.IsIncomplete);
+        Assert.False(fixture.Service.IsRecording);
+        Assert.InRange(fixture.Service.Elapsed.TotalMilliseconds, 249, 251);
+        Assert.NotEmpty(run.Samples);
+        var count = run.Samples.Length;
+        await fixture.SendAsync(9999);
+        Assert.Equal(count, (await fixture.Service.Store.LoadAsync(run.Id)).Samples.Length);
+        Assert.True(fixture.Receiver.IsRunning);
+    }
+
+    [Fact]
+    public async Task MomentsUseProcessedGameTimeRejectGapsAndRemainBounded()
+    {
+        await using var fixture = await RecordingFixture.CreateAsync();
+        Assert.True(fixture.Service.Start());
+        Assert.False(fixture.Service.MarkMoment("Too early"));
+        await fixture.SendAsync(10);
+        await fixture.SendAsync(110);
+        await AddWhenProcessed("Limiter");
+        Assert.Null(fixture.Service.Error);
+
+        var rejected = fixture.Receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets;
+        await fixture.SendInvalidAsync();
+        await RecordingFixture.WaitUntil(() => fixture.Receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets > rejected);
+        Assert.False(fixture.Service.MarkMoment("Missing data"));
+        Assert.Contains("Recording continues", fixture.Service.MarkerStatus);
+        await fixture.SendAsync(210, driving: false);
+        Assert.False(fixture.Service.MarkMoment("Menu"));
+        await fixture.SendAsync(310);
+        await AddWhenProcessed("Exit");
+
+        fixture.PublishContext(expired: true);
+        Assert.False(fixture.Service.MarkMoment("Expired driving observation"));
+        fixture.PublishContext();
+        Assert.False(fixture.Service.MarkMoment(new string('x', 81)));
+        Assert.False(fixture.Service.MarkMoment("two\nlines"));
+        for (var index = 2; index < RunStore.MaximumMarkers; index++) Assert.True(fixture.Service.MarkMoment());
+        Assert.False(fixture.Service.MarkMoment("One too many"));
+        Assert.Contains("128", fixture.Service.MarkerStatus);
+        Assert.True(fixture.Service.IsRecording);
+        var run = await fixture.Service.StopAsync();
+        Assert.NotNull(run);
+        Assert.Equal(RunStore.MaximumMarkers, run.Markers.Length);
+        Assert.Equal(new RunMarker(.1, "Limiter"), run.Markers[0]);
+        Assert.Equal(.3, run.Markers[1].ElapsedSeconds, 6);
+        Assert.Equal("Exit", run.Markers[1].Label);
+        Assert.Equal(run.Markers, (await fixture.Service.Store.LoadAsync(run.Id)).Markers);
+        Assert.True(run.IsIncomplete);
+        Assert.True(fixture.Receiver.IsRunning);
+
+        async Task AddWhenProcessed(string label)
+        {
+            var added = false;
+            for (var retry = 0; retry < 30 && !added; retry++)
+            {
+                added = fixture.Service.MarkMoment(label);
+                if (!added) await Task.Delay(5, TestContext.Current.CancellationToken);
+            }
+            Assert.True(added, fixture.Service.MarkerStatus);
+        }
+    }
+
+    [Fact]
+    public async Task TimedFinishWithMissingTailIsPartialWithoutInventingSamples()
+    {
+        await using var fixture = await RecordingFixture.CreateAsync();
+        var saved = new TaskCompletionSource<RecordedRun>(TaskCreationOptions.RunContinuationsAsynchronously);
+        fixture.Service.RunSaved += run => saved.TrySetResult(run);
+        Assert.True(fixture.Service.Start(new(TimeSpan.FromMilliseconds(500))));
+        await fixture.SendAsync(10);
+        await Task.Delay(550, TestContext.Current.CancellationToken);
+        fixture.Service.RefreshStatus();
+        var run = await saved.Task.WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+        Assert.Equal("Timed recording completed", run.FinishReason);
+        Assert.True(run.IsIncomplete);
+        Assert.Equal(0, Assert.Single(run.Samples).ElapsedSeconds);
+        Assert.Empty(run.Markers);
+    }
+
+    private sealed class RecordingFixture : IAsyncDisposable
+    {
+        private readonly string _directory = Path.Combine(Path.GetTempPath(), "Wisp.RunOptionsTests", Guid.NewGuid().ToString("N"));
+        private readonly UdpClient _sender = new(AddressFamily.InterNetwork);
+        private readonly IPEndPoint _endpoint = new(IPAddress.Loopback, AvailablePort());
+        internal TelemetryUdpReceiver Receiver { get; } = new();
+        internal RunRecordingService Service { get; }
+        private RecordingFixture() => Service = new(Receiver, _directory);
+
+        internal static async Task<RecordingFixture> CreateAsync()
+        {
+            var fixture = new RecordingFixture();
+            await fixture.Receiver.StartAsync(fixture._endpoint.Port, TestContext.Current.CancellationToken);
+            await fixture.SendAsync(0);
+            fixture.PublishContext();
+            return fixture;
+        }
+        internal void PublishContext(bool driving = true, bool expired = false)
+        {
+            var now = Stopwatch.GetTimestamp();
+            Service.UpdateContext(new(now, 2468, DrivetrainType.RearWheelDrive, driving, .35, .35,
+                expired ? now - 1 : now + Stopwatch.Frequency / 4));
+        }
+        internal async Task SendAsync(int timestamp, bool driving = true)
+        {
+            PublishContext(driving);
+            var bytes = new byte[324];
+            Write(0, 1); Write(4, timestamp); Write(8, BitConverter.SingleToInt32Bits(8000));
+            Write(16, BitConverter.SingleToInt32Bits(4000)); Write(212, 2468); Write(224, 1); Write(228, 8);
+            Write(256, BitConverter.SingleToInt32Bits(20));
+            for (var offset = 100; offset <= 112; offset += 4) Write(offset, BitConverter.SingleToInt32Bits(50));
+            bytes[319] = 3;
+            await _sender.SendAsync(bytes, _endpoint, TestContext.Current.CancellationToken);
+            await WaitUntil(() => Receiver.Latest?.GameTimestampMilliseconds == timestamp);
+            void Write(int offset, int value) => BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset, 4), value);
+        }
+        internal async Task SendInvalidAsync() => await _sender.SendAsync(new byte[8], _endpoint, TestContext.Current.CancellationToken);
+        public async ValueTask DisposeAsync()
+        {
+            await Service.DisposeAsync();
+            await Receiver.DisposeAsync();
+            _sender.Dispose();
+            if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true);
+        }
+        private static int AvailablePort()
+        {
+            using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            return ((IPEndPoint)socket.LocalEndPoint!).Port;
+        }
+        internal static async Task WaitUntil(Func<bool> predicate)
+        {
+            var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 3;
+            while (!predicate() && Stopwatch.GetTimestamp() < deadline) await Task.Delay(5, TestContext.Current.CancellationToken);
+            Assert.True(predicate());
+        }
+    }
+}

--- a/tests/Wisp.App.Tests/RunRecordingTests.cs
+++ b/tests/Wisp.App.Tests/RunRecordingTests.cs
@@ -1,0 +1,269 @@
+using System.Diagnostics;
+using System.IO;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Telemetry;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunRecordingTests
+{
+    [Fact]
+    public void TimestampWrapDuplicatesAndResetRetainDataWithoutInventingTime()
+    {
+        var start = Stopwatch.GetTimestamp();
+        long At(double value) => start + (long)(value * Stopwatch.Frequency);
+        var context = new RunRecordingContext(start, 2468, DrivetrainType.RearWheelDrive, true, .35, .35);
+        var builder = new RunSampleBuilder(start);
+        var first = builder.Add(RunTestData.State(uint.MaxValue - 49), start, 1, context);
+        var wrapped = builder.Add(RunTestData.State(50), At(.1), 2, context);
+        var repeated = builder.Add(RunTestData.State(50) with { EngineRpm = 7000 }, At(.11), 3, context);
+        var reset = builder.Add(RunTestData.State(2), At(.2), 4, context);
+        Assert.Equal(0, first.ElapsedSeconds);
+        Assert.Equal(.1, wrapped.ElapsedSeconds, 6);
+        Assert.Equal(.1, repeated.ElapsedSeconds, 6);
+        Assert.Equal(7000, repeated.State.EngineRpm);
+        Assert.Equal(first.Segment, repeated.Segment);
+        Assert.True(reset.Segment > repeated.Segment);
+        Assert.InRange(reset.ElapsedSeconds, .18, .2);
+        Assert.True(builder.HasGap);
+    }
+
+    [Fact]
+    public void NativeVisibilityLossFutureContextAndCalibrationChangeSplitSegments()
+    {
+        var start = Stopwatch.GetTimestamp();
+        long At(double value) => start + (long)(value * Stopwatch.Frequency);
+        var context = new RunRecordingContext(start, 2468, DrivetrainType.RearWheelDrive, true, .35, .35);
+        var builder = new RunSampleBuilder(start);
+        var driving = builder.Add(RunTestData.State(0), start, 1, context);
+        var hidden = builder.Add(RunTestData.State(100), At(.1), 2, context with { IsDriving = false });
+        var future = builder.Add(RunTestData.State(200), At(.2), 3, context with { EffectiveTimestamp = At(.25), RearRadiusMeters = .4 });
+        var changed = builder.Add(RunTestData.State(300), At(.3), 4, context with { EffectiveTimestamp = At(.25), RearRadiusMeters = .4 });
+        Assert.True(driving.IsDriving);
+        Assert.False(hidden.IsDriving);
+        Assert.True(hidden.State.IsRaceOn);
+        Assert.True(hidden.Segment > driving.Segment);
+        Assert.Null(future.WheelSpeedMetersPerSecond);
+        Assert.True(changed.IsDriving);
+        Assert.Equal(4, changed.WheelSpeedMetersPerSecond);
+        Assert.True(changed.Segment > future.Segment);
+    }
+
+    [Fact]
+    public void QueueLossRejectedPacketAndStaleContextCannotBridgeMetrics()
+    {
+        var start = Stopwatch.GetTimestamp();
+        long At(double value) => start + (long)(value * Stopwatch.Frequency);
+        var context = new RunRecordingContext(start, 2468, DrivetrainType.RearWheelDrive, true, .35, .35);
+        var builder = new RunSampleBuilder(start);
+        var first = builder.Add(RunTestData.State(0), start, 1, context);
+        var loss = builder.Add(RunTestData.State(100), At(.1), 3, context);
+        builder.MarkGap();
+        var rejected = builder.Add(RunTestData.State(200), At(.2), 4, context);
+        var stale = builder.Add(RunTestData.State(400), At(.4), 5, context);
+        Assert.True(loss.Segment > first.Segment);
+        Assert.True(rejected.Segment > loss.Segment);
+        Assert.False(stale.IsDriving);
+        Assert.Null(stale.WheelSpeedMetersPerSecond);
+        Assert.True(builder.HasGap);
+    }
+
+    [Fact]
+    public void DrivingDeadlineCannotBeExtendedByPublishingNewCalibrationContext()
+    {
+        var start = Stopwatch.GetTimestamp();
+        long At(double value) => start + (long)(value * Stopwatch.Frequency);
+        var context = new RunRecordingContext(At(.24), 2468, DrivetrainType.RearWheelDrive, true, .35, .4, At(.25));
+        var builder = new RunSampleBuilder(start);
+        var beforePublication = builder.Add(RunTestData.State(230), At(.23), 1, context);
+        var valid = builder.Add(RunTestData.State(245), At(.245), 2, context);
+        var expired = builder.Add(RunTestData.State(260), At(.26), 3, context);
+        Assert.False(beforePublication.IsDriving);
+        Assert.Null(beforePublication.WheelSpeedMetersPerSecond);
+        Assert.True(valid.IsDriving);
+        Assert.Equal(4, valid.WheelSpeedMetersPerSecond);
+        Assert.False(expired.IsDriving);
+        Assert.True(expired.Segment > valid.Segment);
+        Assert.True(builder.HasGap);
+    }
+
+    [Fact]
+    public async Task IdleRefreshDoesNotContinuouslyDispatchAndMissingTelemetryCannotStart()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "WispRunTests", Guid.NewGuid().ToString("N"));
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, directory);
+        var notifications = 0;
+        service.StateChanged += (_, _) => notifications++;
+        for (var index = 0; index < 100; index++) service.RefreshStatus();
+        Assert.Equal(1, notifications);
+        Assert.False(service.CanStart);
+        Assert.False(service.Start());
+        Assert.False(Directory.Exists(directory));
+        Assert.Null(await service.StopAsync());
+    }
+
+    [Fact]
+    public async Task RecordsAllSamplesKeepsMenuGapAndIgnoresThrowingSubscribers()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "WispRunTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            await using var receiver = new TelemetryUdpReceiver();
+            var port = AvailablePort();
+            await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+            using var sender = new UdpClient(AddressFamily.InterNetwork);
+            await Send(0);
+            await WaitUntil(() => receiver.Latest is not null);
+            await using var service = new RunRecordingService(receiver, directory);
+            var savedEvents = 0;
+            service.StateChanged += (_, _) => throw new InvalidOperationException("Test subscriber");
+            service.RunSaved += _ => throw new InvalidOperationException("Test subscriber");
+            service.RunSaved += _ => savedEvents++;
+            service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468, DrivetrainType.RearWheelDrive, true, .35, .35));
+            Assert.True(service.Start());
+            await Send(10);
+            await Send(20, 0, false);
+            await Send(30, 9753, false);
+            await Send(40);
+            await Send(40, rpm: 7000);
+            await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == 40 && receiver.Latest.EngineRpm == 7000);
+            var run = await service.StopAsync();
+            Assert.NotNull(run);
+            Assert.Equal(3, run.Samples.Length);
+            Assert.Equal(new uint[] { 10, 40, 40 }, run.Samples.Select(sample => sample.State.GameTimestampMilliseconds));
+            Assert.Equal(run.Samples[1].ElapsedSeconds, run.Samples[2].ElapsedSeconds);
+            Assert.Equal(7000, run.Samples[2].State.EngineRpm);
+            Assert.True(run.Samples[1].Segment > run.Samples[0].Segment);
+            Assert.True(run.IsIncomplete);
+            Assert.Equal(2, run.RejectedDatagrams);
+            Assert.Equal(1, savedEvents);
+            Assert.Single(await service.Store.ListAsync());
+            await Send(50);
+            await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == 50);
+            Assert.True(receiver.IsRunning);
+
+            async Task Send(int time, int car = 2468, bool driving = true, float rpm = 3000) =>
+                await sender.SendAsync(Packet(time, car, driving, rpm), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
+    public async Task StorageFailureLeavesReceiverRunningAndStartRequiresDrivingContext()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "WispRunTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var blocked = Path.Combine(directory, "file");
+        await File.WriteAllTextAsync(blocked, "preserved", TestContext.Current.CancellationToken);
+        try
+        {
+            await using var receiver = new TelemetryUdpReceiver();
+            var port = AvailablePort();
+            await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+            using var sender = new UdpClient(AddressFamily.InterNetwork);
+            await sender.SendAsync(Packet(0), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+            await WaitUntil(() => receiver.Latest is not null);
+            await using var service = new RunRecordingService(receiver, blocked);
+            Assert.True(service.CanStart);
+            Assert.False(service.Start());
+            Assert.Contains("confirmed driving scene", service.Status);
+            service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468, DrivetrainType.RearWheelDrive, true,
+                DrivingValidUntilTimestamp: Stopwatch.GetTimestamp() - 1));
+            Assert.False(service.Start());
+            Assert.True(service.CanStart);
+            service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468, DrivetrainType.RearWheelDrive, true));
+            Assert.True(service.Start());
+            await WaitUntil(() => service.Error is not null && !service.IsRecording && !service.IsPreparing);
+            await sender.SendAsync(Packet(100), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+            await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == 100);
+            Assert.True(receiver.IsRunning);
+            Assert.Equal("preserved", await File.ReadAllTextAsync(blocked, TestContext.Current.CancellationToken));
+        }
+        finally { Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
+    public async Task BusyStoreRejectsStartBeforeAttachingCaptureAndAllowsRetry()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "WispRunTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            await using var receiver = new TelemetryUdpReceiver();
+            var port = AvailablePort();
+            await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+            using var sender = new UdpClient(AddressFamily.InterNetwork);
+            await sender.SendAsync(Packet(0), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+            await WaitUntil(() => receiver.Latest is not null);
+            await using var service = new RunRecordingService(receiver, directory);
+            service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468, DrivetrainType.RearWheelDrive, true));
+            using (var reservation = service.Store.TryReserveJournalStart())
+            {
+                Assert.NotNull(reservation);
+                Assert.False(service.Start());
+                Assert.Contains("still being read or written", service.Status);
+                Assert.False(service.IsRecording);
+                Assert.False(Directory.Exists(directory));
+                var probe = receiver.BeginRunCapture(2);
+                receiver.EndRunCapture(probe);
+                await sender.SendAsync(Packet(10), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+                await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == 10);
+            }
+            service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468, DrivetrainType.RearWheelDrive, true));
+            Assert.True(service.Start());
+            await sender.SendAsync(Packet(20), new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+            await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == 20);
+            Assert.NotNull(await service.StopAsync());
+            Assert.True(receiver.IsRunning);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    }
+
+    [Fact]
+    public void LargeGameClockJumpUsesReceiptTimeAndSplitsTheRun()
+    {
+        var start = Stopwatch.GetTimestamp();
+        var builder = new RunSampleBuilder(start);
+        var context = new RunRecordingContext(start, 2468, DrivetrainType.RearWheelDrive, true);
+        var first = builder.Add(RunTestData.State(100), start, 1, context);
+        var jump = builder.Add(RunTestData.State(6100), start + Stopwatch.Frequency / 100, 2, context);
+        Assert.InRange(jump.ElapsedSeconds, .009, .011);
+        Assert.True(jump.Segment > first.Segment);
+    }
+
+    private static byte[] Packet(int time, int car = 2468, bool driving = true, float rpm = 3000)
+    {
+        var bytes = new byte[324];
+        Write(0, driving ? 1 : 0);
+        Write(4, time);
+        Write(8, BitConverter.SingleToInt32Bits(8000));
+        Write(16, BitConverter.SingleToInt32Bits(rpm));
+        Write(212, car);
+        Write(224, 1);
+        Write(228, 8);
+        Write(256, BitConverter.SingleToInt32Bits(10));
+        for (var offset = 100; offset <= 112; offset += 4) Write(offset, BitConverter.SingleToInt32Bits(10));
+        bytes[319] = 1;
+        return bytes;
+        void Write(int offset, int value) => BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset, 4), value);
+    }
+
+    private static int AvailablePort()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (!predicate() && DateTime.UtcNow < deadline) await Task.Delay(5, TestContext.Current.CancellationToken);
+        Assert.True(predicate());
+    }
+}

--- a/tests/Wisp.App.Tests/RunStoreTests.cs
+++ b/tests/Wisp.App.Tests/RunStoreTests.cs
@@ -1,0 +1,202 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text.Json;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunStoreTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "WispRunTests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task SavedLibraryMetadataDeleteAndRestorePreserveSamples()
+    {
+        var store = new RunStore(_directory);
+        var run = RunTestData.CreateRun();
+        await store.SaveAsync(run);
+        var summary = Assert.Single(await store.ListAsync());
+        Assert.Equal(run.Id, summary.Id);
+        Assert.Equal(2, summary.SampleCount);
+        var loaded = await store.LoadAsync(run.Id);
+        Assert.Equal(run.Samples, loaded.Samples);
+        await store.UpdateMetadataAsync(run.Id, "  Wet drift  ", "Road tune", "Two laps\nSame tires");
+        Assert.Equal("Wet drift", (await store.LoadAsync(run.Id)).Name);
+        await store.DeleteAsync(run.Id);
+        Assert.Empty(await store.ListAsync());
+        Assert.True(File.Exists(Path.Combine(_directory, "Deleted", $"{run.Id:N}.wisprun")));
+        await store.RestoreAsync(run.Id);
+        Assert.Equal(run.Samples, (await store.LoadAsync(run.Id)).Samples);
+    }
+
+    [Fact]
+    public async Task ExportAndImportUseNewIdentityAndNeverOverwriteDestination()
+    {
+        var store = new RunStore(_directory);
+        var run = RunTestData.CreateRun();
+        await store.SaveAsync(run);
+        var export = Path.Combine(_directory, $"{Guid.NewGuid():N}.wisprun");
+        await store.ExportAsync(run.Id, export);
+        var original = await File.ReadAllBytesAsync(export, TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<IOException>(() => store.ExportAsync(run.Id, export));
+        Assert.Equal(original, await File.ReadAllBytesAsync(export, TestContext.Current.CancellationToken));
+        var imported = await store.ImportAsync(export);
+        Assert.NotEqual(run.Id, imported.Id);
+        Assert.Equal(run.Samples, (await store.LoadAsync(imported.Id)).Samples);
+    }
+
+    [Fact]
+    public async Task BadMetadataNeverReplacesExistingRun()
+    {
+        var store = new RunStore(_directory);
+        var run = RunTestData.CreateRun();
+        await store.SaveAsync(run);
+        await Assert.ThrowsAsync<InvalidDataException>(() => store.UpdateMetadataAsync(run.Id, "bad\0name", "", ""));
+        Assert.Equal(run.Name, (await store.LoadAsync(run.Id)).Name);
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.tmp"));
+    }
+
+    [Fact]
+    public async Task CorruptSummaryIsRebuiltFromTheSavedRun()
+    {
+        var store = new RunStore(_directory);
+        var run = RunTestData.CreateRun();
+        await store.SaveAsync(run);
+        await File.WriteAllTextAsync(Path.Combine(_directory, $"{run.Id:N}.summary.json"), "{broken", TestContext.Current.CancellationToken);
+        var summary = Assert.Single(await store.ListAsync());
+        Assert.Equal(run.Id, summary.Id);
+        Assert.Equal(run.Samples, (await store.LoadAsync(run.Id)).Samples);
+    }
+
+    [Theory]
+    [InlineData("version")]
+    [InlineData("nonfinite")]
+    [InlineData("time")]
+    [InlineData("calibration")]
+    [InlineData("car")]
+    [InlineData("missing")]
+    public async Task InvalidImportIsRejectedBeforeAnyLibraryWrite(string kind)
+    {
+        Directory.CreateDirectory(_directory);
+        var run = RunTestData.CreateRun();
+        run = kind switch
+        {
+            "version" => run with { SchemaVersion = 100 },
+            "nonfinite" => run with { Samples = [run.Samples[0] with { ElapsedSeconds = double.NaN }] },
+            "time" => run with { Samples = [run.Samples[1], run.Samples[0]] },
+            "calibration" => run with { Samples = [run.Samples[0] with { WheelSpeedMetersPerSecond = 50, FrontRadiusMeters = .35, RearRadiusMeters = .35 }] },
+            "car" => run with { Samples = [run.Samples[0], run.Samples[1] with { State = run.Samples[1].State with { CarOrdinal = 2 } }] },
+            _ => run with { Samples = [null!] }
+        };
+        var source = Path.Combine(_directory, "invalid.wisprun");
+        var options = new JsonSerializerOptions(RunStore.JsonOptions) { NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals };
+        await using (var file = File.Create(source))
+        await using (var gzip = new GZipStream(file, CompressionLevel.Fastest))
+        await using (var writer = new StreamWriter(gzip))
+        {
+            await writer.WriteLineAsync(JsonSerializer.Serialize(run with { Samples = [] }, options));
+            foreach (var sample in run.Samples) await writer.WriteLineAsync(JsonSerializer.Serialize(sample, options));
+        }
+        var store = new RunStore(Path.Combine(_directory, "library"));
+        var error = await Record.ExceptionAsync(() => store.ImportAsync(source));
+        Assert.True(error is InvalidDataException or JsonException);
+        Assert.Empty(await store.ListAsync());
+    }
+
+    [Fact]
+    public async Task OversizeInputIsRejectedWithoutReadingItsPayload()
+    {
+        Directory.CreateDirectory(_directory);
+        var source = Path.Combine(_directory, "oversize.wisprun");
+        using (var file = File.Create(source)) file.SetLength(RunStore.MaximumFileBytes + 1);
+        var store = new RunStore(Path.Combine(_directory, "library"));
+        await Assert.ThrowsAsync<InvalidDataException>(() => store.ImportAsync(source));
+        Assert.Empty(await store.ListAsync());
+    }
+
+    [Fact]
+    public async Task PartialJournalRecoversCompletePrefixAndMarksItIncomplete()
+    {
+        var run = RunTestData.CreateRun();
+        var store = new RunStore(_directory);
+        await using (var journal = store.CreateJournal(run with { Samples = [] }))
+        {
+            await journal.AppendAsync(run.Samples[0]);
+            await journal.AppendAsync(run.Samples[1]);
+            await journal.FlushAsync();
+            Assert.Empty(await store.ListAsync());
+        }
+        await File.AppendAllTextAsync(Path.Combine(_directory, $"{run.Id:N}.partial"), "{\"elapsedSeconds\":", TestContext.Current.CancellationToken);
+        var recoveredStore = new RunStore(_directory);
+        var summary = Assert.Single(await recoveredStore.ListAsync());
+        Assert.True(summary.IsIncomplete);
+        Assert.Contains("Recovered", summary.FinishReason);
+        Assert.Equal(run.Samples, (await recoveredStore.LoadAsync(run.Id)).Samples);
+        Assert.False(File.Exists(Path.Combine(_directory, $"{run.Id:N}.partial")));
+    }
+
+    [Fact]
+    public async Task ActiveJournalCannotBeRecoveredOrDuplicateItsCompletedRun()
+    {
+        var run = RunTestData.CreateRun();
+        var store = new RunStore(_directory);
+        await using var journal = store.CreateJournal(run with { Samples = [] });
+        await journal.AppendAsync(run.Samples[0]);
+        await journal.FlushAsync();
+        Assert.Empty(await store.ListAsync());
+        await store.SaveAsync(run);
+        Assert.Single(await store.ListAsync());
+        Assert.False((await store.LoadAsync(run.Id)).IsIncomplete);
+    }
+
+    [Fact]
+    public async Task FullLibraryRejectsAdditionalRecordingAndKeepsExistingFiles()
+    {
+        Directory.CreateDirectory(_directory);
+        for (var index = 0; index < RunStore.MaximumLibraryEntries; index++)
+            await File.WriteAllTextAsync(Path.Combine(_directory, $"{Guid.NewGuid():N}.wisprun"), "retained", TestContext.Current.CancellationToken);
+        var store = new RunStore(_directory);
+        Assert.Throws<RunLibraryFullException>(() => store.CreateJournal(RunTestData.CreateRun() with { Samples = [] }));
+        Assert.True(store.IsFull);
+        Assert.Equal(RunStore.MaximumLibraryEntries, Directory.EnumerateFiles(_directory, "*.wisprun").Count());
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.partial"));
+    }
+
+    public void Dispose() { if (Directory.Exists(_directory)) Directory.Delete(_directory, recursive: true); }
+}
+
+internal static class RunTestData
+{
+    internal static VehicleState State(uint time = 0) => new()
+    {
+        IsRaceOn = true,
+        GameTimestampMilliseconds = time,
+        ReceivedAtUtc = DateTimeOffset.UtcNow,
+        CarOrdinal = 2468,
+        Drivetrain = DrivetrainType.RearWheelDrive,
+        NumCylinders = 8,
+        GroundSpeedMetersPerSecond = 10,
+        WheelRotationRadiansPerSecond = new(10, 10, 10, 10),
+        TireSlipRatio = default,
+        TireSlipAngle = default,
+        NormalizedSuspensionTravel = default,
+        LateralAccelerationMetersPerSecondSquared = 0,
+        LongitudinalAccelerationMetersPerSecondSquared = 0,
+        EngineRpm = 3000,
+        EngineMaximumRpm = 8000,
+        Gear = TransmissionGear.First,
+        Steering = 0,
+        Accelerator = 128,
+        Brake = 0
+    };
+    internal static RecordedRun CreateRun() => new()
+    {
+        Name = "Test run",
+        StartedAtUtc = DateTimeOffset.UtcNow,
+        FinishReason = "Stopped by you",
+        Samples = [new() { State = State(), ElapsedSeconds = 0, IsDriving = true }, new() { State = State(100), ElapsedSeconds = .1, IsDriving = true }]
+    };
+}

--- a/tests/Wisp.App.Tests/RunWorkflowTests.cs
+++ b/tests/Wisp.App.Tests/RunWorkflowTests.cs
@@ -1,0 +1,238 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.ExceptionServices;
+using System.Windows.Threading;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Wisp.Telemetry;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunWorkflowTests
+{
+    [Fact]
+    public void RecordStopLibraryAndComparisonSurviveAServiceAndViewModelRestart() => OnDispatcher(async () =>
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "Wisp.RunWorkflowTests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var settings = new AppSettings { SpeedUnit = SpeedUnit.KilometersPerHour };
+            Guid baselineId;
+            Guid revisedId;
+            await using (var receiver = new TelemetryUdpReceiver())
+            await using (var service = new RunRecordingService(receiver, directory))
+            using (var model = new RunsViewModel(service, settings, Dispatcher.CurrentDispatcher))
+            using (var sender = new UdpClient(AddressFamily.InterNetwork))
+            {
+                var endpoint = new IPEndPoint(IPAddress.Loopback, AvailablePort());
+                await receiver.StartAsync(endpoint.Port, TestContext.Current.CancellationToken);
+                await model.InitializeAsync();
+                model.SetPageVisible(true);
+                model.BeforeStart = PublishContext;
+                RecordedRun? deliveredRun = null;
+                service.RunSaved += run => deliveredRun = run;
+
+                baselineId = await RecordRun(1000, 1, "Baseline", "Road tune", 1);
+                revisedId = await RecordRun(4000, 2, "Revised", "Shorter gearing", 2);
+                Assert.NotEqual(baselineId, revisedId);
+                Assert.Equal(2, Directory.EnumerateFiles(directory, "*.wisprun").Count());
+                Assert.Empty(Directory.EnumerateFiles(directory, "*.partial"));
+                Assert.True(receiver.IsRunning);
+
+                async Task<Guid> RecordRun(int gameStart, int slope, string name, string tune, int expectedLibraryCount)
+                {
+                    await Send(gameStart - 100, 10, 1000);
+                    await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == gameStart - 100);
+                    model.RefreshStatus();
+                    Assert.True(model.ToggleRecordingCommand.CanExecute(null));
+                    await model.ToggleRecordingAsync();
+                    Assert.True(model.IsRecording, model.Error);
+                    Assert.False(model.CanManageLibrary);
+
+                    for (var index = 0; index <= 20; index++)
+                    {
+                        await Send(gameStart + index * 100, 10 + index * slope, 1000 + index * 100);
+                        if (index == 10) await Send(gameStart + index * 100, 10 + index * slope, 2050);
+                    }
+                    await WaitUntil(() => receiver.Latest?.GameTimestampMilliseconds == gameStart + 2000);
+                    await model.ToggleRecordingAsync();
+                    await WaitUntil(() => model.Library.Count == expectedLibraryCount && model.SelectedRun is not null &&
+                        model.HasRun && !model.IsBusy && model.Metrics.Count > 0 && model.Charts.Count > 0 &&
+                        model.SelectedRun.Id == model.Library[0].Id);
+                    Assert.False(model.HasError, model.Error);
+                    Assert.True(model.CanManageRun);
+                    Assert.NotNull(deliveredRun);
+                    Assert.Same(deliveredRun, typeof(RunsViewModel).GetField("_runA", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(model));
+                    Assert.Equal("2.0s", Metric(model, "Recorded time").Value);
+                    Assert.Equal("0", Metric(model, "Telemetry gaps").Value);
+                    Assert.Equal(slope == 1 ? "108.0 km/h" : "180.0 km/h", Metric(model, "Peak ground speed").Value);
+
+                    var id = model.SelectedRun!.Id;
+                    model.Name = name;
+                    model.Tune = tune;
+                    model.Notes = "Same car and tire calibration.";
+                    await model.SaveDetailsAsync();
+                    Assert.False(model.HasError, model.Error);
+                    Assert.StartsWith("A · " + name, model.RunALabel);
+                    var saved = await service.Store.LoadAsync(id);
+                    AssertRecordedData(saved, gameStart, slope);
+                    Assert.Equal(tune, saved.Tune);
+                    return id;
+                }
+
+                void PublishContext() => service.UpdateContext(new(Stopwatch.GetTimestamp(), 2468,
+                    DrivetrainType.RearWheelDrive, true, .35, .35));
+
+                async Task Send(int gameTime, float speed, float rpm)
+                {
+                    PublishContext();
+                    await sender.SendAsync(Packet(gameTime, speed, rpm), endpoint, TestContext.Current.CancellationToken);
+                }
+            }
+
+            await using var reopenedReceiver = new TelemetryUdpReceiver();
+            await using var reopenedService = new RunRecordingService(reopenedReceiver, directory);
+            using var reopened = new RunsViewModel(reopenedService, settings, Dispatcher.CurrentDispatcher);
+            await reopened.InitializeAsync();
+            reopened.SetPageVisible(true);
+            Assert.Equal(2, reopened.Library.Count);
+            var baseline = Assert.Single(reopened.Library, item => item.Id == baselineId);
+            var revised = Assert.Single(reopened.Library, item => item.Id == revisedId);
+            Assert.Equal("Road tune", baseline.Tune);
+            Assert.Equal("Shorter gearing", revised.Tune);
+            reopened.SelectedRun = revised;
+            await WaitUntil(() => reopened.HasRun && !reopened.IsBusy && reopened.Charts.Count > 0);
+            Assert.False(reopened.HasError, reopened.Error);
+            Assert.Equal("Revised", reopened.Name);
+            Assert.Equal("Same car and tire calibration.", reopened.Notes);
+
+            reopened.ComparisonChoice = baseline;
+            Assert.True(reopened.CompareCommand.CanExecute(null));
+            reopened.CompareCommand.Execute(null);
+            await ComparisonReady();
+            AssertComparison(reopened);
+
+            reopened.RemoveComparisonCommand.Execute(null);
+            await WaitUntil(() => !reopened.HasComparison && !reopened.IsBusy);
+            Assert.True(reopened.ComparePreviousCommand.CanExecute(null));
+            reopened.ComparePreviousCommand.Execute(null);
+            await ComparisonReady();
+            AssertComparison(reopened);
+            Assert.Equal(revisedId, reopened.SelectedRun!.Id);
+            AssertRecordedData(await reopenedService.Store.LoadAsync(baselineId), 1000, 1);
+            AssertRecordedData(await reopenedService.Store.LoadAsync(revisedId), 4000, 2);
+
+            Task ComparisonReady() => WaitUntil(() => reopened.HasComparison && !reopened.IsBusy &&
+                reopened.Metrics.Any(metric => metric.Comparison is not null) &&
+                reopened.Charts.SelectMany(panel => panel.Series).Any(series => series.Comparison));
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    });
+
+    private static void AssertComparison(RunsViewModel model)
+    {
+        Assert.False(model.HasError, model.Error);
+        Assert.StartsWith("A · Revised", model.RunALabel);
+        Assert.StartsWith("B · Baseline", model.RunBLabel);
+        var peak = Metric(model, "Peak ground speed");
+        Assert.Equal("180.0 km/h", peak.Value);
+        Assert.Equal("108.0 km/h (-72.0 km/h)", peak.Comparison);
+        var average = Metric(model, "Average car speed");
+        Assert.Equal("108.0 km/h", average.Value);
+        Assert.Equal("72.0 km/h (-36.0 km/h)", average.Comparison);
+        Assert.Contains("routes", model.ComparisonNote);
+        var speed = Assert.Single(model.Charts);
+        Assert.Equal("km/h", speed.Unit);
+        Assert.Equal(180, Assert.Single(speed.Series, series => !series.Comparison && series.ColorIndex == 0).Points[^1].Value, 5);
+        Assert.Equal(108, Assert.Single(speed.Series, series => series.Comparison && series.ColorIndex == 0).Points[^1].Value, 5);
+    }
+
+    private static void AssertRecordedData(RecordedRun run, int gameStart, int slope)
+    {
+        Assert.False(run.IsIncomplete);
+        Assert.Equal(0, run.DroppedDatagrams);
+        Assert.Equal(0, run.RejectedDatagrams);
+        Assert.Equal(22, run.Samples.Length);
+        Assert.Equal(2, run.Samples[^1].ElapsedSeconds, 6);
+        Assert.All(run.Samples, sample =>
+        {
+            Assert.True(sample.IsDriving);
+            Assert.Equal(0, sample.Segment);
+            Assert.Equal(2468, sample.State.CarOrdinal);
+            Assert.Null(sample.State.ReceivedTimestamp);
+            Assert.Equal(.35, sample.FrontRadiusMeters);
+            Assert.Equal(.35, sample.RearRadiusMeters);
+            Assert.InRange(Math.Abs(sample.WheelSpeedMetersPerSecond!.Value - sample.State.GroundSpeedMetersPerSecond), 0, .00001);
+        });
+        var duplicate = run.Samples.Where(sample => sample.State.GameTimestampMilliseconds == gameStart + 1000).ToArray();
+        Assert.Equal(2, duplicate.Length);
+        Assert.Equal(duplicate[0].ElapsedSeconds, duplicate[1].ElapsedSeconds);
+        Assert.Equal(2050, duplicate[1].State.EngineRpm);
+        Assert.Equal(10 + 20 * slope, run.Samples[^1].State.GroundSpeedMetersPerSecond);
+    }
+
+    private static RunMetric Metric(RunsViewModel model, string label) => Assert.Single(model.Metrics, metric => metric.Label == label);
+
+    private static byte[] Packet(int gameTime, float speed, float rpm)
+    {
+        var bytes = new byte[324];
+        Write(0, 1);
+        Write(4, gameTime);
+        Write(8, BitConverter.SingleToInt32Bits(8000));
+        Write(16, BitConverter.SingleToInt32Bits(rpm));
+        Write(212, 2468);
+        Write(224, 1);
+        Write(228, 8);
+        Write(256, BitConverter.SingleToInt32Bits(speed));
+        Write(260, BitConverter.SingleToInt32Bits(150000));
+        Write(264, BitConverter.SingleToInt32Bits(300));
+        for (var offset = 100; offset <= 112; offset += 4) Write(offset, BitConverter.SingleToInt32Bits(speed / .35f));
+        for (var offset = 268; offset <= 280; offset += 4) Write(offset, BitConverter.SingleToInt32Bits(212));
+        bytes[315] = 255;
+        bytes[319] = 3;
+        return bytes;
+        void Write(int offset, int value) => BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset, 4), value);
+    }
+
+    private static int AvailablePort()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private static async Task WaitUntil(Func<bool> ready)
+    {
+        var deadline = Stopwatch.GetTimestamp() + Stopwatch.Frequency * 4;
+        while (!ready() && Stopwatch.GetTimestamp() < deadline) await Task.Delay(5, TestContext.Current.CancellationToken);
+        Assert.True(ready(), "The real recording workflow did not reach the expected state within four seconds.");
+    }
+
+    private static void OnDispatcher(Func<Task> test)
+    {
+        Exception? failure = null;
+        using var finished = new ManualResetEventSlim();
+        var thread = new Thread(() =>
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var dispatcher = Dispatcher.CurrentDispatcher;
+            _ = dispatcher.InvokeAsync(async () =>
+            {
+                try { await test(); }
+                catch (Exception error) { failure = error; }
+                finally { dispatcher.BeginInvokeShutdown(DispatcherPriority.Send); finished.Set(); }
+            });
+            Dispatcher.Run();
+        })
+        { IsBackground = true };
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(20)), "Recording workflow exceeded its bounded dispatcher deadline.");
+        if (failure is not null) ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+}

--- a/tests/Wisp.App.Tests/RunsViewModelTests.cs
+++ b/tests/Wisp.App.Tests/RunsViewModelTests.cs
@@ -1,0 +1,459 @@
+using System.Runtime.ExceptionServices;
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Windows.Threading;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+using Wisp.Telemetry;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class RunsViewModelTests
+{
+    [Fact]
+    public void GraphNavigationPreservesTheReviewAndNewRunsReturnToSummary() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        model.ShowGraphs();
+        Assert.True(model.IsSummaryVisible); Assert.False(model.IsGraphWorkspaceOpen);
+        await model.ShowReviewAsync(Run("Baseline", 0, 4), Run("Revised", 0, 4));
+        model.SelectInterval(.5, 1.5); await Ready(model);
+        model.SelectedGraph = model.GraphChoices.Single(choice => choice.Mode == RunPlotMode.PowerByRpm);
+        await Ready(model);
+        var metrics = model.Metrics.ToArray();
+        model.ShowGraphs(); Assert.True(model.IsGraphWorkspaceOpen); Assert.False(model.IsSummaryVisible);
+        model.ShowSummary(); Assert.True(model.IsSummaryVisible);
+        model.ShowGraphs();
+        Assert.Equal(RunPlotMode.PowerByRpm, model.SelectedGraph.Mode);
+        Assert.True(model.HasComparison); Assert.True(model.HasSelection);
+        Assert.Equal(metrics, model.Metrics.ToArray());
+        await model.ShowReviewAsync(Run("Next run", 0, 3));
+        Assert.True(model.IsSummaryVisible); Assert.False(model.IsGraphWorkspaceOpen);
+        Assert.False(model.HasComparison); Assert.False(model.HasSelection);
+    });
+
+    [Fact]
+    public void IdleWithoutTelemetryExplainsWhyRecordingIsUnavailable() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        model.RefreshStatus();
+        Assert.False(model.CanToggleRecording);
+        Assert.False(model.ToggleRecordingCommand.CanExecute(null));
+        Assert.Contains("Open Forza and return to free roam", model.RecordingStatus);
+        Assert.DoesNotContain("Ready to record", model.RecordingStatus);
+        Assert.False(service.Start());
+        Assert.Equal(service.Status, model.RecordingStatus);
+    });
+
+    [Fact]
+    public void ADisplayedReportCannotBeRelabeledWhileRecordingOrCountingDown() => OnDispatcher(async () =>
+    {
+        await WithLiveReceiver(async (receiver, refreshTelemetry) =>
+        {
+            await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+            var clock = new ManualClock();
+            using var model = new RunsViewModel(service, new AppSettings { RecordingCountdownSeconds = 3 }, Dispatcher.CurrentDispatcher, clock);
+            model.BeforeStart = () => service.UpdateContext(new(Stopwatch.GetTimestamp(), 1, DrivetrainType.RearWheelDrive, true));
+            await model.ShowReviewAsync(Run("Original A", 0, 2), Run("Original B", 0, 3));
+            model.ChartGroup = RunChartGroup.Engine; model.GraphView = model.AvailableGraphViews[1]; await Ready(model);
+            var metrics = model.Metrics.ToArray(); var runId = model.SelectedRun!.Id; var comparison = model.ComparisonChoice;
+            await refreshTelemetry(); await model.ToggleRecordingAsync(); Assert.True(model.IsCountingDown);
+            AssertUnchanged();
+            await refreshTelemetry(); clock.Advance(TimeSpan.FromSeconds(3)); model.RefreshStatus(); Assert.True(model.IsRecording, model.Error);
+            AssertUnchanged();
+
+            void AssertUnchanged()
+            {
+                Assert.False(model.RemoveComparisonCommand.CanExecute(null)); Assert.False(model.ApplyIntervalCommand.CanExecute(null));
+                Assert.False(model.ApplySpeedRangeCommand.CanExecute(null)); Assert.False(model.CanManageRun);
+                model.RemoveComparisonCommand.Execute(null); model.SelectInterval(.5, 1.5); model.SameSpeed = true;
+                model.Purpose = RunPurpose.Drifting; model.FromSpeed = "5"; model.ToSpeed = "15";
+                model.SelectionFrom = "7"; model.SelectionTo = "8";
+                model.Name = "Changed"; model.Tune = "Changed"; model.Notes = "Changed";
+                model.SelectedRun = model.Library.Single(item => item.Id != runId); model.ComparisonChoice = model.SelectedRun;
+                model.GraphView = model.AvailableGraphViews[0]; model.ChartGroup = RunChartGroup.Handling;
+                model.SelectedGraph = model.GraphChoices[0];
+                model.FullThrottleOnly = false; model.GearFilter = model.GearOptions[1];
+                Assert.True(model.HasComparison); Assert.False(model.HasSelection); Assert.False(model.SameSpeed);
+                Assert.Equal(RunPurpose.General, model.Purpose); Assert.Equal("20", model.FromSpeed); Assert.Equal("60", model.ToSpeed);
+                Assert.Equal("0", model.SelectionFrom); Assert.Equal("0", model.SelectionTo);
+                Assert.Equal("Original A", model.Name); Assert.Empty(model.Tune); Assert.Empty(model.Notes);
+                Assert.Equal(runId, model.SelectedRun!.Id); Assert.Equal(comparison, model.ComparisonChoice);
+                Assert.Equal(RunChartGroup.Engine, model.ChartGroup); Assert.Equal(RunPlotMode.PowerByRpm, model.GraphView.Mode);
+                Assert.True(model.FullThrottleOnly); Assert.Null(model.GearFilter.Gear);
+                Assert.Equal(metrics, model.Metrics.ToArray()); Assert.Equal("Whole run", model.IntervalLabel);
+                Assert.All(model.Findings, finding => Assert.False(finding.ShowCommand.CanExecute(null)));
+                model.CursorSeconds = .5; Assert.Equal(.5, model.CursorSeconds);
+                Assert.True(model.ResetViewCommand.CanExecute(null)); model.ResetViewCommand.Execute(null); Assert.Equal(0, model.ViewStart);
+            }
+        });
+    });
+
+    [Fact]
+    public void CountdownStartsAtItsDeadlineWithFreshContextAndKeepsStopAvailable() => OnDispatcher(async () =>
+    {
+        await WithLiveReceiver(async (receiver, refreshTelemetry) =>
+        {
+            var directory = TemporaryDirectory();
+            await using var service = new RunRecordingService(receiver, directory);
+            var clock = new ManualClock();
+            using var model = new RunsViewModel(service, new AppSettings { RecordingCountdownSeconds = 3, RecordingStopAfterSeconds = 30 }, Dispatcher.CurrentDispatcher, clock);
+            var starts = 0;
+            model.BeforeStart = () => { starts++; service.UpdateContext(new(Stopwatch.GetTimestamp(), 1, DrivetrainType.RearWheelDrive, true)); };
+            var arming = model.ToggleRecordingAsync();
+            Assert.True(arming.IsCompleted); await arming;
+            Assert.True(model.IsCountingDown); Assert.False(model.CanManageLibrary); Assert.False(model.CanEditRecordingOptions);
+            Assert.True(model.ToggleRecordingCommand.CanExecute(null)); Assert.False(model.CanMarkMoment); Assert.Equal(0, starts);
+            clock.Advance(TimeSpan.FromSeconds(2.9)); model.RefreshStatus();
+            Assert.Equal(1, model.CountdownRemainingSeconds); Assert.False(model.IsRecording);
+            await refreshTelemetry(); clock.Advance(TimeSpan.FromSeconds(.1)); model.RefreshStatus();
+            Assert.False(model.IsCountingDown); Assert.True(model.IsRecording, model.Error); Assert.Equal(1, starts);
+            Assert.True(model.ToggleRecordingCommand.CanExecute(null)); Assert.True(model.CanMarkMoment);
+            Assert.Contains("stops at 30.0s", model.RecordingStatus);
+            await refreshTelemetry(); model.RefreshStatus(); Assert.Equal(1, starts);
+        });
+    });
+
+    [Theory]
+    [InlineData("button")]
+    [InlineData("suspend")]
+    [InlineData("telemetry")]
+    [InlineData("dispose")]
+    public void CountdownCancellationNeverStartsARecording(string cause) => OnDispatcher(async () =>
+    {
+        await WithLiveReceiver(async (receiver, _) =>
+        {
+            var directory = TemporaryDirectory();
+            await using var service = new RunRecordingService(receiver, directory);
+            var clock = new ManualClock();
+            using var model = new RunsViewModel(service, new AppSettings { RecordingCountdownSeconds = 3 }, Dispatcher.CurrentDispatcher, clock);
+            var starts = 0; model.BeforeStart = () => starts++;
+            await model.ToggleRecordingAsync(); Assert.True(model.IsCountingDown);
+            switch (cause)
+            {
+                case "button": await model.ToggleRecordingAsync(); break;
+                case "suspend": model.SuspendHotkeyStatus(); break;
+                case "telemetry": await receiver.StopAsync(); model.RefreshStatus(); break;
+                case "dispose": model.Dispose(); break;
+            }
+            clock.Advance(TimeSpan.FromSeconds(10)); model.RefreshStatus();
+            Assert.False(model.IsCountingDown); Assert.False(model.IsRecording); Assert.Equal(0, starts);
+            Assert.False(Directory.Exists(directory));
+        });
+    });
+
+    [Fact]
+    public void MarkerJumpUsesTheCorrectRunsMatchedOrigin() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        var a = Run("A", 3, 5); var b = Run("B", 7, 8);
+        var factor = RunPresentation.SpeedFactor(SpeedUnit.MilesPerHour);
+        var matchA = RunAnalysis.MeasureAcceleration(a, 20 / factor, 60 / factor)!;
+        var matchB = RunAnalysis.MeasureAcceleration(b, 20 / factor, 60 / factor)!;
+        a = a with { Markers = [new(.1, "Outside"), new(matchA.Interval.StartSeconds + .5, "A marker")] };
+        b = b with { Markers = [new(matchB.Interval.StartSeconds + 1, "B marker")] };
+        await model.ShowReviewAsync(a, b); model.SameSpeed = true; await Ready(model);
+        Assert.Equal(2, model.Markers.Count); Assert.Equal(2, model.PlotMarkers.Length);
+        Assert.Equal("A marker", Assert.Single(model.PlotMarkers, item => !item.Comparison).Label);
+        Assert.Equal("B marker", Assert.Single(model.PlotMarkers, item => item.Comparison).Label);
+        Assert.Equal("B · B marker", Assert.Single(model.Markers, item => item.Comparison).Label);
+        var marker = Assert.Single(model.Markers, item => item.Comparison);
+        Assert.Equal(1, marker.Seconds, 6); marker.JumpCommand.Execute(null);
+        Assert.Equal(1, model.CursorSeconds, 6); Assert.InRange(model.CursorSeconds, model.ViewStart, model.ViewEnd);
+        Assert.True(model.IsTimeGraph);
+    });
+
+    [Fact]
+    public void AlternativePointPreservesTheSelectedDuplicateAndItsRunIdentity() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        var a = Run("A", 0, 1);
+        var b = Run("B", 0, 1) with
+        {
+            Samples = [RunPresentationTests.Sample(0, 1000), RunPresentationTests.Sample(.1, 6200),
+                RunPresentationTests.Sample(.1, 7000), RunPresentationTests.Sample(.2, 7500)]
+        };
+        await model.ShowReviewAsync(a, b);
+        model.SelectAlternativePoint(new(true, .1, 1));
+        Assert.Equal(.1, model.CursorSeconds);
+        Assert.Contains("Selected point · B", model.SelectedPointContext);
+        Assert.Contains(6200.ToString("N0") + " RPM", model.SelectedPointContext);
+        Assert.DoesNotContain(7000.ToString("N0") + " RPM", model.SelectedPointContext);
+        model.CursorSeconds = .2; Assert.Empty(model.SelectedPointContext);
+        model.SelectAlternativePoint(new(true, .1, 1));
+        await model.ShowReviewAsync(a); Assert.Empty(model.SelectedPointContext);
+    });
+
+    [Fact]
+    public void GraphChoicesKeepTheLatestModeAndDoNotChangeReportStatistics() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        await model.ShowReviewAsync(Run("Engine", 0, 2));
+        var before = model.Metrics.ToArray();
+        model.ChartGroup = RunChartGroup.Engine;
+        model.GraphView = model.AvailableGraphViews[1];
+        model.FullThrottleOnly = false;
+        model.GearFilter = model.GearOptions.Single(option => option.Gear == TransmissionGear.Third);
+        model.ChartGroup = RunChartGroup.Handling;
+        model.GraphView = model.AvailableGraphViews[1];
+        await Ready(model);
+        Assert.False(model.IsTimeGraph); Assert.False(model.IsRpmGraph);
+        Assert.Equal(RunPlotMode.GForce, model.GraphView.Mode);
+        Assert.NotEmpty(model.AlternativeCharts); Assert.Empty(model.Charts);
+        Assert.Equal(before, model.Metrics.ToArray());
+        model.ChartGroup = RunChartGroup.Speed; await Ready(model);
+        Assert.True(model.IsTimeGraph); Assert.Single(model.AvailableGraphViews);
+        Assert.Empty(model.AlternativeCharts); Assert.NotEmpty(model.Charts);
+    });
+
+    [Fact]
+    public void ShowMeSelectsTheRelevantChannelsAndInterval() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        var run = Run("Throttle test", 0, 1);
+        await model.ShowReviewAsync(run);
+        var finding = Assert.Single(model.Findings, item => item.Title == "Longest full-throttle stretch");
+        finding.ShowCommand.Execute(null); await Ready(model);
+        Assert.Equal(RunChartGroup.Inputs, model.ChartGroup);
+        Assert.True(model.HasSelection);
+        Assert.Equal(model.SelectionStart, model.ViewStart); Assert.Equal(model.SelectionEnd, model.ViewEnd);
+        Assert.Contains(model.Charts, chart => chart.Unit == "%"); Assert.Contains(model.Charts, chart => chart.Unit == "mph");
+        Assert.Contains("RPM", model.CursorVehicleContext); Assert.Contains("gear 3", model.CursorVehicleContext);
+    });
+
+    [Fact]
+    public void MatchedIntervalsAndSelectionsUseEachRunsOwnOrigin() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        var a = Run("Baseline", 3, 5); var b = Run("Revised", 7, 8);
+        await model.ShowReviewAsync(a, b, RunPurpose.Acceleration);
+        model.SameSpeed = true; await Ready(model);
+        Assert.True(model.SameSpeed);
+        var expectedA = RunAnalysis.MeasureAcceleration(a, 20 / RunPresentation.SpeedFactor(SpeedUnit.MilesPerHour), 60 / RunPresentation.SpeedFactor(SpeedUnit.MilesPerHour))!;
+        var expectedB = RunAnalysis.MeasureAcceleration(b, expectedA.FromMetersPerSecond, expectedA.ToMetersPerSecond)!;
+        var duration = Assert.Single(model.Metrics, metric => metric.Label == "Recorded time");
+        Assert.Equal(RunPresentation.Time(expectedA.DurationSeconds), duration.Value);
+        Assert.StartsWith(RunPresentation.Time(expectedB.DurationSeconds) + " (", duration.Comparison);
+        Assert.All(model.Charts[0].Series.Where(line => line.Comparison).SelectMany(line => line.Points), point =>
+            Assert.InRange(point.Seconds, 0, expectedB.DurationSeconds));
+
+        model.SelectInterval(.25, 1.25); await Ready(model);
+        duration = Assert.Single(model.Metrics, metric => metric.Label == "Recorded time");
+        Assert.Equal("1.0s", duration.Value); Assert.StartsWith("1.0s (", duration.Comparison);
+        Assert.DoesNotContain(model.Findings, finding => finding.Title.Contains("interval is missing", StringComparison.Ordinal));
+        var average = Assert.Single(model.Metrics, metric => metric.Label == "Average car speed");
+        Assert.NotEqual(average.Value, average.Comparison);
+    });
+
+    [Fact]
+    public void UnavailableRangeCanBeRetriedAndUnitsRemainCoherent() => OnDispatcher(async () =>
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, TemporaryDirectory());
+        var settings = new AppSettings();
+        using var model = new RunsViewModel(service, settings, Dispatcher.CurrentDispatcher);
+        await model.ShowReviewAsync(Run("A", 0, 1), Run("B", 1, 1.1));
+        model.SameSpeed = true; await Ready(model);
+        Assert.False(model.SameSpeed); Assert.Contains("unavailable", model.ComparisonNote);
+        model.FromSpeed = "5"; model.ToSpeed = "15"; model.ApplySpeedRangeCommand.Execute(null); await Ready(model);
+        Assert.True(model.SameSpeed);
+        var before = model.ViewEnd;
+        settings.SpeedUnit = SpeedUnit.KilometersPerHour; model.RefreshStatus(); await Ready(model);
+        Assert.Equal("km/h", model.SpeedUnitText);
+        Assert.InRange(Math.Abs(model.ViewEnd - before), 0, .01);
+        Assert.Contains("km/h", Assert.Single(model.Metrics, metric => metric.Label == "Average car speed").Value);
+    });
+
+    [Fact]
+    public void FailedSelectionRestoresTheDisplayedRunAndPreservesItsData() => OnDispatcher(async () =>
+    {
+        var directory = TemporaryDirectory();
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, directory);
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        try
+        {
+            var a = RunTestData.CreateRun() with { Name = "Retained run" };
+            var b = RunTestData.CreateRun() with { Name = "Unreadable run" };
+            await service.Store.SaveAsync(a); await service.Store.SaveAsync(b); await model.InitializeAsync();
+            model.SelectedRun = model.Library.Single(item => item.Id == a.Id); await Ready(model);
+            var metrics = model.Metrics.ToArray();
+            var original = await File.ReadAllBytesAsync(Path.Combine(directory, $"{a.Id:N}.wisprun"), TestContext.Current.CancellationToken);
+            await File.WriteAllTextAsync(Path.Combine(directory, $"{b.Id:N}.wisprun"), "damaged", TestContext.Current.CancellationToken);
+
+            model.SelectedRun = model.Library.Single(item => item.Id == b.Id);
+            await SelectionFailed(model);
+
+            Assert.Equal(a.Id, model.SelectedRun!.Id);
+            Assert.Equal("A · Retained run", model.RunALabel);
+            Assert.Equal("Retained run", model.Name);
+            Assert.Equal(metrics, model.Metrics.ToArray());
+            Assert.True(model.CanManageRun);
+            Assert.Equal(original, await File.ReadAllBytesAsync(Path.Combine(directory, $"{a.Id:N}.wisprun"), TestContext.Current.CancellationToken));
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    });
+
+    [Fact]
+    public void FailedFirstSelectionLeavesNoRunSelectedOrManageable() => OnDispatcher(async () =>
+    {
+        var directory = TemporaryDirectory();
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, directory);
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        try
+        {
+            var run = RunTestData.CreateRun();
+            await service.Store.SaveAsync(run); await model.InitializeAsync();
+            File.Delete(Path.Combine(directory, $"{run.Id:N}.wisprun"));
+
+            model.SelectedRun = Assert.Single(model.Library);
+            await SelectionFailed(model);
+
+            Assert.Null(model.SelectedRun);
+            Assert.False(model.HasRun); Assert.False(model.CanManageRun);
+            Assert.False(model.SaveDetailsCommand.CanExecute(null));
+            Assert.False(model.CompareCommand.CanExecute(null));
+            Assert.Empty(model.RunALabel); Assert.Empty(model.Metrics);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    });
+
+    [Fact]
+    public void ComparePreviousUsesAnEarlierRunAndStaysUnavailableForTheOldest() => OnDispatcher(async () =>
+    {
+        var directory = TemporaryDirectory();
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, directory);
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        try
+        {
+            var first = RunTestData.CreateRun() with { Name = "First", StartedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-2) };
+            var second = RunTestData.CreateRun() with { Name = "Second", StartedAtUtc = first.StartedAtUtc.AddMinutes(1) };
+            await service.Store.SaveAsync(first); await service.Store.SaveAsync(second); await model.InitializeAsync();
+            model.SelectedRun = model.Library.Single(item => item.Id == first.Id); await Ready(model);
+
+            Assert.False(model.ComparePreviousCommand.CanExecute(null));
+            model.ComparePreviousCommand.Execute(null); await Ready(model);
+            Assert.False(model.HasComparison);
+
+            model.SelectedRun = model.Library.Single(item => item.Id == second.Id); await Ready(model);
+            Assert.True(model.ComparePreviousCommand.CanExecute(null));
+            model.ComparePreviousCommand.Execute(null); await Ready(model);
+            Assert.Equal(first.Id, model.ComparisonChoice!.Id);
+            Assert.Equal("B · First", model.RunBLabel);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    });
+
+    [Fact]
+    public void RapidSelectionsAndRefreshKeepTheDisplayedRunAndSelectorTogether() => OnDispatcher(async () =>
+    {
+        var directory = TemporaryDirectory();
+        await using var receiver = new TelemetryUdpReceiver();
+        await using var service = new RunRecordingService(receiver, directory);
+        using var model = new RunsViewModel(service, new AppSettings(), Dispatcher.CurrentDispatcher);
+        try
+        {
+            var a = Run("First", 0, 2); var b = Run("Second", 0, 3);
+            await service.Store.SaveAsync(a); await service.Store.SaveAsync(b); await model.InitializeAsync();
+            var first = Assert.Single(model.Library, item => item.Id == a.Id); var second = Assert.Single(model.Library, item => item.Id == b.Id);
+            model.SelectedRun = first; model.SelectedRun = second; await Ready(model);
+            Assert.Equal(b.Id, model.SelectedRun!.Id); Assert.StartsWith("A · Second", model.RunALabel);
+            model.RefreshLibraryCommand.Execute(null); model.SelectedRun = first;
+            await Ready(model); await Task.Delay(40);
+            Assert.Equal(a.Id, model.SelectedRun!.Id); Assert.StartsWith("A · First", model.RunALabel);
+        }
+        finally { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+    });
+
+    private static RecordedRun Run(string name, double delay, double rate) => new()
+    {
+        Name = name,
+        StartedAtUtc = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        Samples = Enumerable.Range(0, 2001).Select(index =>
+        {
+            var sample = RunPresentationTests.Sample(index / 100d, 3000);
+            return sample with { State = sample.State with { GroundSpeedMetersPerSecond = (float)Math.Max(0, (sample.ElapsedSeconds - delay) * rate) } };
+        }).ToArray()
+    };
+    private static string TemporaryDirectory() => Path.Combine(Path.GetTempPath(), "Wisp.RunsViewModelTests", Guid.NewGuid().ToString("N"));
+    private static async Task Ready(RunsViewModel model)
+    {
+        for (int step = 0; step < 250 && (model.IsBusy || model.IsPreparingCharts); step++) await Task.Delay(10);
+        Assert.False(model.IsBusy); Assert.False(model.IsPreparingCharts); Assert.False(model.HasError, model.Error);
+    }
+    private static async Task SelectionFailed(RunsViewModel model)
+    {
+        for (int step = 0; step < 250 && model.IsBusy; step++) await Task.Delay(10);
+        Assert.False(model.IsBusy);
+        Assert.True(model.HasError);
+        Assert.Contains("could not be opened", model.Error);
+    }
+    private sealed class ManualClock : TimeProvider
+    {
+        private long _timestamp;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+        public override long GetTimestamp() => _timestamp;
+        internal void Advance(TimeSpan duration) => _timestamp += duration.Ticks;
+    }
+    private static async Task WithLiveReceiver(Func<TelemetryUdpReceiver, Func<Task>, Task> test)
+    {
+        await using var receiver = new TelemetryUdpReceiver();
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        int port;
+        using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+        { socket.Bind(new IPEndPoint(IPAddress.Loopback, 0)); port = ((IPEndPoint)socket.LocalEndPoint!).Port; }
+        await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+        var timestamp = 0;
+        await Refresh(); await test(receiver, Refresh);
+        async Task Refresh()
+        {
+            var bytes = new byte[324]; timestamp += 10;
+            Write(0, 1); Write(4, timestamp); Write(8, BitConverter.SingleToInt32Bits(8000)); Write(16, BitConverter.SingleToInt32Bits(3000));
+            Write(212, 1); Write(224, 1); Write(228, 8); bytes[319] = 3;
+            await sender.SendAsync(bytes, new IPEndPoint(IPAddress.Loopback, port));
+            for (var index = 0; index < 200 && receiver.Latest?.GameTimestampMilliseconds != timestamp; index++) await Task.Delay(5);
+            Assert.Equal((uint)timestamp, receiver.Latest?.GameTimestampMilliseconds);
+            void Write(int offset, int value) => BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(offset, 4), value);
+        }
+    }
+    private static void OnDispatcher(Func<Task> test)
+    {
+        Exception? failure = null;
+        using var finished = new ManualResetEventSlim();
+        var thread = new Thread(() =>
+        {
+            var dispatcher = Dispatcher.CurrentDispatcher;
+            _ = dispatcher.InvokeAsync(async () =>
+            {
+                try { await test(); }
+                catch (Exception error) { failure = error; }
+                finally { dispatcher.BeginInvokeShutdown(DispatcherPriority.Send); finished.Set(); }
+            });
+            Dispatcher.Run();
+        })
+        { IsBackground = true };
+        thread.SetApartmentState(ApartmentState.STA); thread.Start();
+        Assert.True(finished.Wait(TimeSpan.FromSeconds(15)), "Run view-model test exceeded its bounded dispatcher deadline.");
+        if (failure is not null) ExceptionDispatchInfo.Capture(failure).Throw();
+    }
+}

--- a/tests/Wisp.App.Tests/ScrollLayoutAssertions.cs
+++ b/tests/Wisp.App.Tests/ScrollLayoutAssertions.cs
@@ -14,11 +14,11 @@ internal static class ScrollLayoutAssertions
         (int TabIndex, string ViewName)[] pages =
         [
             (0, "DashboardScaleView"),
-            (1, "AppearanceScaleView"),
-            (2, "DiagnosticsScaleView"),
-            (3, "ProfilesScaleView"),
-            (4, "SetupScaleView"),
-            (6, "ReleaseNotesScaleView")
+            (2, "AppearanceScaleView"),
+            (3, "DiagnosticsScaleView"),
+            (4, "ProfilesScaleView"),
+            (5, "SetupScaleView"),
+            (7, "ReleaseNotesScaleView")
         ];
         var scrollingCases = 0;
         var compactCases = 0;

--- a/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
+++ b/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
@@ -259,12 +259,13 @@ public sealed class TachDiagnosticExportTests
             }
             File.WriteAllText(path, "not-json-private-sentinel");
             Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
-            var privateText = text.Replace("\"build_kind\":\"release\"",
-                $"\"build_kind\":\"private\",\"private_build_id\":\"{ApplicationVersionInfo.DiagnosticBuildId}\"", StringComparison.Ordinal);
-            File.WriteAllText(path, privateText);
-            Assert.NotNull(TachDiagnosticReport.ReadPackagedBuild(path));
-            File.WriteAllText(path, privateText.Replace(ApplicationVersionInfo.DiagnosticBuildId!, "wrong-preview", StringComparison.Ordinal));
-            Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
+            foreach (var privateIdentity in new[] { "", ",\"private_build_id\":\"unpublished-preview\"" })
+            {
+                var privateText = text.Replace("\"build_kind\":\"release\"",
+                    "\"build_kind\":\"private\"" + privateIdentity, StringComparison.Ordinal);
+                File.WriteAllText(path, privateText);
+                Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
+            }
         }
         finally { Directory.Delete(root, recursive: true); }
     }

--- a/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
+++ b/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
@@ -202,7 +202,7 @@ public sealed class TachDiagnosticExportTests
             {
                 schema_version = 1,
                 build_kind = "release",
-                version = "1.1.4",
+                version = ApplicationVersionInfo.MachineVersion,
                 source_revision = new string('a', 40),
                 source_dirty = true,
                 created_at_utc = Now,
@@ -234,10 +234,10 @@ public sealed class TachDiagnosticExportTests
             Assert.Equal(200, nativeRenderer.GetProperty("bytes").GetInt64());
             foreach (var wrongIdentity in new[]
             {
-                text.Replace("1.1.4", "1.1.3", StringComparison.Ordinal),
-                text.Replace("1.1.4", "1.1.5", StringComparison.Ordinal),
+                text.Replace(ApplicationVersionInfo.MachineVersion, "1.1.3", StringComparison.Ordinal),
+                text.Replace(ApplicationVersionInfo.MachineVersion, "1.1.5", StringComparison.Ordinal),
                 text.Replace("release", "diagnostics.4", StringComparison.Ordinal),
-                text.Replace("\"build_kind\":\"release\",\"version\":\"1.1.4\"",
+                text.Replace($"\"build_kind\":\"release\",\"version\":\"{ApplicationVersionInfo.MachineVersion}\"",
                     "\"build_id\":\"diagnostics.4\",\"build_label\":\"1.1.3 Diagnostics4\",\"baseline_version\":\"1.1.3\"", StringComparison.Ordinal)
             })
             {
@@ -258,6 +258,12 @@ public sealed class TachDiagnosticExportTests
                 Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
             }
             File.WriteAllText(path, "not-json-private-sentinel");
+            Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
+            var privateText = text.Replace("\"build_kind\":\"release\"",
+                $"\"build_kind\":\"private\",\"private_build_id\":\"{ApplicationVersionInfo.DiagnosticBuildId}\"", StringComparison.Ordinal);
+            File.WriteAllText(path, privateText);
+            Assert.NotNull(TachDiagnosticReport.ReadPackagedBuild(path));
+            File.WriteAllText(path, privateText.Replace(ApplicationVersionInfo.DiagnosticBuildId!, "wrong-preview", StringComparison.Ordinal));
             Assert.Null(TachDiagnosticReport.ReadPackagedBuild(path));
         }
         finally { Directory.Delete(root, recursive: true); }

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -351,7 +351,7 @@ public sealed class WpfStyleRuntimeTests
                 CalmSidebarTests.AssertOnCurrentDispatcher(mainWindow, surface);
                 MaintenancePersistenceTests.AssertProfileSaveRetryOnCurrentDispatcher();
 
-                tabs.SelectedIndex = 2;
+                tabs.SelectedIndex = 3;
                 surface.UpdateLayout();
                 mainWindow.Dispatcher.Invoke(() => { }, System.Windows.Threading.DispatcherPriority.DataBind);
                 var logo = Assert.IsType<Image>(mainWindow.FindName("HeaderLogo"));

--- a/tests/Wisp.App.Tests/XamlContractTests.cs
+++ b/tests/Wisp.App.Tests/XamlContractTests.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using Wisp.App;
+using Wisp.App.Runs;
 using Xunit;
 
 namespace Wisp.App.Tests;
@@ -17,7 +18,7 @@ public sealed class XamlContractTests
         @"\{Binding(?:\s+Path\s*=\s*|\s+)(?<path>[A-Za-z_][A-Za-z0-9_.]*)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex AncestorTypePattern = new(
-        @"RelativeSource\s*=\s*\{RelativeSource\s+AncestorType\s*=\s*\{x:Type\s+(?<type>[A-Za-z_][A-Za-z0-9_]*)\s*\}\s*\}",
+        @"RelativeSource\s*=\s*\{RelativeSource\s+AncestorType\s*=\s*(?:\{x:Type\s+(?<type>[A-Za-z_][A-Za-z0-9_]*)\s*\}|(?<type>[A-Za-z_][A-Za-z0-9_]*))\s*\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private static readonly HashSet<string> RoutedHandlerAttributes =
@@ -30,13 +31,16 @@ public sealed class XamlContractTests
         "ValueChanged",
         "SelectionChanged",
         "SelectedColorChanged",
-        "ResetRequested"
+        "ResetRequested",
+        "Loaded",
+        "Unloaded"
     ];
 
     private static readonly HashSet<string> InteractiveElements =
     [
         "Button",
         "CheckBox",
+        "ComboBox",
         "ListBox",
         "ListBoxItem",
         "RadioButton",
@@ -183,6 +187,39 @@ public sealed class XamlContractTests
         Assert.False(BindingPathResolves(sourceType!, "AccentTypo"));
         document.Root!.Attribute("DataType")!.Remove();
         Assert.Null(BindingSourceType("{Binding Name}", document, target));
+    }
+
+    [Fact]
+    public void RunsBindingContractChecksPageTemplatesAndSharedDashboardContext()
+    {
+        var runs = LoadXaml(RunsPagePath());
+        var chart = Assert.Single(runs.Descendants(XName.Get("RunChartView", "clr-namespace:Wisp.App.Runs")));
+        var owner = BindingSourceType(chart.Attribute("StartSeconds")!.Value, runs, chart);
+        Assert.Equal(typeof(RunsPage), owner);
+        Assert.True(BindingPathResolves(owner!, "DataContext.ViewStart"));
+        Assert.False(BindingPathResolves(owner!, "DataContext.ViewStartTypo"));
+        Assert.Equal(typeof(RunPlotPanel), BindingSourceType("{Binding Title}", runs, chart));
+        Assert.True(BindingPathResolves(typeof(RunPlotPanel), "Title"));
+        Assert.False(BindingPathResolves(typeof(RunPlotPanel), "TitleTypo"));
+        Assert.Equal(typeof(RunsViewModel), BindingSourceType("{Binding RecordingStatus}", runs, runs.Root));
+        Assert.False(BindingPathResolves(typeof(RunsViewModel), "RecordingStatusTypo"));
+        var graphName = runs.Descendants(Presentation + "Style").Single(element => element.Attribute(Xaml + "Key")?.Value == "RunGraphTab")
+            .Elements(Presentation + "Setter").Single(element => element.Attribute("Property")?.Value == "AutomationProperties.Name");
+        Assert.Equal(typeof(RunGraphChoice), BindingSourceType(graphName.Attribute("Value")!.Value, runs, graphName));
+        Assert.True(BindingPathResolves(typeof(RunGraphChoice), "Label"));
+        Assert.False(BindingPathResolves(typeof(RunGraphChoice), "LabelTypo"));
+        var dropdown = Assert.Single(runs.Descendants(Presentation + "ToggleButton"));
+        var templateSource = BindingSourceType(dropdown.Attribute("IsChecked")!.Value, runs, dropdown);
+        Assert.Equal(typeof(System.Windows.Controls.ComboBox), templateSource);
+        Assert.True(BindingPathResolves(templateSource!, "IsDropDownOpen"));
+        Assert.False(BindingPathResolves(templateSource!, "IsDropDownOpenTypo"));
+
+        var main = LoadXaml(Path.Combine(AppSourceDirectory(), "MainWindow.xaml"));
+        var panel = Assert.Single(main.Descendants(), element => element.Attribute(Xaml + "Name")?.Value == "DashboardRunPanel");
+        Assert.Equal(typeof(RunsViewModel), BindingSourceType("{Binding RecordingStatus}", main, panel));
+        var code = File.ReadAllText(Path.Combine(AppSourceDirectory(), "MainWindow.xaml.cs"));
+        Assert.Contains("RunsSurface.DataContext = controller.Runs;", code, StringComparison.Ordinal);
+        Assert.Contains("DashboardRunPanel.DataContext = controller.Runs;", code, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -404,25 +441,28 @@ public sealed class XamlContractTests
     [Fact]
     public void EveryMainWindowControlHasAnAccessibleNameOrTextLabel()
     {
-        var xamlPath = Path.Combine(AppSourceDirectory(), "MainWindow.xaml");
-        var document = LoadXaml(xamlPath);
         var failures = new List<string>();
-
-        foreach (var element in document.Descendants()
-                     .Where(element => element.Name.Namespace == Presentation &&
-                                       InteractiveElements.Contains(element.Name.LocalName)))
+        foreach (var xamlPath in new[] { Path.Combine(AppSourceDirectory(), "MainWindow.xaml"), RunsPagePath() })
         {
-            var automationName = element.Attribute("AutomationProperties.Name")?.Value;
-            var content = element.Attribute("Content")?.Value;
-            var header = element.Attribute("Header")?.Value;
-            var hasDescriptiveAutomationName = !string.IsNullOrWhiteSpace(automationName);
-            var hasTextLabel = IsDescriptiveText(content) || IsDescriptiveText(header);
-
-            if (!hasDescriptiveAutomationName && !hasTextLabel)
+            var document = LoadXaml(xamlPath);
+            foreach (var element in document.Descendants()
+                         .Where(element => (element.Name.Namespace == Presentation &&
+                                            InteractiveElements.Contains(element.Name.LocalName)) ||
+                                           (element.Name.NamespaceName == "clr-namespace:Wisp.App.Runs" &&
+                                            element.Name.LocalName is "RunChartView" or "RunAlternativePlotView")))
             {
-                failures.Add(
-                    $"{Location(xamlPath, element)}: {element.Name.LocalName} needs descriptive Content/Header " +
-                    "or AutomationProperties.Name.");
+                var automationName = element.Attribute("AutomationProperties.Name")?.Value;
+                var content = element.Attribute("Content")?.Value;
+                var header = element.Attribute("Header")?.Value;
+                var hasDescriptiveAutomationName = !string.IsNullOrWhiteSpace(automationName);
+                var hasTextLabel = IsDescriptiveText(content) || IsDescriptiveText(header);
+
+                if (!hasDescriptiveAutomationName && !hasTextLabel)
+                {
+                    failures.Add(
+                        $"{Location(xamlPath, element)}: {element.Name.LocalName} needs descriptive Content/Header " +
+                        "or AutomationProperties.Name.");
+                }
             }
         }
 
@@ -992,9 +1032,26 @@ public sealed class XamlContractTests
         var tabs = document.Descendants(Presentation + "TabControl")
             .Single(element => element.Attribute(Xaml + "Name")?.Value == "RootTabs");
         var scrollViewers = tabs.Elements(Presentation + "TabItem")
-            .Select(tab => Assert.Single(tab.Descendants(Presentation + "ScrollViewer")))
+            .SelectMany(tab =>
+            {
+                if (tab.Attribute(Xaml + "Name")?.Value != "RunsTab")
+                    return new[] { Assert.Single(tab.Descendants(Presentation + "ScrollViewer")) };
+
+                var page = Assert.Single(tab.Elements());
+                Assert.Equal(XName.Get("RunsPage", "clr-namespace:Wisp.App.Runs"), page.Name);
+                Assert.Equal("RunsSurface", page.Attribute(Xaml + "Name")?.Value);
+                var runs = LoadXaml(RunsPagePath());
+                Assert.Equal(typeof(RunsPage).FullName, runs.Root!.Attribute(Xaml + "Class")?.Value);
+                Assert.Empty(runs.Descendants(Presentation + "Viewbox"));
+                var panes = runs.Descendants(Presentation + "ScrollViewer")
+                    .Where(element => element.Attribute(Xaml + "Name")?.Value is "RunsScroll" or "GraphScroll")
+                    .ToArray();
+                Assert.Equal(2, panes.Length);
+                Assert.All(panes, scroll => Assert.Equal("Auto", scroll.Attribute("VerticalScrollBarVisibility")?.Value));
+                return panes;
+            })
             .ToArray();
-        Assert.Equal(7, scrollViewers.Length);
+        Assert.Equal(9, scrollViewers.Length);
         Assert.All(
             scrollViewers,
             scrollViewer => Assert.Equal(
@@ -1028,6 +1085,31 @@ public sealed class XamlContractTests
                 "{Binding ViewportWidth, RelativeSource={RelativeSource AncestorType={x:Type ScrollViewer}}, Converter={StaticResource ResponsivePageWidthConverter}}",
                 designSurface.Attribute("Width")?.Value);
         }
+    }
+
+    [Fact]
+    public void RunsHasOneGraphEntryAndKeepsEveryGraphChoiceOutsideTheScrollingPlots()
+    {
+        var runs = LoadXaml(RunsPagePath());
+        var showGraphs = Assert.Single(runs.Descendants(Presentation + "Button"),
+            element => element.Attribute("Content")?.Value == "Show graphs");
+        Assert.Equal("ShowGraphsButton", showGraphs.Attribute(Xaml + "Name")?.Value);
+        Assert.Equal("ViewGraphs_Click", showGraphs.Attribute("Click")?.Value);
+
+        var picker = Assert.Single(runs.Descendants(Presentation + "ListBox"),
+            element => element.Attribute(Xaml + "Name")?.Value == "GraphPicker");
+        Assert.Equal("{Binding GraphChoices}", picker.Attribute("ItemsSource")?.Value);
+        Assert.Contains("SelectedGraph", picker.Attribute("SelectedItem")?.Value ?? "", StringComparison.Ordinal);
+        Assert.Empty(picker.Ancestors(Presentation + "ScrollViewer"));
+        Assert.DoesNotContain(runs.Descendants(Presentation + "ComboBox"), element =>
+            element.Attribute("AutomationProperties.Name")?.Value is "Chart channels" or "Graph type");
+
+        var summary = Assert.Single(runs.Descendants(Presentation + "Button"),
+            element => element.Attribute(Xaml + "Name")?.Value == "BackToSummaryButton");
+        Assert.Equal("RunSummary_Click", summary.Attribute("Click")?.Value);
+        var comparison = Assert.Single(runs.Descendants(Presentation + "Expander"),
+            element => element.Attribute(Xaml + "Name")?.Value == "CompareExpander");
+        Assert.NotEqual("True", comparison.Attribute("IsExpanded")?.Value);
     }
 
     [Fact]
@@ -1396,6 +1478,12 @@ public sealed class XamlContractTests
     {
         if (binding.Contains("RelativeSource", StringComparison.Ordinal))
         {
+            if (Regex.IsMatch(binding, @"RelativeSource\s*=\s*\{RelativeSource\s+TemplatedParent\s*\}"))
+            {
+                var template = targetElement?.AncestorsAndSelf()
+                    .FirstOrDefault(element => element.Name == Presentation + "ControlTemplate");
+                return ResolveXamlType(template?.Attribute("TargetType")?.Value, template);
+            }
             var ancestor = AncestorTypePattern.Match(binding);
             if (!ancestor.Success)
             {
@@ -1437,14 +1525,33 @@ public sealed class XamlContractTests
             .FirstOrDefault(element => element.Name == Presentation + "DataTemplate");
         if (dataTemplate is not null)
         {
-            var type = Regex.Match(dataTemplate.Attribute("DataType")?.Value ?? string.Empty,
-                @"^\{x:Type\s+(?<prefix>[A-Za-z_][A-Za-z0-9_]*):(?<type>[A-Za-z_][A-Za-z0-9_]*)\s*\}$");
-            return type.Success && dataTemplate.GetNamespaceOfPrefix(type.Groups["prefix"].Value)?.NamespaceName == "clr-namespace:Wisp.App"
-                ? typeof(DiagnosticsViewModel).Assembly.GetType($"Wisp.App.{type.Groups["type"].Value}")
-                : null;
+            return ResolveXamlType(dataTemplate.Attribute("DataType")?.Value, dataTemplate);
         }
 
+        if (document?.Root?.Attribute(Xaml + "Class")?.Value == typeof(RunsPage).FullName &&
+            targetElement?.AncestorsAndSelf().Any(element => element.Name == Presentation + "Style" && element.Attribute(Xaml + "Key")?.Value == "RunGraphTab") == true)
+            return typeof(RunGraphChoice);
+
+        if (document?.Root?.Attribute(Xaml + "Class")?.Value == typeof(RunsPage).FullName ||
+            targetElement?.AncestorsAndSelf().Any(element => element.Attribute(Xaml + "Name")?.Value == "DashboardRunPanel") == true)
+            return typeof(RunsViewModel);
+
         return typeof(DiagnosticsViewModel);
+    }
+
+    private static Type? ResolveXamlType(string? name, XElement? element)
+    {
+        var type = Regex.Match(name ?? string.Empty,
+            @"^(?:\{x:Type\s+)?(?:(?<prefix>[A-Za-z_][A-Za-z0-9_]*):)?(?<type>[A-Za-z_][A-Za-z0-9_]*)(?:\s*\})?$");
+        if (!type.Success || element is null) return null;
+        var namespaceName = type.Groups["prefix"].Success
+            ? element.GetNamespaceOfPrefix(type.Groups["prefix"].Value)?.NamespaceName
+            : element.GetDefaultNamespace().NamespaceName;
+        if (namespaceName == Presentation.NamespaceName)
+            return typeof(System.Windows.Controls.Control).Assembly.GetType($"System.Windows.Controls.{type.Groups["type"].Value}");
+        return namespaceName is "clr-namespace:Wisp.App" or "clr-namespace:Wisp.App.Runs"
+            ? typeof(DiagnosticsViewModel).Assembly.GetType($"{namespaceName[14..]}.{type.Groups["type"].Value}")
+            : null;
     }
 
     private static XElement? BindingSourceElement(string binding, XDocument? document)
@@ -1467,7 +1574,11 @@ public sealed class XamlContractTests
                 return false;
             }
 
-            if (segment == "SelectedItem" &&
+            if (segment == "DataContext" && currentType == typeof(RunsPage))
+            {
+                currentType = typeof(RunsViewModel);
+            }
+            else if (segment == "SelectedItem" &&
                 currentType == typeof(System.Windows.Controls.TabControl) &&
                 sourceElement is not null && sourceElement.Name == Presentation + "TabControl")
             {
@@ -1591,7 +1702,10 @@ public sealed class XamlContractTests
 
     private static IEnumerable<string> AppXamlFiles() =>
         Directory.EnumerateFiles(AppSourceDirectory(), "*.xaml", SearchOption.TopDirectoryOnly)
+            .Append(RunsPagePath())
             .OrderBy(path => path, StringComparer.Ordinal);
+
+    private static string RunsPagePath() => Path.Combine(AppSourceDirectory(), "Runs", "RunsPage.xaml");
 
     private static string AppSourceDirectory() =>
         Path.Combine(RepositoryRoot(), "src", "Wisp.App");

--- a/tests/Wisp.Core.Tests/RunAnalysisTests.cs
+++ b/tests/Wisp.Core.Tests/RunAnalysisTests.cs
@@ -1,0 +1,490 @@
+using Wisp.Core.Runs;
+using Xunit;
+
+namespace Wisp.Core.Tests;
+
+public sealed class RunAnalysisTests
+{
+    private static RunSample Sample(double time, float speed = 10, int segment = 0, double? wheel = 12, double? radius = 0.3,
+        byte throttle = 0, byte brake = 0, uint? gameTime = null) => new()
+        {
+            ElapsedSeconds = time,
+            Segment = segment,
+            IsDriving = true,
+            WheelSpeedMetersPerSecond = wheel,
+            RearRadiusMeters = radius,
+            State = TestVehicleState.Create(groundSpeed: speed) with
+            {
+                GameTimestampMilliseconds = gameTime ?? (uint)Math.Round(time * 1000),
+                NumCylinders = 8,
+                Accelerator = throttle,
+                Brake = brake,
+                TireTemperatureFahrenheit = new(100, 100, 110, 110)
+            }
+        };
+
+    private static RecordedRun Run(params RunSample[] samples) => new() { Samples = samples };
+    private static RunSample[] Steady(int count = 21, double start = 0, int segment = 0) => Enumerable.Range(0, count)
+        .Select(i => Sample(start + i * 0.1, segment: segment, wheel: 20, throttle: 255)).ToArray();
+
+    [Fact]
+    public void AveragesAndDistanceUseTimeRatherThanSampleDensity()
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 0), Sample(0.1, 10), Sample(0.3, 10))).Statistics;
+        Assert.Equal(0.3, stats.RecordedSeconds, 8);
+        Assert.Equal(2.5, stats.DistanceMeters, 8);
+        Assert.Equal(2.5 / 0.3, stats.AverageSpeedMetersPerSecond!.Value, 8);
+        Assert.Equal(0, stats.GapCount);
+    }
+
+    [Fact]
+    public void SelectedBoundariesAreInterpolatedInsideAdjacentValidSamples()
+    {
+        var run = Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20));
+        var report = RunAnalysis.BuildReport(run, interval: new(0.05, 0.15));
+        Assert.Equal(new(0.05, 0.15), report.Interval);
+        Assert.Equal(1, report.Statistics.SampleCount);
+        Assert.Equal(0.1, report.Statistics.RecordedSeconds, 8);
+        Assert.Equal(1, report.Statistics.DistanceMeters, 8);
+        Assert.Equal(10, report.Statistics.AverageSpeedMetersPerSecond!.Value, 8);
+        Assert.Equal(15, report.Statistics.PeakSpeedMetersPerSecond!.Value, 8);
+    }
+
+    [Fact]
+    public void DuplicateTimestampsRetainInstantaneousReadingsButNeverAddTime()
+    {
+        var a = Sample(0.1, 10) with { State = Sample(0.1).State with { GroundSpeedMetersPerSecond = 10, PowerWatts = 100 } };
+        var latest = a with { WheelSpeedMetersPerSecond = 30, State = a.State with { GroundSpeedMetersPerSecond = 20, PowerWatts = 999 } };
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 0), a, latest, Sample(0.2, 20))).Statistics;
+        Assert.Equal(4, stats.SampleCount);
+        Assert.Equal(0.2, stats.RecordedSeconds, 8);
+        Assert.Equal(12.5, stats.AverageSpeedMetersPerSecond!.Value, 8);
+        Assert.Equal(999, stats.PeakPowerWatts);
+        Assert.Equal(0, stats.GapCount);
+    }
+
+    [Fact]
+    public void OnlyDuplicatesHavePeaksButNoTimeBasedMetricsOrSustainedFindings()
+    {
+        var samples = Steady(10).Select(s => s with { ElapsedSeconds = 0, State = s.State with { GameTimestampMilliseconds = 0 } }).ToArray();
+        var report = RunAnalysis.BuildReport(Run(samples), RunPurpose.Acceleration);
+        Assert.Equal(10, report.Statistics.SampleCount);
+        Assert.Equal(0, report.Statistics.RecordedSeconds);
+        Assert.Null(report.Statistics.AverageSpeedMetersPerSecond);
+        Assert.NotNull(report.Statistics.PeakSpeedMetersPerSecond);
+        Assert.Single(report.Findings);
+        Assert.Contains("not enough", report.Findings[0].Title);
+    }
+
+    [Theory]
+    [InlineData(0.251, 0)]
+    [InlineData(0.1, 1)]
+    public void GapsAndSegmentChangesNeverBecomeDrivingTime(double nextTime, int nextSegment)
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 10), Sample(nextTime, 200, nextSegment))).Statistics;
+        Assert.Equal(0, stats.RecordedSeconds);
+        Assert.Equal(0, stats.DistanceMeters);
+        Assert.Equal(1, stats.GapCount);
+    }
+
+    [Fact]
+    public void MultipleValidSectionsExcludeInterruptionFromAverage()
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 10), Sample(0.1, 10), Sample(1, 30, 1), Sample(1.1, 30, 1))).Statistics;
+        Assert.Equal(1.1, stats.DurationSeconds, 8);
+        Assert.Equal(0.2, stats.RecordedSeconds, 8);
+        Assert.Equal(20, stats.AverageSpeedMetersPerSecond!.Value, 8);
+        Assert.Equal(1, stats.GapCount);
+    }
+
+    [Fact]
+    public void UintTimestampWrapIsContinuousButAResetIsNot()
+    {
+        Assert.True(RunAnalysis.AreContinuous(Sample(0, gameTime: uint.MaxValue - 50), Sample(0.1, gameTime: 49)));
+        Assert.False(RunAnalysis.AreContinuous(Sample(0, gameTime: 1000), Sample(0.1, gameTime: 10)));
+        Assert.False(RunAnalysis.AreContinuous(Sample(0, gameTime: 10), Sample(0.1, gameTime: 11)));
+        Assert.False(RunAnalysis.AreContinuous(Sample(0, gameTime: 100), Sample(0.1, gameTime: 100)));
+    }
+
+    [Theory]
+    [InlineData("car")]
+    [InlineData("drivetrain")]
+    [InlineData("menu")]
+    [InlineData("native")]
+    [InlineData("nan")]
+    public void InvalidContextCannotBridgeMetricsOrProducePeaks(string mode)
+    {
+        var bad = Sample(0.1, 200);
+        bad = mode switch
+        {
+            "car" => bad with { State = bad.State with { CarOrdinal = 999 } },
+            "drivetrain" => bad with { State = bad.State with { Drivetrain = DrivetrainType.AllWheelDrive } },
+            "menu" => bad with { State = bad.State with { IsRaceOn = false } },
+            "native" => bad with { IsDriving = false },
+            _ => bad with { State = bad.State with { GroundSpeedMetersPerSecond = float.NaN } }
+        };
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 10), bad, Sample(0.2, 10))).Statistics;
+        Assert.Equal(0, stats.RecordedSeconds);
+        Assert.Equal(1, stats.GapCount);
+        Assert.Equal(mode is "car" or "drivetrain" ? 200d : 10d, stats.PeakSpeedMetersPerSecond);
+    }
+
+    [Fact]
+    public void ReorderedElapsedTimeCannotDoubleCountAnEarlierSection()
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 10), Sample(0.1, 10), Sample(0.05, 100), Sample(0.2, 10), Sample(0.3, 10))).Statistics;
+        Assert.Equal(0.2, stats.RecordedSeconds, 8);
+        Assert.Equal(10, stats.PeakSpeedMetersPerSecond);
+        Assert.Equal(1, stats.GapCount);
+    }
+
+    [Fact]
+    public void OptionalNonfiniteMetricsDoNotEraseValidVehicleSpeed()
+    {
+        var samples = new[] { Sample(0), Sample(0.1) }.Select(s => s with
+        { State = s.State with { PowerWatts = float.NaN, TorqueNm = float.PositiveInfinity, LateralAccelerationMetersPerSecondSquared = float.NaN } }).ToArray();
+        var stats = RunAnalysis.BuildReport(Run(samples)).Statistics;
+        Assert.Equal(10, stats.AverageSpeedMetersPerSecond);
+        Assert.Null(stats.PeakPowerWatts);
+        Assert.Null(stats.PeakTorqueNm);
+        Assert.Null(stats.PeakLateralG);
+    }
+
+    [Fact]
+    public void InputDurationsInterpolateThresholds()
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0), Sample(0.2, throttle: 255, brake: 26))).Statistics;
+        Assert.Equal(0.2 * 5 / 255, stats.FullThrottleSeconds, 8);
+        Assert.Equal(0.1, stats.BrakingSeconds, 8);
+    }
+
+    [Fact]
+    public void WheelExcessIntegratesOnlyPositivePartAndOnlyTrustedCalibration()
+    {
+        var stats = RunAnalysis.BuildReport(Run(Sample(0, 10, wheel: 0), Sample(0.2, 10, wheel: 20))).Statistics;
+        Assert.Equal(2.5, stats.AverageWheelSpeedExcessMetersPerSecond!.Value, 8);
+        var missing = RunAnalysis.BuildReport(Run(Sample(0, radius: null), Sample(0.1, radius: null)));
+        Assert.Null(missing.Statistics.AverageWheelSpeedExcessMetersPerSecond);
+        Assert.Equal(10, missing.Statistics.AverageSpeedMetersPerSecond);
+        Assert.Contains("calibration", missing.QualityNote);
+        var changed = RunAnalysis.BuildReport(Run(Sample(0, radius: 0.3), Sample(0.1, radius: 0.4)));
+        Assert.Null(changed.Statistics.AverageWheelSpeedExcessMetersPerSecond);
+    }
+
+    [Fact]
+    public void AllWheelDriveRequiresBothCalibratedAxles()
+    {
+        var samples = new[] { Sample(0), Sample(0.1) }.Select(s => s with { State = s.State with { Drivetrain = DrivetrainType.AllWheelDrive } }).ToArray();
+        Assert.Null(RunAnalysis.BuildReport(Run(samples)).Statistics.AverageWheelSpeedExcessMetersPerSecond);
+        Assert.NotNull(RunAnalysis.BuildReport(Run(samples.Select(s => s with { FrontRadiusMeters = 0.3 }).ToArray())).Statistics.AverageWheelSpeedExcessMetersPerSecond);
+    }
+
+    [Theory]
+    [InlineData(8, -15, 0, false)]
+    [InlineData(0, -15, 20, false)]
+    [InlineData(8, -15, 20, true)]
+    public void BoostNeedsEvidenceOfPositiveBoostAndNeverAppliesToEv(int cylinders, float first, float last, bool available)
+    {
+        var samples = new[] { Sample(0), Sample(0.1) };
+        samples[0] = samples[0] with { State = samples[0].State with { NumCylinders = cylinders, BoostPressurePsi = first } };
+        samples[1] = samples[1] with { State = samples[1].State with { NumCylinders = cylinders, BoostPressurePsi = last } };
+        var stats = RunAnalysis.BuildReport(Run(samples)).Statistics;
+        Assert.Equal(available, stats.PeakBoostPsi.HasValue);
+        if (available) Assert.Equal(last, stats.PeakBoostPsi);
+    }
+
+    [Fact]
+    public void VacuumRemainsARealReadingOnceBoostIsEstablishedElsewhereInTheRun()
+    {
+        var samples = new[] { Sample(0), Sample(0.1), Sample(0.2) };
+        for (var i = 0; i < samples.Length; i++)
+            samples[i] = samples[i] with { State = samples[i].State with { BoostPressurePsi = i == 2 ? 5 : -10 } };
+        Assert.Equal(-10, RunAnalysis.BuildReport(Run(samples), interval: new(0, 0.1)).Statistics.PeakBoostPsi);
+    }
+
+    [Fact]
+    public void UnavailableTemperaturesStayNullInsteadOfZeroOrLaterValidValue()
+    {
+        var samples = new[] { Sample(0), Sample(0.1), Sample(0.2) };
+        samples[0] = samples[0] with { State = samples[0].State with { TireTemperatureFahrenheit = default } };
+        samples[2] = samples[2] with { State = samples[2].State with { TireTemperatureFahrenheit = new(120, 0, 120, 120) } };
+        var report = RunAnalysis.BuildReport(Run(samples));
+        Assert.Null(report.Statistics.StartingFrontTemperatureFahrenheit);
+        Assert.Null(report.Statistics.StartingRearTemperatureFahrenheit);
+        Assert.Null(report.Statistics.EndingFrontTemperatureFahrenheit);
+        Assert.Equal(120, report.Statistics.EndingRearTemperatureFahrenheit);
+        Assert.Contains("unavailable", report.QualityNote);
+        Assert.DoesNotContain(report.Findings, f => f.Title.Contains("warmer"));
+    }
+
+    [Fact]
+    public void ClippedSignedAccelerationInterpolatesBeforeTakingMagnitude()
+    {
+        var a = Sample(0) with { State = Sample(0).State with { LateralAccelerationMetersPerSecondSquared = -9.80665f } };
+        var b = Sample(0.2) with { State = Sample(0.2).State with { LateralAccelerationMetersPerSecondSquared = 9.80665f } };
+        var stats = RunAnalysis.BuildReport(Run(a, b), interval: new(0.09, 0.11)).Statistics;
+        Assert.InRange(stats.PeakLateralG!.Value, 0.09999, 0.10001);
+    }
+
+    [Fact]
+    public void AccelerationUsesAdjacentThresholdInterpolationAndExactSelectedBoundaries()
+    {
+        var run = Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20));
+        var result = RunAnalysis.MeasureAcceleration(run, 5, 15)!;
+        Assert.Equal(0.1, result.DurationSeconds, 8);
+        Assert.Equal(0.05, result.Interval.StartSeconds, 8);
+        Assert.Equal(0.15, result.Interval.EndSeconds, 8);
+        Assert.NotNull(RunAnalysis.MeasureAcceleration(run, 5, 15, new(0.05, 0.15)));
+        Assert.Null(RunAnalysis.MeasureAcceleration(run, 5, 15, new(0.08, 0.18)));
+        Assert.Null(RunAnalysis.MeasureAcceleration(run, 5, 15, new(0.02, 0.12)));
+    }
+
+    [Theory]
+    [InlineData(TransmissionGear.Reverse)]
+    [InlineData(TransmissionGear.Neutral)]
+    [InlineData(TransmissionGear.Unknown)]
+    public void AccelerationCannotTimeThroughNonForwardGear(TransmissionGear gear)
+    {
+        var middle = Sample(0.1, 10);
+        middle = middle with { State = middle.State with { Gear = gear } };
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(Sample(0, 0), middle, Sample(0.2, 20)), 5, 15));
+    }
+
+    [Fact]
+    public void AccelerationCannotBridgeSegmentsOrZeroTimeThresholdJumps()
+    {
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20, 1)), 5, 15));
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(Sample(0, 0), Sample(0.1, 3), Sample(0.1, 25), Sample(0.2, 30)), 5, 15));
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(Sample(0, 10), Sample(0.1, 20)), 5, 15));
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(Sample(0, 0), Sample(0.1, 10), Sample(0.1, 25), Sample(0.2, 30), Sample(0.3, 10), Sample(0.4, 20)), 5, 15));
+    }
+
+    [Fact]
+    public void AccelerationSelectsQuickestCompletePassAndRestartsBelowEntrySpeed()
+    {
+        var samples = new[] { Sample(0, 0), Sample(0.1, 10), Sample(0.2, 3), Sample(0.3, 15), Sample(0.4, 20) };
+        var result = RunAnalysis.MeasureAcceleration(Run(samples), 5, 18)!;
+        Assert.Equal(0.2 + 0.1 * 2 / 12, result.Interval.StartSeconds, 8);
+        Assert.Equal(0.36, result.Interval.EndSeconds, 8);
+        var later = samples.Concat(new[] { Sample(1, 0, 1), Sample(1.1, 20, 1) }).ToArray();
+        var best = RunAnalysis.MeasureAcceleration(Run(later), 5, 18)!;
+        Assert.Equal(0.065, best.DurationSeconds, 8);
+        Assert.True(best.Interval.StartSeconds > 1);
+    }
+
+    [Fact]
+    public void SustainedWheelspinObservationIsPurposeSpecificAndHasEvidence()
+    {
+        var run = Run(Steady());
+        var acceleration = RunAnalysis.BuildReport(run, RunPurpose.Acceleration);
+        var finding = Assert.Single(acceleration.Findings, f => f.Title == "Wheel speed ran ahead of car speed");
+        Assert.Equal(new RunInterval(0, 2), finding.Interval);
+        Assert.DoesNotContain(RunAnalysis.BuildReport(run, RunPurpose.Drifting).Findings, f => f.Title == finding.Title);
+        Assert.InRange(acceleration.Findings.Length, 1, 3);
+    }
+
+    [Theory]
+    [InlineData("stationary")]
+    [InlineData("turning")]
+    [InlineData("calibration")]
+    [InlineData("short")]
+    public void WheelspinCounterexamplesCannotBecomeLaunchFindings(string example)
+    {
+        var samples = Steady(example == "short" ? 4 : 21);
+        samples = samples.Select(s => example switch
+        {
+            "stationary" => s with { State = s.State with { GroundSpeedMetersPerSecond = 0 } },
+            "turning" => s with { State = s.State with { Steering = 40 } },
+            "calibration" => s with { RearRadiusMeters = null },
+            _ => s
+        }).ToArray();
+        Assert.DoesNotContain(RunAnalysis.BuildReport(Run(samples), RunPurpose.Acceleration).Findings, f => f.Title.StartsWith("Wheel speed"));
+    }
+
+    [Fact]
+    public void SeparateShortStretchesCannotCombineAcrossAGap()
+    {
+        var samples = Steady(4).Concat(Steady(4, 1, 1)).ToArray();
+        Assert.DoesNotContain(RunAnalysis.BuildReport(Run(samples), RunPurpose.Acceleration).Findings, f => f.Title.StartsWith("Wheel speed"));
+    }
+
+    [Fact]
+    public void DriftObservationAnchorsSpeedAndInputChangesWithoutClaimingCause()
+    {
+        var samples = Enumerable.Range(0, 11).Select(i => Sample(i * 0.1, 20 - i * 0.5f, throttle: (byte)(255 - i * 25))).ToArray();
+        var report = RunAnalysis.BuildReport(Run(samples), RunPurpose.Drifting);
+        var finding = Assert.Single(report.Findings, f => f.Title.Contains("throttle decreased"));
+        Assert.Equal(new RunInterval(0, 1), finding.Interval);
+        Assert.Equal(RunEvidenceView.Inputs, finding.EvidenceView);
+        Assert.Equal("Car speed and throttle both fell in this section. Inspect the input chart alongside speed.", finding.Detail);
+        samples[5] = samples[5] with { IsDriving = false };
+        Assert.DoesNotContain(RunAnalysis.BuildReport(Run(samples), RunPurpose.Drifting).Findings, f => f.Title.Contains("throttle decreased"));
+    }
+
+    [Fact]
+    public void IncompleteRecordingAndRecorderLossAreVisible()
+    {
+        var report = RunAnalysis.BuildReport(Run(Steady()) with { IsIncomplete = true, DroppedDatagrams = 2, RejectedDatagrams = 1 });
+        Assert.Contains("before it was complete", report.QualityNote);
+        Assert.Contains("lost", report.QualityNote);
+        Assert.Contains("could not be read", report.QualityNote);
+    }
+
+    [Fact]
+    public void ComparisonShowsConditionDifferencesWithoutAutomaticWinner()
+    {
+        var a = Run(Steady());
+        var b = Run(Steady(41).Select(s => s with
+        {
+            RearRadiusMeters = 0.35,
+            State = s.State with { CarOrdinal = 200, TireTemperatureFahrenheit = new(120, 120, 130, 130), GroundSpeedMetersPerSecond = 15 }
+        }).ToArray());
+        var comparison = RunAnalysis.Compare(a, b, RunPurpose.Drifting);
+        var conditions = comparison.Findings[0];
+        Assert.Equal("Check the starting conditions", conditions.Title);
+        Assert.Contains("same single car", conditions.Detail);
+        Assert.Contains("calibration", conditions.Detail);
+        Assert.Contains("different temperatures", conditions.Detail);
+        Assert.Contains("different durations", conditions.Detail);
+        Assert.DoesNotContain(comparison.Findings, f => f.Title.Contains("winner") || f.Title.Contains("better"));
+        Assert.InRange(comparison.Findings.Length, 1, 3);
+    }
+
+    [Fact]
+    public void ComparisonMeasuresSameSpeedRangeAndLabelsTheQuickestPass()
+    {
+        var a = Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20));
+        var b = Run(Sample(0, 0), Sample(0.1, 20));
+        var result = RunAnalysis.Compare(a, b, RunPurpose.Acceleration, speedFromMetersPerSecond: 5, speedToMetersPerSecond: 15);
+        Assert.Equal(0.1, result.AccelerationA!.DurationSeconds, 8);
+        Assert.Equal(0.05, result.AccelerationB!.DurationSeconds, 8);
+        var finding = Assert.Single(result.Findings, f => f.Title.Contains("sooner"));
+        Assert.Contains("quickest complete pass", finding.Detail);
+        Assert.DoesNotContain("mph", finding.Detail);
+    }
+
+    [Fact]
+    public void AccelerationComparisonKeepsWheelSpeedDifferenceAlongsideTimingAndTireConditions()
+    {
+        var a = Run(Enumerable.Range(0, 161).Select(i => Sample(i * 0.05, Math.Min(35, i * 0.25f),
+            wheel: Math.Min(35, i * 0.25) + (i < 60 ? 10 : 0), throttle: 255)).ToArray());
+        var b = Run(Enumerable.Range(0, 161).Select(i => Sample(i * 0.05, Math.Min(35, i * 0.3f),
+            wheel: Math.Min(35, i * 0.3) + (i < 60 ? 3 : 0), throttle: 255) with
+        { State = Sample(i * 0.05, Math.Min(35, i * 0.3f), throttle: 255).State with { TireTemperatureFahrenheit = new(150, 150, 160, 160) } }).ToArray());
+        var result = RunAnalysis.Compare(a, b, RunPurpose.Acceleration);
+        Assert.Equal(3, result.Findings.Length);
+        Assert.Contains("different temperatures", result.Findings[0].Detail);
+        Assert.Equal("Run B crossed the speed range sooner", result.Findings[1].Title);
+        Assert.Equal("Run B had less wheel-speed excess", result.Findings[2].Title);
+        Assert.DoesNotContain(result.Findings, f => f.Title.Contains("average"));
+        Assert.InRange(result.AccelerationA!.DurationSeconds, 3.57, 3.59);
+        Assert.InRange(result.AccelerationB!.DurationSeconds, 2.97, 2.99);
+    }
+
+    [Fact]
+    public void FindingsOpenTheChannelsThatContainTheirEvidence()
+    {
+        var input = RunAnalysis.BuildReport(Run(Enumerable.Range(0, 21)
+            .Select(i => Sample(i * 0.1, throttle: 255, brake: 30)).ToArray()));
+        Assert.All(input.Findings, finding => Assert.Equal(RunEvidenceView.Inputs, finding.EvidenceView));
+        Assert.Equal(2, input.Findings.Length);
+        var tires = RunAnalysis.BuildReport(Run(Enumerable.Range(0, 21).Select(i => Sample(i * 0.1) with
+        { State = Sample(i * 0.1).State with { TireTemperatureFahrenheit = new(100, 100, 110 + i, 110 + i) } }).ToArray()));
+        Assert.Equal(RunEvidenceView.Tires, Assert.Single(tires.Findings).EvidenceView);
+        var launch = RunAnalysis.BuildReport(Run(Steady()), RunPurpose.Acceleration);
+        Assert.Equal(RunEvidenceView.Speed, Assert.Single(launch.Findings, f => f.Title.StartsWith("Wheel speed")).EvidenceView);
+    }
+
+    [Fact]
+    public void RepeatedShiftPullShowsTotalThrottleTimeAsWellAsItsLongestStretch()
+    {
+        var samples = Enumerable.Range(0, 241).Select(i =>
+        {
+            var time = i * 0.05;
+            var shift = i >= 40 && i % 40 < 3;
+            return Sample(time, 10 + i * 0.15f, wheel: 10 + i * 0.15, throttle: shift ? (byte)0 : (byte)255) with
+            { State = Sample(time, 10 + i * 0.15f, throttle: shift ? (byte)0 : (byte)255).State with { Gear = (TransmissionGear)(2 + i / 40) } };
+        }).ToArray();
+        var report = RunAnalysis.BuildReport(Run(samples), RunPurpose.Acceleration);
+        var finding = Assert.Single(report.Findings, f => f.Title == "Longest full-throttle stretch");
+        Assert.InRange(report.Statistics.FullThrottleSeconds, 10.9, 11.1);
+        Assert.Equal(0, finding.Interval!.Value.StartSeconds, 8);
+        Assert.Equal(1.95, finding.Interval.Value.EndSeconds, 8);
+        Assert.StartsWith("Full throttle totaled ", finding.Detail);
+        Assert.Contains("The longest uninterrupted stretch lasted 1.95 seconds.", finding.Detail);
+        Assert.Equal(RunEvidenceView.Inputs, finding.EvidenceView);
+    }
+
+    [Theory]
+    [InlineData(true, false, "Run A needs")]
+    [InlineData(false, true, "Run B needs")]
+    [InlineData(true, true, "Both Run A and Run B need")]
+    public void MissingSpeedRangeIdentifiesTheSelectionThatNeedsAdjustment(bool missingA, bool missingB, string prefix)
+    {
+        var run = Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20));
+        var result = RunAnalysis.Compare(run, run, RunPurpose.Acceleration,
+            intervalA: missingA ? new RunInterval(0.1, 0.2) : null,
+            intervalB: missingB ? new RunInterval(0.1, 0.2) : null,
+            speedFromMetersPerSecond: 5, speedToMetersPerSecond: 15);
+        var finding = Assert.Single(result.Findings, f => f.Title == "A matching acceleration interval is missing");
+        Assert.StartsWith(prefix, finding.Detail);
+        Assert.Equal(missingA, result.AccelerationA is null);
+        Assert.Equal(missingB, result.AccelerationB is null);
+    }
+
+    [Fact]
+    public void AccelerationComparisonDoesNotPromoteUncalibratedWheelSpeedDifferences()
+    {
+        var a = Run(Steady());
+        var b = Run(Steady().Select(s => s with { WheelSpeedMetersPerSecond = 10, RearRadiusMeters = null }).ToArray());
+        var result = RunAnalysis.Compare(a, b, RunPurpose.Acceleration);
+        Assert.DoesNotContain(result.Findings, f => f.Title.Contains("less wheel-speed"));
+        Assert.Contains(result.Findings, f => f.Detail.Contains("calibration"));
+    }
+
+    [Fact]
+    public void SubsampleIntervalComparisonRetainsCarAndCalibrationContext()
+    {
+        var run = Run(Sample(0, 0), Sample(0.1, 10), Sample(0.2, 20));
+        var result = RunAnalysis.Compare(run, run, intervalA: new(0.02, 0.08), intervalB: new(0.02, 0.08));
+        Assert.DoesNotContain(result.Findings, f => f.Title == "Check the starting conditions");
+        Assert.Equal(5, result.RunA.Statistics.AverageSpeedMetersPerSecond!.Value, 8);
+    }
+
+    [Fact]
+    public void EmptyAndOutOfBoundsSelectionsHaveNoInventedMeasurements()
+    {
+        var empty = RunAnalysis.BuildReport(Run());
+        Assert.Equal(0, empty.Statistics.SampleCount);
+        Assert.Null(empty.Statistics.AverageSpeedMetersPerSecond);
+        Assert.Null(RunAnalysis.MeasureAcceleration(Run(), 5, 15));
+        var outside = RunAnalysis.BuildReport(Run(Sample(0), Sample(0.1)), interval: new(10, 20));
+        Assert.Equal(0, outside.Statistics.RecordedSeconds);
+        Assert.Null(outside.Statistics.AverageSpeedMetersPerSecond);
+    }
+
+    [Theory]
+    [InlineData(-1, 10)]
+    [InlineData(10, 10)]
+    [InlineData(20, 10)]
+    [InlineData(double.NaN, 10)]
+    [InlineData(0, double.PositiveInfinity)]
+    public void InvalidSpeedRangesFailClearly(double from, double to) =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => RunAnalysis.MeasureAcceleration(Run(), from, to));
+
+    [Fact]
+    public void InvalidIntervalsFailClearly() =>
+        Assert.Throws<ArgumentOutOfRangeException>(() => RunAnalysis.BuildReport(Run(Sample(0), Sample(0.1)), interval: new(1, 0)));
+
+    [Fact]
+    public void TenMinuteRecordingProducesStableFiniteStatisticsAndComparison()
+    {
+        var run = Run(Enumerable.Range(0, 60_001).Select(i => Sample(i * 0.01, 20, throttle: 255)).ToArray());
+        var comparison = RunAnalysis.Compare(run, run, RunPurpose.Drifting);
+        Assert.Equal(600, comparison.RunA.Statistics.RecordedSeconds, 6);
+        Assert.Equal(12_000, comparison.RunA.Statistics.DistanceMeters, 5);
+        Assert.Equal(20, comparison.RunA.Statistics.AverageSpeedMetersPerSecond!.Value, 7);
+        Assert.Equal(comparison.RunA.Statistics, comparison.RunB.Statistics);
+        Assert.Equal(0, comparison.RunA.Statistics.GapCount);
+    }
+}

--- a/tests/Wisp.Telemetry.Tests/RunDatagramCaptureTests.cs
+++ b/tests/Wisp.Telemetry.Tests/RunDatagramCaptureTests.cs
@@ -1,0 +1,119 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Wisp.Telemetry.Tests;
+
+public sealed class RunDatagramCaptureTests
+{
+    [Fact]
+    public async Task CapturesEveryDatagramBeforeTheReceiverDrainsItsSharedBuffer()
+    {
+        var port = AvailablePort();
+        await using var receiver = new TelemetryUdpReceiver();
+        await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+        var capture = receiver.BeginRunCapture(32);
+        using var firstReceived = new ManualResetEventSlim();
+        using var releaseReceiver = new ManualResetEventSlim();
+        receiver.DiagnosticObserver = observation =>
+        {
+            if (observation.Kind == TelemetryPacketDiagnosticKind.Received && observation.CarOrdinal == 4000)
+            {
+                firstReceived.Set();
+                releaseReceiver.Wait(TimeSpan.FromSeconds(3));
+            }
+        };
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        try
+        {
+            await Send(4000);
+            await WaitUntil(() => firstReceived.IsSet);
+            for (var car = 4001; car <= 4012; car++) await Send(car);
+        }
+        finally { releaseReceiver.Set(); }
+        await WaitUntil(() => receiver.Latest?.CarOrdinal == 4012);
+        receiver.EndRunCapture(capture);
+        var cars = new List<int>();
+        await foreach (var packet in capture.ReadAllAsync(TestContext.Current.CancellationToken))
+        {
+            cars.Add(BinaryPrimitives.ReadInt32LittleEndian(packet.Bytes.Span.Slice(212, 4)));
+            Assert.Equal(cars.Count, packet.Sequence);
+            Assert.True(packet.Timestamp > 0);
+        }
+        Assert.Equal(Enumerable.Range(4000, 13), cars);
+        Assert.True(receiver.DrainedDatagrams >= 12);
+        Assert.Equal(0, capture.DroppedDatagrams);
+
+        async Task Send(int car)
+        {
+            var bytes = Fh6PacketFixture.Create();
+            Fh6PacketFixture.WriteInt32(bytes, 212, car);
+            await sender.SendAsync(bytes, new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task FullCaptureDropsRecordingDataWithoutBlockingLatestTelemetryOrRestart()
+    {
+        var port = AvailablePort();
+        await using var receiver = new TelemetryUdpReceiver();
+        await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+        var capture = receiver.BeginRunCapture(2);
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        for (var car = 5000; car < 5010; car++)
+        {
+            var bytes = Fh6PacketFixture.Create();
+            Fh6PacketFixture.WriteInt32(bytes, 212, car);
+            await sender.SendAsync(bytes, new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+        }
+        await WaitUntil(() => receiver.Latest?.CarOrdinal == 5009);
+        Assert.Equal(8, capture.DroppedDatagrams);
+        Assert.True(receiver.IsRunning);
+        await receiver.StopAsync();
+        var count = 0;
+        await foreach (var packet in capture.ReadAllAsync(TestContext.Current.CancellationToken))
+        {
+            count++;
+            Assert.Equal(324, packet.Bytes.Length);
+        }
+        Assert.Equal(2, count);
+        Assert.Equal("Telemetry listener changed", capture.CompletionReason);
+    }
+
+    [Fact]
+    public async Task InvalidLengthIsRepresentedWithoutRetainingUnboundedPayload()
+    {
+        var port = AvailablePort();
+        await using var receiver = new TelemetryUdpReceiver();
+        await receiver.StartAsync(port, TestContext.Current.CancellationToken);
+        var capture = receiver.BeginRunCapture(2);
+        using var sender = new UdpClient(AddressFamily.InterNetwork);
+        await sender.SendAsync(new byte[1000], new IPEndPoint(IPAddress.Loopback, port), TestContext.Current.CancellationToken);
+        await WaitUntil(() => receiver.GetStatistics(DateTimeOffset.UtcNow).RejectedPackets == 1);
+        receiver.EndRunCapture(capture);
+        var count = 0;
+        await foreach (var packet in capture.ReadAllAsync(TestContext.Current.CancellationToken))
+        {
+            count++;
+            Assert.True(packet.Bytes.IsEmpty);
+            Assert.False(new Fh6PacketParser().TryParse(packet.Bytes.Span, DateTimeOffset.UtcNow, out _, out _));
+        }
+        Assert.Equal(1, count);
+        Assert.True(receiver.IsRunning);
+    }
+
+    private static int AvailablePort()
+    {
+        using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private static async Task WaitUntil(Func<bool> predicate)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (!predicate() && DateTime.UtcNow < deadline) await Task.Delay(5, TestContext.Current.CancellationToken);
+        Assert.True(predicate());
+    }
+}

--- a/tools/Wisp.UiReview/CalmShellReview.cs
+++ b/tools/Wisp.UiReview/CalmShellReview.cs
@@ -113,7 +113,7 @@ internal static class CalmShellReview
     private sealed class Session
     {
         private static readonly string[] PageNames =
-            ["Dashboard", "Appearance", "Diagnostics", "Profiles", "Setup", "Extras", "Release Notes"];
+            ["Dashboard", "Runs", "Appearance", "Diagnostics", "Profiles", "Setup", "Extras", "Release Notes"];
         private readonly string _output, _settingsPath, _initialHudSettings;
         private readonly SettingsService _settingsService;
         private readonly Application _application;
@@ -295,7 +295,7 @@ internal static class CalmShellReview
             Add("loaded", 20, () =>
             {
                 Check(_window.IsLoaded && _report.ContentRendered && _report.NonactivatingStyle, "loaded-nonactivating-window");
-                Check(_tabs.Items.Count == 5 && _navigation.Items.Count == 5, "page-count");
+                Check(_tabs.Items.Count == PageNames.Length && _navigation.Items.Count == PageNames.Length, "page-count");
                 Check(AppColorThemes.All.Count == 15 && _themes.Items.Count == 15, "theme-count");
                 Check(_globalBrushes.Length > 0, "global-brush-snapshot-empty");
                 CheckRows(); CheckSettled(open: true);

--- a/tools/Wisp.UiReview/Program.cs
+++ b/tools/Wisp.UiReview/Program.cs
@@ -24,7 +24,7 @@ internal static class Program
     private static readonly (string Name, int Width, int Height)[] Viewports =
         [("baseline", 980, 750), ("compact", 720, 440), ("wide", 1280, 900), ("fullscreen", 2560, 1440)];
     private static readonly string[] TabNames =
-        ["dashboard", "appearance", "diagnostics", "profiles", "setup", "extras", "release-notes"];
+        ["dashboard", "runs", "appearance", "diagnostics", "profiles", "setup", "extras", "release-notes"];
     private static readonly (string Name, int Width, int Height)[] WizardViewports =
         [("baseline", 800, 730), ("compact", 540, 440), ("wide", 840, 760), ("launch", 900, 780)];
     private static readonly string[] WizardStepNames = ["welcome", "connection", "display", "appearance"];
@@ -34,6 +34,11 @@ internal static class Program
     {
         try
         {
+            if (args.Length == 3 && args[0] == "--runs-check" && args[1] == "--output")
+            {
+                var output = PrepareOutput(args[2]);
+                return RunsReview.Run(output, () => LoadApplicationResources(output, out _));
+            }
             if (args.Length == 3 && args[0] == "--calm-shell-check" && args[1] == "--output")
             {
                 var output = PrepareOutput(args[2]);
@@ -221,7 +226,7 @@ internal static class Program
 
             if (options.Present)
             {
-                tabs.SelectedIndex = 1;
+                tabs.SelectedIndex = 2;
                 PresentSurface(window, surface, fixture, report, bindings);
                 return;
             }
@@ -229,7 +234,7 @@ internal static class Program
             foreach (var viewport in appearanceOnly ? Viewports.Take(1) : Viewports)
                 for (var index = 0; index < tabs.Items.Count; index++)
                 {
-                    if (appearanceOnly && index != 1)
+                    if (appearanceOnly && index != 2)
                     {
                         continue;
                     }

--- a/tools/Wisp.UiReview/RunsReview.cs
+++ b/tools/Wisp.UiReview/RunsReview.cs
@@ -1,0 +1,454 @@
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using Wisp.App;
+using Wisp.App.Runs;
+using Wisp.Core;
+using Wisp.Core.Runs;
+
+namespace Wisp.UiReview;
+
+internal static class RunsReview
+{
+    internal static int Run(string output, Func<ResourceDictionary> loadResources)
+    {
+        using var deadline = new System.Threading.Timer(_ => Environment.Exit(124), null, TimeSpan.FromSeconds(45), Timeout.InfiniteTimeSpan);
+        using var bindings = new BindingTrace();
+        var captures = new List<object>(); var failures = new List<string>();
+        var foreground = GetForegroundWindow();
+        using var foregroundMonitor = new ForegroundMonitor();
+        var ownWindowActivations = 0;
+        var synchronization = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext(Dispatcher.CurrentDispatcher));
+        AppController? controller = null; MainWindow? source = null; Window? host = null;
+        var application = new ResourceApplication { ShutdownMode = ShutdownMode.OnExplicitShutdown };
+        try
+        {
+            RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
+            application.Resources = loadResources();
+            var fixture = Fixture.All[0]; var settings = fixture.CreateSettings();
+            settings.DebugLoggingEnabled = false; settings.HasCompletedSetup = true;
+            controller = new AppController(settings, new SettingsService(Path.Combine(output, "fixture", "settings.json")));
+            fixture.Apply(controller.ViewModel, waiting: false);
+            source = new MainWindow(controller);
+            source.Activated += (_, _) => ownWindowActivations++;
+            var tabs = (TabControl)source.FindName("RootTabs");
+            var page = (RunsPage)source.FindName("RunsSurface");
+            var scroll = (ScrollViewer)page.FindName("RunsScroll");
+            var graphScroll = (ScrollViewer)page.FindName("GraphScroll");
+            var graphPicker = (ListBox)page.FindName("GraphPicker");
+            var showGraphs = (Button)page.FindName("ShowGraphsButton");
+            var backToSummary = (Button)page.FindName("BackToSummaryButton");
+            var compareOptions = (Expander)page.FindName("CompareExpander");
+            var surface = (FrameworkElement)source.Content;
+            var names = NameScope.GetNameScope(source);
+            var font = (FontFamily)surface.GetValue(TextElement.FontFamilyProperty);
+            var foregroundBrush = (Brush)surface.GetValue(TextElement.ForegroundProperty);
+            source.Content = null;
+            surface.DataContext = controller.ViewModel;
+            surface.SetValue(TextElement.FontFamilyProperty, font); surface.SetValue(TextElement.ForegroundProperty, foregroundBrush);
+            NameScope.SetNameScope(surface, names);
+            surface.Resources.MergedDictionaries.Add(source.Resources);
+            tabs.SelectedItem = source.FindName("RunsTab");
+            host = new Window
+            {
+                Content = surface,
+                Left = -20000,
+                Top = -20000,
+                Width = 1080,
+                Height = 780,
+                WindowStyle = WindowStyle.None,
+                ResizeMode = ResizeMode.NoResize,
+                ShowActivated = false,
+                ShowInTaskbar = false
+            };
+            host.SourceInitialized += (_, _) =>
+            {
+                var hwnd = new WindowInteropHelper(host).Handle;
+                _ = SetWindowLongPtr(hwnd, -20, new IntPtr(GetWindowLongPtr(hwnd, -20).ToInt64() | 0x08000000L | 0x00000080L));
+            };
+            host.Activated += (_, _) => ownWindowActivations++;
+            host.Show();
+            foreach (var (width, height) in new[] { (1080, 780), (720, 440) })
+            {
+                host.Width = width; host.Height = height; Settle(surface);
+                foreach (var comparison in new[] { false, true })
+                {
+                    controller.Runs.ChartGroup = RunChartGroup.Speed;
+                    var a = RunFixture("Hill road · baseline", "Road tune", 1, false);
+                    var b = comparison ? RunFixture("Hill road · revised", "Shorter final drive", 1.15, true) : null;
+                    Await(controller.Runs.ShowReviewAsync(a, b, RunPurpose.Acceleration));
+                    controller.Runs.SetPageVisible(true);
+                    AwaitReady(controller.Runs);
+                    if (!controller.Runs.IsSummaryVisible || controller.Runs.IsGraphWorkspaceOpen || !scroll.IsVisible || graphScroll.IsVisible)
+                        failures.Add("new-report-did-not-open-summary");
+                    if (compareOptions.IsExpanded) failures.Add("comparison-controls-expanded-by-default");
+                    if (Descendants(page).OfType<Button>().Count(button => Equals(button.Content, "Show graphs")) != 1)
+                        failures.Add("graph-entry-is-not-unique");
+                    Capture((comparison ? "comparison" : "report") + $"-{width}-opened");
+                    scroll.ScrollToHome(); Settle(surface);
+                    Capture((comparison ? "comparison" : "report") + $"-{width}-top");
+                    if (comparison)
+                    {
+                        controller.Runs.SameSpeed = true; AwaitReady(controller.Runs);
+                        if (!controller.Runs.SameSpeed) failures.Add("fixture-matched-speed-unavailable");
+                    }
+                    controller.Runs.ChartGroup = RunChartGroup.Speed; AwaitReady(controller.Runs);
+                    Click(showGraphs); CheckGraphNavigation($"{width}-opened", requireVisiblePlot: true);
+                    if (comparison && width == 1080)
+                    {
+                        Await(controller.Runs.ExportImageAsync(Path.Combine(output, "export-comparison-time.png")));
+                        if (controller.Runs.HasError) failures.Add("time-image-export");
+                    }
+                    Capture((comparison ? "comparison" : "report") + $"-{width}-charts");
+                    controller.Runs.SelectInterval(.5, 1.5); AwaitReady(controller.Runs);
+                    controller.Runs.ZoomSelectionCommand.Execute(null); Settle(surface);
+                    if (!controller.Runs.HasSelection || controller.Runs.ViewStart != .5 || controller.Runs.ViewEnd != 1.5)
+                        failures.Add("selected-interval");
+                    Capture((comparison ? "comparison" : "report") + $"-{width}-selection");
+                    Click(backToSummary); CheckSummaryNavigation($"{width}-return");
+                }
+                compareOptions.IsExpanded = true; Settle(surface);
+                var matchToggle = Descendants(compareOptions).OfType<CheckBox>()
+                    .Single(toggle => Equals(toggle.Content, "Match an acceleration speed range"));
+                foreach (var enabled in new[] { false, true })
+                {
+                    controller.Runs.SameSpeed = enabled; AwaitReady(controller.Runs); Settle(surface);
+                    if (matchToggle.IsChecked != enabled || matchToggle.Template.FindName("ToggleTrack", matchToggle) is not Border)
+                        failures.Add("comparison-toggle-does-not-use-wisp-style");
+                    scroll.ScrollToVerticalOffset(scroll.VerticalOffset + matchToggle.TranslatePoint(new Point(), scroll).Y - 50);
+                    Settle(surface); Capture($"comparison-toggle-{width}-" + (enabled ? "checked" : "unchecked"));
+                }
+                matchToggle.SetCurrentValue(UIElement.IsEnabledProperty, false); Settle(surface);
+                if (matchToggle.Template.FindName("ToggleContent", matchToggle) is not FrameworkElement { Opacity: < 1 })
+                    failures.Add("comparison-toggle-disabled-state-not-visible");
+                Capture($"comparison-toggle-{width}-disabled");
+                matchToggle.GetBindingExpression(UIElement.IsEnabledProperty)?.UpdateTarget();
+                compareOptions.IsExpanded = false; Settle(surface);
+                Click(showGraphs); CheckGraphNavigation($"{width}-reopened", requireVisiblePlot: true);
+                controller.Runs.ClearSelectionCommand.Execute(null); AwaitReady(controller.Runs);
+                if (graphPicker.Items.Count != 8) failures.Add("graph-picker-does-not-list-all-eight-views");
+                foreach (var choice in graphPicker.Items.Cast<RunGraphChoice>())
+                {
+                    graphPicker.SetCurrentValue(ListBox.SelectedItemProperty, choice);
+                    AwaitReady(controller.Runs); Settle(surface);
+                    if (controller.Runs.SelectedGraph != choice || controller.Runs.ChartGroup != choice.Group || controller.Runs.GraphView.Mode != choice.Mode)
+                        failures.Add("graph-choice-not-applied-" + choice.Label);
+                    if (choice.Mode == RunPlotMode.TimeSeries ? controller.Runs.Charts.Count == 0 || controller.Runs.AlternativeCharts.Count != 0
+                        : controller.Runs.AlternativeCharts.Count == 0 || controller.Runs.Charts.Count != 0)
+                        failures.Add("graph-choice-content-mismatch-" + choice.Label);
+                    graphScroll.ScrollToHome(); Settle(surface);
+                    CheckGraphNavigation($"{width}-{choice.Group}-{choice.Mode}", requireVisiblePlot: true);
+                    Capture($"comparison-{width}-{choice.Group}-{choice.Mode}");
+                    var pickerTop = graphPicker.TranslatePoint(new Point(), page).Y;
+                    graphScroll.ScrollToEnd(); Settle(surface);
+                    if (Math.Abs(graphPicker.TranslatePoint(new Point(), page).Y - pickerTop) > .5)
+                        failures.Add("graph-picker-moved-with-content-" + choice.Label);
+                    CheckGraphNavigation($"{width}-{choice.Group}-{choice.Mode}-scrolled");
+                    if (choice.Mode == RunPlotMode.PowerByRpm && width == 1080)
+                    {
+                        Await(controller.Runs.ExportImageAsync(Path.Combine(output, "export-comparison-rpm.png")));
+                        if (controller.Runs.HasError) failures.Add("rpm-image-export");
+                    }
+                }
+                Click(backToSummary); CheckSummaryNavigation($"{width}-all-graphs-return");
+                Capture($"summary-{width}-returned");
+                var options = (Expander)page.FindName("RecordingOptionsExpander");
+                options.IsExpanded = true; scroll.ScrollToHome(); Settle(surface); Capture($"options-{width}"); options.IsExpanded = false;
+                Click(showGraphs); CheckGraphNavigation($"{width}-markers-open", requireVisiblePlot: true);
+                var markers = (Expander)page.FindName("MarkersExpander");
+                markers.IsExpanded = true; Settle(surface);
+                graphScroll.ScrollToVerticalOffset(graphScroll.VerticalOffset + markers.TranslatePoint(new Point(), graphScroll).Y);
+                Settle(surface);
+                var jumps = Descendants(markers).OfType<Button>().Where(button => Equals(button.Content, "Jump")).ToArray();
+                if (jumps.Length == 0 || jumps.Any(button => !button.IsEnabled)) failures.Add("marker-jump-buttons-unavailable");
+                Capture($"markers-{width}"); markers.IsExpanded = false;
+                if (jumps.FirstOrDefault() is { Command: { } jumpCommand } markerButton)
+                {
+                    jumpCommand.Execute(markerButton.CommandParameter); AwaitReady(controller.Runs);
+                    CheckGraphNavigation($"{width}-marker-jump", requireVisiblePlot: true);
+                    if (!controller.Runs.IsTimeGraph) failures.Add("marker-did-not-open-time-graph");
+                }
+                var protectedImage = Path.Combine(output, "fixture", $"existing-image-{width}.png");
+                Directory.CreateDirectory(Path.GetDirectoryName(protectedImage)!);
+                File.WriteAllText(protectedImage, "Keep this existing fixture file.");
+                graphScroll.ScrollToEnd(); Settle(surface);
+                Await(controller.Runs.ExportImageAsync(protectedImage)); Settle(surface);
+                var errorFeedback = (TextBlock)page.FindName("GraphActionError");
+                if (!controller.Runs.HasError || errorFeedback.Text != controller.Runs.Error || !WithinPage(errorFeedback))
+                    failures.Add("graph-export-error-not-visible");
+                if (File.ReadAllText(protectedImage) != "Keep this existing fixture file.") failures.Add("graph-export-overwrote-existing-file");
+                Capture($"graph-export-error-{width}");
+                Await(controller.Runs.ExportImageAsync(Path.Combine(output, $"export-feedback-retry-{width}.png"))); AwaitReady(controller.Runs); Settle(surface);
+                var savedFeedback = (TextBlock)page.FindName("GraphExportStatus");
+                if (controller.Runs.HasError || errorFeedback.IsVisible || savedFeedback.Text != RunsViewModel.ImageExportSavedMessage || !WithinPage(savedFeedback))
+                    failures.Add("graph-export-retry-feedback-not-visible");
+                Capture($"graph-export-saved-{width}");
+            }
+            if (bindings.TotalCount != 0) failures.Add("binding-diagnostics");
+            if (!foregroundMonitor.IsAvailable) failures.Add("foreground-monitor-unavailable");
+            CheckOwnForeground();
+            if (ownWindowActivations != 0 || foregroundMonitor.Events != 0) failures.Add("review-window-activated");
+
+            void Capture(string name)
+            {
+                Settle(surface);
+                CheckOwnForeground();
+                var activeScroll = controller.Runs.IsGraphWorkspaceOpen ? graphScroll : scroll;
+                if (activeScroll.ScrollableWidth > .5) failures.Add(name + "/horizontal-overflow");
+                if (controller.Runs.Charts.SelectMany(panel => panel.Series).Any(series => series.Points.Length > 1200)) failures.Add(name + "/geometry-budget");
+                if (new WindowInteropHelper(source).Handle != IntPtr.Zero || host.Left > -10000) failures.Add(name + "/isolation");
+                var bitmap = new RenderTargetBitmap((int)Math.Ceiling(surface.ActualWidth), (int)Math.Ceiling(surface.ActualHeight), 96, 96, PixelFormats.Pbgra32);
+                bitmap.Render(surface); var encoder = new PngBitmapEncoder(); encoder.Frames.Add(BitmapFrame.Create(bitmap));
+                using var file = new FileStream(Path.Combine(output, name + ".png"), FileMode.CreateNew); encoder.Save(file);
+                captures.Add(new
+                {
+                    name,
+                    width = surface.ActualWidth,
+                    height = surface.ActualHeight,
+                    scrollOffset = activeScroll.VerticalOffset,
+                    graphsOpen = controller.Runs.IsGraphWorkspaceOpen,
+                    visiblePlot = VisiblePlot(),
+                    selectedGraph = controller.Runs.SelectedGraph.Label,
+                    chartCount = controller.Runs.Charts.Count,
+                    alternativeChartCount = controller.Runs.AlternativeCharts.Count,
+                    graphMode = controller.Runs.GraphView.Label,
+                    markerCount = controller.Runs.Markers.Count,
+                    metrics = controller.Runs.Metrics.ToArray(),
+                    findings = controller.Runs.Findings.Select(f => new { f.Title, f.Detail }),
+                    interval = controller.Runs.IntervalLabel,
+                    comparison = controller.Runs.ComparisonNote,
+                    bindingWarnings = bindings.TotalCount
+                });
+            }
+            void Click(Button button)
+            {
+                if (!button.IsVisible || !button.IsEnabled) failures.Add("navigation-button-unavailable-" + button.Name);
+                button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent, button));
+                AwaitReady(controller.Runs); Settle(surface);
+            }
+            void CheckSummaryNavigation(string phase)
+            {
+                if (!controller.Runs.IsSummaryVisible || controller.Runs.IsGraphWorkspaceOpen || !scroll.IsVisible || graphScroll.IsVisible)
+                    failures.Add(phase + "/summary-pane-state");
+                if (!showGraphs.IsVisible || !showGraphs.IsEnabled) failures.Add(phase + "/show-graphs-unavailable");
+            }
+            void CheckGraphNavigation(string phase, bool requireVisiblePlot = false)
+            {
+                Settle(surface);
+                if (!controller.Runs.IsGraphWorkspaceOpen || controller.Runs.IsSummaryVisible || !graphScroll.IsVisible || scroll.IsVisible)
+                    failures.Add(phase + "/graph-pane-state");
+                if (!backToSummary.IsVisible || !backToSummary.IsEnabled) failures.Add(phase + "/back-to-summary-unavailable");
+                if (graphScroll.ViewportHeight < 90) failures.Add(phase + "/graph-viewport-too-small");
+                if (requireVisiblePlot)
+                {
+                    var visible = VisiblePlot();
+                    if (visible.Width < 100 || visible.Height < 40) failures.Add(phase + "/plot-data-not-visible-on-entry");
+                    foreach (var chart in Descendants(graphScroll).OfType<FrameworkElement>().Where(element => element.IsVisible && element is RunChartView or RunAlternativePlotView))
+                    {
+                        var drawing = VisualTreeHelper.GetDrawing(chart);
+                        var content = drawing is null ? [] : Drawings(drawing).ToArray();
+                        if (!content.OfType<GlyphRunDrawing>().Any() || !content.OfType<GeometryDrawing>().Any(item => item.Geometry is not null && item.Pen is not null))
+                            failures.Add(phase + "/graph-has-no-rendered-content");
+                    }
+                }
+                foreach (var choice in graphPicker.Items)
+                {
+                    if (graphPicker.ItemContainerGenerator.ContainerFromItem(choice) is not ListBoxItem item || !item.IsVisible)
+                    { failures.Add(phase + "/hidden-graph-choice"); continue; }
+                    var bounds = item.TransformToAncestor(page).TransformBounds(new Rect(item.RenderSize));
+                    if (bounds.Left < -.5 || bounds.Top < -.5 || bounds.Right > page.ActualWidth + .5 || bounds.Bottom > page.ActualHeight + .5)
+                        failures.Add(phase + "/graph-choice-outside-viewport");
+                    if (choice is RunGraphChoice named && AutomationProperties.GetName(item) != named.Label)
+                        failures.Add(phase + "/graph-choice-accessible-name");
+                }
+            }
+            bool WithinPage(FrameworkElement element)
+            {
+                if (!element.IsVisible || element.ActualHeight <= 0 || element.ActualWidth <= 0) return false;
+                var bounds = element.TransformToAncestor(page).TransformBounds(new Rect(element.RenderSize));
+                return bounds.Left >= -.5 && bounds.Top >= -.5 && bounds.Right <= page.ActualWidth + .5 && bounds.Bottom <= page.ActualHeight + .5;
+            }
+            PlotVisibility VisiblePlot()
+            {
+                if (!controller.Runs.IsGraphWorkspaceOpen || !graphScroll.IsVisible) return new(0, 0);
+                var viewport = graphScroll.TransformToAncestor(page).TransformBounds(new Rect(0, 0, graphScroll.ViewportWidth, graphScroll.ViewportHeight));
+                viewport.Intersect(new Rect(page.RenderSize));
+                var best = new PlotVisibility(0, 0);
+                foreach (var chart in Descendants(graphScroll).OfType<FrameworkElement>().Where(element => element.IsVisible && element is RunChartView or RunAlternativePlotView))
+                {
+                    // Inspect the view's actual data rectangle so a visible title or legend cannot pass for a visible graph.
+                    if (chart.GetType().GetProperty("Plot", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(chart) is not Rect dataBounds) continue;
+                    var visible = chart.TransformToAncestor(page).TransformBounds(dataBounds);
+                    visible.Intersect(viewport);
+                    if (!visible.IsEmpty && visible.Width * visible.Height > best.Width * best.Height)
+                        best = new(visible.Width, visible.Height);
+                }
+                return best;
+            }
+            void CheckOwnForeground()
+            {
+                var current = GetForegroundWindow();
+                if (current == IntPtr.Zero) return;
+                _ = GetWindowThreadProcessId(current, out var process);
+                if (process == (uint)Environment.ProcessId && !failures.Contains("review-process-is-foreground"))
+                    failures.Add("review-process-is-foreground");
+            }
+        }
+        catch (Exception error) { failures.Add("review/" + error.GetType().Name + ": " + error.Message); failures.Add(error.StackTrace ?? "No stack trace."); }
+        finally
+        {
+            host?.Close(); source?.Close();
+            if (controller is not null) Await(controller.DisposeAsync().AsTask());
+            application.Shutdown();
+            SynchronizationContext.SetSynchronizationContext(synchronization);
+        }
+        File.WriteAllText(Path.Combine(output, "runs-review.json"), JsonSerializer.Serialize(new
+        {
+            input = "Deterministic synthetic runs; isolated store; no service start, game access, or desktop capture.",
+            captures,
+            failures,
+            ownWindowActivations,
+            ownForegroundEvents = foregroundMonitor.Events,
+            unrelatedForegroundChanged = ownWindowActivations == 0 && foregroundMonitor.Events == 0 && GetForegroundWindow() != foreground,
+            bindingDiagnostics = bindings.Messages
+        }, new JsonSerializerOptions { WriteIndented = true }));
+        Console.WriteLine($"Runs review: {(failures.Count == 0 ? "PASS" : "FAIL")}; {captures.Count} own-surface images; {failures.Count} failures.");
+        return failures.Count == 0 ? 0 : 2;
+    }
+    private sealed record PlotVisibility(double Width, double Height);
+
+    private static IEnumerable<Drawing> Drawings(Drawing drawing)
+    {
+        yield return drawing;
+        if (drawing is DrawingGroup group)
+            foreach (var child in group.Children)
+                foreach (var descendant in Drawings(child)) yield return descendant;
+    }
+
+    private sealed class ForegroundMonitor : IDisposable
+    {
+        private readonly WinEventCallback _callback;
+        private readonly IntPtr _hook;
+        private int _events;
+        internal bool IsAvailable => _hook != IntPtr.Zero;
+        internal int Events => Volatile.Read(ref _events);
+        internal ForegroundMonitor()
+        {
+            _callback = (_, _, _, _, _, _, _) => Interlocked.Increment(ref _events);
+            _hook = SetWinEventHook(3, 3, IntPtr.Zero, _callback, (uint)Environment.ProcessId, 0, 0);
+        }
+        public void Dispose()
+        {
+            if (_hook != IntPtr.Zero) _ = UnhookWinEvent(_hook);
+            GC.KeepAlive(_callback);
+        }
+    }
+
+    private static void Await(Task task)
+    {
+        if (!task.IsCompleted)
+        {
+            var dispatcher = Dispatcher.CurrentDispatcher; var frame = new DispatcherFrame();
+            _ = task.ContinueWith(_ => dispatcher.InvokeAsync(() => frame.Continue = false), TaskScheduler.Default);
+            Dispatcher.PushFrame(frame);
+        }
+        task.GetAwaiter().GetResult();
+    }
+    private static void AwaitReady(RunsViewModel model)
+    {
+        var started = Stopwatch.StartNew();
+        do { Await(Task.Delay(20)); } while ((model.IsBusy || model.IsPreparingCharts) && started.Elapsed < TimeSpan.FromSeconds(5));
+        Await(Task.Delay(40));
+        if (model.IsBusy || model.IsPreparingCharts || model.HasError) throw new InvalidOperationException("Synthetic report did not settle.");
+    }
+    private static void Settle(FrameworkElement surface)
+    {
+        surface.UpdateLayout();
+        surface.Dispatcher.Invoke(static () => { }, DispatcherPriority.ContextIdle);
+        surface.UpdateLayout();
+    }
+
+    private static IEnumerable<DependencyObject> Descendants(DependencyObject parent)
+    {
+        for (var index = 0; index < VisualTreeHelper.GetChildrenCount(parent); index++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, index);
+            yield return child;
+            foreach (var descendant in Descendants(child)) yield return descendant;
+        }
+    }
+
+    private static RecordedRun RunFixture(string name, string tune, double acceleration, bool gap)
+    {
+        var samples = Enumerable.Range(0, 2401).Select(index =>
+        {
+            var time = index / 100d;
+            var speed = (float)(time < 12 ? time * 3 * acceleration : Math.Max(10, 36 * acceleration - (time - 12) * 1.4));
+            var slip = time > 2 && time < 5 ? (float)(4 + Math.Sin(time * 7)) : 0;
+            return new RunSample
+            {
+                ElapsedSeconds = time,
+                IsDriving = true,
+                Segment = 0,
+                FrontRadiusMeters = .34,
+                RearRadiusMeters = .35,
+                WheelSpeedMetersPerSecond = speed + slip,
+                State = new VehicleState
+                {
+                    IsRaceOn = true,
+                    GameTimestampMilliseconds = (uint)(index * 10),
+                    ReceivedAtUtc = DateTimeOffset.UnixEpoch.AddSeconds(time),
+                    CarOrdinal = 101,
+                    Drivetrain = DrivetrainType.RearWheelDrive,
+                    NumCylinders = 8,
+                    GroundSpeedMetersPerSecond = speed,
+                    WheelRotationRadiansPerSecond = new(speed / .34f, speed / .34f, (speed + slip) / .35f, (speed + slip) / .35f),
+                    TireSlipRatio = new(0, 0, slip / 10, slip / 10),
+                    TireSlipAngle = default,
+                    NormalizedSuspensionTravel = new(.5f, .5f, .5f, .5f),
+                    LateralAccelerationMetersPerSecondSquared = (float)Math.Sin(time / 2) * 4,
+                    LongitudinalAccelerationMetersPerSecondSquared = time < 12 ? 3 : -1.4f,
+                    EngineRpm = (float)(1800 + speed * 120 + Math.Sin(time * 4) * 180),
+                    EngineMaximumRpm = 8200,
+                    Gear = time < 5 ? TransmissionGear.Second : TransmissionGear.Third,
+                    Steering = (sbyte)(Math.Sin(time) * (time < 12 ? 4 : 48)),
+                    Accelerator = time < 12 ? (byte)255 : (byte)100,
+                    Brake = time is > 18 and < 20 ? (byte)120 : (byte)0,
+                    BoostPressurePsi = time < 12 ? 14 : -8,
+                    PowerWatts = speed * 8500,
+                    TorqueNm = 650,
+                    TireTemperatureFahrenheit = new(170 + (float)time, 172 + (float)time, 180 + (float)time * 2, 181 + (float)time * 2)
+                }
+            };
+        }).Where(sample => !gap || sample.ElapsedSeconds is < 16 or > 16.6).ToArray();
+        return new RecordedRun
+        {
+            Name = name,
+            Tune = tune,
+            Notes = "Same road, rolling start. Review the early wheelspin and tire temperatures.",
+            StartedAtUtc = new DateTimeOffset(2026, 1, 2, 12, 0, 0, TimeSpan.Zero),
+            FinishReason = "Stopped by you",
+            Markers = [new(4.5, "Wheelspin"), new(9, "Shift")],
+            Samples = samples
+        };
+    }
+    private sealed class ResourceApplication : Application { protected override void OnStartup(StartupEventArgs e) { } }
+    private delegate void WinEventCallback(IntPtr hook, uint eventType, IntPtr hwnd, int objectId, int childId, uint threadId, uint eventTime);
+    [DllImport("user32.dll")] private static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr module, WinEventCallback callback, uint process, uint thread, uint flags);
+    [DllImport("user32.dll")][return: MarshalAs(UnmanagedType.Bool)] private static extern bool UnhookWinEvent(IntPtr hook);
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint process);
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW")] private static extern IntPtr GetWindowLongPtr(IntPtr hwnd, int index);
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW")] private static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr value);
+}

--- a/tools/Wisp.UiReview/ScrollPresentation.cs
+++ b/tools/Wisp.UiReview/ScrollPresentation.cs
@@ -80,9 +80,9 @@ internal static class ScrollPresentation
     public static void Run(MainWindow sourceWindow, FrameworkElement surface, TabControl tabs, Fixture fixture,
         ReviewReport report, BindingTrace bindings, CancellationToken cancellationToken)
     {
-        if (report.ScrollCheck is null || tabs.Items[1] is not TabItem { Content: ScrollViewer scroll })
+        if (report.ScrollCheck is null || tabs.Items[2] is not TabItem { Content: ScrollViewer scroll })
             throw new InvalidOperationException("The scroll presentation contract changed.");
-        tabs.SelectedIndex = 1;
+        tabs.SelectedIndex = 2;
         var originalContent = scroll.Content;
         var originalDecorator = originalContent is Decorator and not Viewbox ? (Decorator)originalContent : null;
         var viewbox = originalContent as Viewbox ?? originalDecorator?.Child as Viewbox

--- a/tools/Wisp.UiReview/ScrollReview.cs
+++ b/tools/Wisp.UiReview/ScrollReview.cs
@@ -74,8 +74,9 @@ internal static class ScrollReview
             {
                 token.ThrowIfCancellationRequested();
                 AssertOffscreen(sourceWindow, surface);
-                tabs.SelectedIndex = tab;
-                if (tabs.Items[tab] is not TabItem { Content: ScrollViewer scroll })
+                var selected = tabs.Items.OfType<TabItem>().Single(item => string.Equals(item.Header?.ToString(), Tabs[tab], StringComparison.OrdinalIgnoreCase));
+                tabs.SelectedItem = selected;
+                if (selected.Content is not ScrollViewer scroll)
                 {
                     throw new InvalidOperationException("The main-tab scroll contract changed.");
                 }


### PR DESCRIPTION
Adds local run recording with optional shortcuts, countdowns, timed stops and review markers. Saved runs support names, tune labels, notes, time or matched-speed comparison, and image/CSV/recording exports.

The Runs page presents interpreted findings and eight graph views through one Show graphs action. Comparisons use distinct colors, line styles and matching legends. Final audit fixes cover hidden export feedback, first-open blank charts, duplicated marker labels, failed-load selection mismatches and Compare previous choosing a newer recording. Graph choices expose readable accessibility names and keyboard focus follows explicit navigation.

Capture and analysis are bounded and separated from the live HUD renderer. Existing profiles and calibration are preserved. Includes public 1.2 metadata, release notes and README updates.

Validation: final focused workflow/export/navigation tests passed (79); isolated WPF review passed 48 captures at two window sizes, including graph choices, toggle states and export failure/retry. Earlier preview packaging passed the full .NET and Python suites, native renderer provenance and installer runtime checks. Required GitHub build and installer checks must pass on this final release commit before merge.
