### PR TITLE
Wisp 1.2.1: CPU rendering option and reduced dial drawing work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 Notable changes to Wisp are recorded here.
 
-## 1.2.1 - Test candidate
+## 1.2.1 - 2026-09-10
 
+- Add an optional **CPU rendering** toggle in Diagnostics for Analogue tachometer lag or hitching. GPU rendering remains the default. Choose **Exit Wisp** from the tray menu and reopen Wisp to apply the change.
+- CPU mode can increase CPU usage. Other gauges keep their existing renderers, and Windows still uses the GPU to compose the overlay.
+- Reuse unchanged dial-background pixels in CPU mode to reduce repeated drawing work while the needle and live readings continue updating.
 - Separate queued telemetry publication time from consumption time so a sample queued during rendering cannot falsely trigger the needle's clock-rewind reset.
 - Draw the Analogue HUD once per pending frame, then retry only Present while the queue is busy. Continue consuming telemetry; discard pending pixels when their layout or source becomes invalid, or after occlusion.
-- Add bounded, nonblocking debug capture for frame waits, scene building, drawing, buffer mapping, presentation results and retry delays. These measure CPU-side operations, not displayed FPS.
-- Retain the existing renderer, artwork, interpolation, settings and Record and Compare Runs features. Remaining choppiness under game load still requires confirmation on affected PCs.
+- Add bounded, nonblocking debug capture for frame waits, scene building, drawing, buffer mapping, presentation results and retry delays. Exports identify the active rendering mode and separate the native wait from its surrounding checks. These measure CPU-side operations, not displayed FPS.
+- Preserve the existing artwork, needle interpolation, HUD settings and Record and Compare Runs features.
 
 ## 1.2.0 - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to Wisp are recorded here.
 
+## 1.2.1 - Test candidate
+
+- Separate queued telemetry publication time from consumption time so a sample queued during rendering cannot falsely trigger the needle's clock-rewind reset.
+- Draw the Analogue HUD once per pending frame, then retry only Present while the queue is busy. Continue consuming telemetry; discard pending pixels when their layout or source becomes invalid, or after occlusion.
+- Add bounded, nonblocking debug capture for frame waits, scene building, drawing, buffer mapping, presentation results and retry delays. These measure CPU-side operations, not displayed FPS.
+- Retain the existing renderer, artwork, interpolation, settings and Record and Compare Runs features. Remaining choppiness under game load still requires confirmation on affected PCs.
+
 ## 1.2.0 - 2026-09-09
 
 - Record drives locally from Dashboard or Runs, with optional shortcuts, a start countdown, timed stops and markers for moments to review.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
   <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
 </p>
 
+## New in Wisp 1.2.1
+
+If the Analogue tachometer lags or hitches, enable **CPU rendering** in
+**Diagnostics**. Right-click Wisp's tray icon, choose **Exit Wisp**, then reopen
+it to apply the change.
+
+CPU mode reuses the unchanged dial background to reduce repeated drawing work,
+while the needle and live readings continue updating.
+
+GPU rendering remains the default. CPU mode can increase CPU usage; other
+gauges keep their existing renderers. The gauge artwork, needle smoothing,
+HUD settings, and Record and Compare Runs features are preserved.
+
+[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
+[1.2.1 release notes](docs/releases/Wisp-1.2.1-release-notes.md)
+
 ## New in Wisp 1.2
 
 Record a drive and compare it with another run without leaving Wisp. Start from

--- a/docs/releases/Wisp-1.2.1-release-notes.md
+++ b/docs/releases/Wisp-1.2.1-release-notes.md
@@ -1,0 +1,31 @@
+# Wisp 1.2.1
+
+September 10, 2026
+
+Adds an optional CPU rendering mode for the Analogue tachometer, for PCs that
+experience overlay lag or hitching.
+
+1. Open **Diagnostics** and enable **CPU rendering**.
+2. Right-click Wisp's tray icon and choose **Exit Wisp**.
+3. Reopen Wisp to apply the change.
+
+CPU mode reuses the unchanged dial background to reduce repeated drawing work,
+while the needle and live readings continue updating.
+
+GPU rendering remains the default. CPU mode can increase CPU usage. Other
+gauges keep their existing renderers, and Windows still uses the GPU to compose
+the overlay. The gauge artwork and needle smoothing are preserved.
+
+Also included:
+
+- Prevents telemetry queued during rendering from falsely resetting needle
+  playback when the render thread catches up.
+- Reuses the already drawn HUD when Windows is busy accepting a frame, avoiding
+  repeated drawing work during presentation retries.
+- Expands bounded local debug exports with the active rendering mode, detailed
+  frame waits, drawing and presentation timings. These measurements help
+  investigate hitching; they are not displayed frame rates.
+
+The installer is `Wisp-Setup-1.2.1.exe`. Install over your current Wisp version
+to keep your HUD settings, profiles, tire calibration and saved runs. Record
+and Compare Runs remain available.

--- a/installer/Wisp.iss
+++ b/installer/Wisp.iss
@@ -1,5 +1,5 @@
 #define MyAppName "Wisp"
-#define MyAppVersion "1.2.0"
+#define MyAppVersion "1.2.1"
 #define MyAppDisplayVersion MyAppVersion
 #define MyAppOutputVersion MyAppVersion
 #define MyAppPublisher "Wisp"

--- a/src/Wisp.App/AppController.cs
+++ b/src/Wisp.App/AppController.cs
@@ -238,6 +238,16 @@ public sealed partial class AppController : IAsyncDisposable
         _receiver.DiagnosticObserver = enabled ? TachDiagnostics.RecordTelemetry : null;
     }
 
+    public void SetCpuRenderingEnabled(bool enabled)
+    {
+        if (_disposed) return;
+        var previous = Settings.CpuRenderingEnabled;
+        Settings.CpuRenderingEnabled = enabled;
+        var saved = SaveSettings();
+        if (!saved) Settings.CpuRenderingEnabled = previous;
+        ViewModel.UpdateCpuRendering(Settings.CpuRenderingEnabled, saved);
+    }
+
     public async Task SetDebugLoggingEnabledAsync(bool enabled)
     {
         if (_disposed)

--- a/src/Wisp.App/AppSettings.cs
+++ b/src/Wisp.App/AppSettings.cs
@@ -82,6 +82,7 @@ public sealed class AppSettings
     public bool AnimatedBackground { get; set; } = true;
     public bool AutomaticApplicationUpdateChecks { get; set; } = true;
     public DateTimeOffset? LastApplicationUpdateCheckUtc { get; set; }
+    public bool CpuRenderingEnabled { get; set; }
     public bool DebugLoggingEnabled { get; set; }
     public DateTimeOffset? DebugLoggingExpiresAtUtc { get; set; }
     public string ColorTheme { get; set; } = AppColorThemes.DefaultName;

--- a/src/Wisp.App/DebugLogging/DebugLogService.cs
+++ b/src/Wisp.App/DebugLogging/DebugLogService.cs
@@ -457,6 +457,8 @@ internal sealed class DebugLogService : IAsyncDisposable
                                 WriteEntry(archive, "tach-native-recent.ndjson", capture.NativeRecent.Select(SerializeDiagnostic));
                                 WriteEntry(archive, "tach-needle-startup.ndjson", capture.NeedleStartup.Select(SerializeDiagnostic));
                                 WriteEntry(archive, "tach-needle-recent.ndjson", capture.NeedleRecent.Select(SerializeDiagnostic));
+                                WriteEntry(archive, "tach-renderer-startup.ndjson", capture.RendererStartup.Select(SerializeDiagnostic));
+                                WriteEntry(archive, "tach-renderer-recent.ndjson", capture.RendererRecent.Select(SerializeDiagnostic));
                                 WriteEntry(archive, "tach-lifecycle.ndjson", capture.Lifecycle.Select(SerializeDiagnostic));
                                 WriteEntry(archive, "tach-native-context.ndjson", capture.NativeContexts.Select(SerializeDiagnostic));
                             }

--- a/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
@@ -12,8 +12,12 @@ internal static class TachDiagnosticReport
         "Raw needle routes: immediate/composition record WPF transform application; directcomposition records successful Present submissions only, excluding queue-busy and occluded attempts. " +
         "AppliedTimestamp is the sampling time, not presentation completion. Neither route proves physical display. Interval applied counts combine routes; inspect raw routes before comparing rates.";
     private const string RendererPolicy =
-        "Renderer events record completed CPU-side operations, including failed and queue-busy attempts. All timestamps and duration ticks use the process Stopwatch clock; optional CPU thread ticks must use that same frequency. " +
+        "Renderer events record completed CPU-side operations, including failed and queue-busy attempts. All timestamps and duration ticks use the process Stopwatch clock. " +
         "Stage durations can contain waits; native setup/map timings are included in native draw, which is included in draw-stage time. Do not add nested durations. " +
+        "The frame_wait stage measures the full managed wrapper. Nullable native_wait_ticks measures the native wrapper; wait_precheck_ticks covers cancellation/device checks, wait_call_ticks covers WaitForMultipleObjects, and wait_postcheck_ticks covers the checks/outcome handling after it. " +
+        "Wait call elapsed time includes delayed thread resumption and is not an exact blocked-time measurement. Missing split fields mean unavailable, not zero cost; measured zero can mean that an early return skipped a later portion. " +
+        "Nullable wait_return_code is the Win32 wait outcome, including a cancellation precheck; 0xffffffff also marks an error before the wait was reached. Nullable swap_chain_generation starts at 1 and increments on replacement within that renderer lifetime, not ordinary resizing. " +
+        "Optional cpu_thread_ticks is coarse GetThreadTimes CPU accounting normalized from 100-nanosecond units to Stopwatch frequency; null means unavailable. It is not GPU execution time or a precise measure of blocked time or scheduler delay. " +
         "Present submitted means accepted by the presentation API, not displayed. Sequence correlates a prepared frame and its retry operations; use completion timestamps to order operations. Sample/received/queued timestamps can repeat across attempts. " +
         "Input ages are measured at operation start, exclude missing/future origins, and do not measure physical display latency. " +
         "Thrown draw/present operations retain stage elapsed time and HRESULT, but nested native durations are unavailable and recorded as zero for those error events.";
@@ -80,10 +84,10 @@ internal static class TachDiagnosticReport
             native_value_fields = "top-level nullable angle/blur are validated values; nested read.angle/read.blur are zero sanitization placeholders",
             native_changed_policy = "validated native angle changes counted across all observed reads; this is not displayed FPS",
             needle_route_policy = NeedleRoutePolicy,
-            renderer_schema_version = 1,
+            renderer_schema_version = 2,
             renderer_policy = RendererPolicy,
             renderer_detail_policy = "every observed completed operation, bounded startup/recent rings; no sampling. In-progress operations at export have no completion record",
-            renderer_aggregate_policy = "at most 256 control/window/stage/result/HRESULT groups per collected interval; excess groups retain raw detail but omit aggregates. Counters reset each interval",
+            renderer_aggregate_policy = "at most 256 control/window/stage/result/HRESULT/wait-return-code groups per collected interval; excess groups retain raw detail but omit aggregates. Counters reset each interval. Split timing sample counts describe measured coverage; nullable totals and generation bounds stay null when unavailable",
             renderer_omission_counters = "cumulative within each capture; use the latest or maximum, do not sum intervals",
             renderer_contention_omissions = capture?.RendererContentionOmissions,
             renderer_aggregate_omissions = capture?.RendererAggregateOmissions,
@@ -199,29 +203,62 @@ internal static class TachDiagnosticReport
         if (longest is not null)
             text.AppendLine($"Longest observed renderer operation: {longest.Stage}/{longest.Result}, {Number(longest.MaximumMilliseconds)} ms (control {longest.ControlId}, window handle {longest.HostWindowHandle}). This identifies where time was observed, not why the operation waited.");
         text.AppendLine("Renderer stages by control and outcome (CPU-side elapsed time, including waits):");
-        foreach (var group in observations.GroupBy(value => (value.ControlId, value.HostWindowHandle, value.Stage, value.Result, value.HResult)).Take(256))
+        foreach (var group in observations.GroupBy(value => (value.ControlId, value.HostWindowHandle, value.NativeThreadId, value.Stage, value.Result, value.HResult, value.WaitReturnCode)).Take(256))
         {
             var count = group.Sum(value => (double)value.Count);
             var mean = group.Sum(value => value.MeanMilliseconds * value.Count) / Math.Max(1, count);
             var queueSamples = group.Sum(value => (double)value.QueueAgeSamples);
             var queueAge = group.Sum(value => value.MeanQueueAgeMilliseconds * value.QueueAgeSamples) / Math.Max(1, queueSamples);
             text.AppendLine($"  Control {group.Key.ControlId}, window handle {group.Key.HostWindowHandle}, {group.Key.Stage}/{group.Key.Result}, HRESULT 0x{group.Key.HResult:X8}: {Number(count)} operations; {Number(mean)} ms mean, {Number(group.Max(value => value.MaximumMilliseconds))} ms maximum.");
+            text.AppendLine($"    Native render thread: {(group.Key.NativeThreadId is { } threadId ? threadId.ToString(CultureInfo.InvariantCulture) : "unavailable")}.");
             text.AppendLine($"    Draw commands/maps: {Number(group.Sum(value => (double)value.DrawCommands))}/{Number(group.Sum(value => (double)value.MapCount))}; total scene/setup/native draw/map/present: {Number(group.Sum(value => value.TotalSceneMilliseconds))}/{Number(group.Sum(value => value.TotalNativeSetupMilliseconds))}/{Number(group.Sum(value => value.TotalNativeDrawMilliseconds))}/{Number(group.Sum(value => value.TotalMapMilliseconds))}/{Number(group.Sum(value => value.TotalNativePresentMilliseconds))} ms; maximum single map: {Number(group.Max(value => value.MaximumMapMilliseconds))} ms.");
             text.AppendLine($"    Queue age: {Number(queueAge)} ms mean, {Number(group.Max(value => value.MaximumQueueAgeMilliseconds))} ms maximum ({Number(queueSamples)} observations); discarded queued inputs: {Number(group.Sum(value => (double)value.QueueDropped))}.");
+            if (group.Key.Stage == "frame_wait")
+            {
+                text.AppendLine($"    Native wait total: {DurationCoverage(group, value => value.NativeWaitSamples, value => value.TotalNativeWaitMilliseconds)}; precheck: {DurationCoverage(group, value => value.WaitPrecheckSamples, value => value.TotalWaitPrecheckMilliseconds)}; wait call: {DurationCoverage(group, value => value.WaitCallSamples, value => value.TotalWaitCallMilliseconds)}; postcheck: {DurationCoverage(group, value => value.WaitPostcheckSamples, value => value.TotalWaitPostcheckMilliseconds)}.");
+                var maximumCall = group.Max(value => value.MaximumWaitCallMilliseconds);
+                var firstGeneration = group.Min(value => value.MinimumSwapChainGeneration);
+                var lastGeneration = group.Max(value => value.MaximumSwapChainGeneration);
+                text.AppendLine($"    Maximum wait call: {(maximumCall is { } maximum ? Number(maximum) + " ms" : "unavailable")}; Win32 wait outcome: {(group.Key.WaitReturnCode is { } code ? $"0x{code:X8}" : "unavailable")}; swap-chain generation range: {(firstGeneration is { } first && lastGeneration is { } last ? $"{first}-{last}" : "unavailable")} ({Number(group.Sum(value => (double)value.SwapChainGenerationSamples))} observations).");
+                text.AppendLine($"    Coarse thread CPU accounting: {DurationCoverage(group, value => value.CpuThreadSamples, value => value.TotalCpuThreadMilliseconds)}. Missing measurements are not evidence of zero CPU work or zero waiting.");
+            }
         }
+    }
+
+    private static string DurationCoverage(IEnumerable<TachRendererCounts> values,
+        Func<TachRendererCounts, long> samples, Func<TachRendererCounts, double?> milliseconds)
+    {
+        var count = values.Sum(value => (double)samples(value));
+        return count == 0 ? "unavailable (0 observations)" :
+            $"{Number(values.Sum(value => milliseconds(value) ?? 0))} ms ({Number(count)} observations)";
     }
 
     private static string RendererTotal(IEnumerable<TachRendererCounts> values, string stage, string result) =>
         Number(values.Where(value => value.Stage == stage && value.Result == result).Sum(value => (double)value.Count));
 
     private static bool ValidRendererCounts(TachRendererCounts value) =>
+        value.NativeThreadId is not 0 &&
         value.Count >= 0 && value.DrawCommands >= 0 && value.MapCount >= 0 && value.QueueDropped >= 0 &&
         value.QueueAgeSamples >= 0 && value.ReceiveAgeSamples >= 0 && value.SampleAgeSamples >= 0 && value.CpuThreadSamples >= 0 &&
+        ValidOptionalDuration(value.NativeWaitSamples, value.TotalNativeWaitMilliseconds, value.Count) &&
+        ValidOptionalDuration(value.WaitPrecheckSamples, value.TotalWaitPrecheckMilliseconds, value.Count) &&
+        ValidOptionalDuration(value.WaitCallSamples, value.TotalWaitCallMilliseconds, value.Count) &&
+        ValidOptionalDuration(value.WaitCallSamples, value.MaximumWaitCallMilliseconds, value.Count) &&
+        ValidOptionalDuration(value.WaitPostcheckSamples, value.TotalWaitPostcheckMilliseconds, value.Count) &&
+        (value.WaitCallSamples == 0 || value.MaximumWaitCallMilliseconds <= value.TotalWaitCallMilliseconds) &&
+        value.SwapChainGenerationSamples >= 0 && value.SwapChainGenerationSamples <= value.Count &&
+        (value.SwapChainGenerationSamples == 0
+            ? value.MinimumSwapChainGeneration is null && value.MaximumSwapChainGeneration is null
+            : value.MinimumSwapChainGeneration is > 0 && value.MaximumSwapChainGeneration >= value.MinimumSwapChainGeneration) &&
         new[] { value.MeanMilliseconds, value.MaximumMilliseconds, value.TotalMapMilliseconds, value.MaximumMapMilliseconds,
             value.TotalSceneMilliseconds, value.TotalNativeSetupMilliseconds, value.TotalNativeDrawMilliseconds,
             value.TotalNativePresentMilliseconds, value.MeanQueueAgeMilliseconds, value.MaximumQueueAgeMilliseconds,
             value.MeanReceiveAgeMilliseconds, value.MaximumReceiveAgeMilliseconds, value.MeanSampleAgeMilliseconds,
             value.MaximumSampleAgeMilliseconds, value.TotalCpuThreadMilliseconds }.All(number => double.IsFinite(number) && number >= 0);
+
+    private static bool ValidOptionalDuration(long samples, double? total, long count) =>
+        samples >= 0 && samples <= count && (samples == 0 ? total is null :
+            total is { } milliseconds && double.IsFinite(milliseconds) && milliseconds >= 0);
 
     internal static object Coverage<T>(T[] startup, T[] recent, long overwritten,
         int startupCapacity, int recentCapacity, Func<T, long> timestamp) where T : struct => new

--- a/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnosticReport.cs
@@ -11,6 +11,12 @@ internal static class TachDiagnosticReport
     private const string NeedleRoutePolicy =
         "Raw needle routes: immediate/composition record WPF transform application; directcomposition records successful Present submissions only, excluding queue-busy and occluded attempts. " +
         "AppliedTimestamp is the sampling time, not presentation completion. Neither route proves physical display. Interval applied counts combine routes; inspect raw routes before comparing rates.";
+    private const string RendererPolicy =
+        "Renderer events record completed CPU-side operations, including failed and queue-busy attempts. All timestamps and duration ticks use the process Stopwatch clock; optional CPU thread ticks must use that same frequency. " +
+        "Stage durations can contain waits; native setup/map timings are included in native draw, which is included in draw-stage time. Do not add nested durations. " +
+        "Present submitted means accepted by the presentation API, not displayed. Sequence correlates a prepared frame and its retry operations; use completion timestamps to order operations. Sample/received/queued timestamps can repeat across attempts. " +
+        "Input ages are measured at operation start, exclude missing/future origins, and do not measure physical display latency. " +
+        "Thrown draw/present operations retain stage elapsed time and HRESULT, but nested native durations are unavailable and recorded as zero for those error events.";
 
     internal static string? SafeCaptureId(string? value) =>
         value is { Length: 32 } && value.All(character => character is >= '0' and <= '9' or >= 'a' and <= 'f')
@@ -21,7 +27,9 @@ internal static class TachDiagnosticReport
         if (SafeCaptureId(sample.CaptureId) is null || !double.IsFinite(sample.IntervalMilliseconds) ||
             sample.IntervalMilliseconds <= 0 || sample.NativeReads is null || sample.Needles is null ||
             sample.NativeReads.Length > 1024 || sample.Needles.Length > 128 ||
-            sample.NativeReads.Any(read => read is null) || sample.Needles.Any(needle => needle is null))
+            sample.NativeReads.Any(read => read is null) || sample.Needles.Any(needle => needle is null) ||
+            sample.Renderer is null || sample.Renderer.Length > TachDiagnostics.RendererAggregateCapacity ||
+            sample.Renderer.Any(renderer => renderer is null || !ValidRendererCounts(renderer)))
             return null;
 
         return sample with
@@ -37,6 +45,11 @@ internal static class TachDiagnosticReport
             {
                 ControlKind = needle.ControlKind is "analogue" or "digital" ? needle.ControlKind : "unknown",
                 HostKind = HostKind(needle.HostKind)
+            }).ToArray(),
+            Renderer = sample.Renderer.Select(renderer => renderer with
+            {
+                Stage = TachDiagnostics.RendererStage(renderer.Stage),
+                Result = TachDiagnostics.RendererResult(renderer.Result)
             }).ToArray()
         };
     }
@@ -67,6 +80,14 @@ internal static class TachDiagnosticReport
             native_value_fields = "top-level nullable angle/blur are validated values; nested read.angle/read.blur are zero sanitization placeholders",
             native_changed_policy = "validated native angle changes counted across all observed reads; this is not displayed FPS",
             needle_route_policy = NeedleRoutePolicy,
+            renderer_schema_version = 1,
+            renderer_policy = RendererPolicy,
+            renderer_detail_policy = "every observed completed operation, bounded startup/recent rings; no sampling. In-progress operations at export have no completion record",
+            renderer_aggregate_policy = "at most 256 control/window/stage/result/HRESULT groups per collected interval; excess groups retain raw detail but omit aggregates. Counters reset each interval",
+            renderer_omission_counters = "cumulative within each capture; use the latest or maximum, do not sum intervals",
+            renderer_contention_omissions = capture?.RendererContentionOmissions,
+            renderer_aggregate_omissions = capture?.RendererAggregateOmissions,
+            renderer_invalid_omissions = capture?.RendererInvalidOmissions,
             native_context_records = capture?.NativeContexts.Length,
             native_context_policy = "active compatibility pack changes; at most the latest 32 records",
             contention_omissions = capture?.ContentionOmissions,
@@ -86,6 +107,9 @@ internal static class TachDiagnosticReport
                 capture.NeedleOverwritten, 18_000, 45_000, value => value.AppliedTimestamp),
             lifecycle = capture is null ? null : Coverage(Array.Empty<TachLifecycleDiagnostic>(), capture.Lifecycle,
                 capture.LifecycleOverwritten, 0, 1024, value => value.Timestamp),
+            renderer = capture is null ? null : Coverage(capture.RendererStartup, capture.RendererRecent,
+                capture.RendererOverwritten, TachDiagnostics.RendererStartupCapacity, TachDiagnostics.RendererRecentCapacity,
+                value => value.CompletedTimestamp),
             build = new
             {
                 diagnostic_build_id = ApplicationVersionInfo.DiagnosticBuildId,
@@ -108,6 +132,7 @@ internal static class TachDiagnosticReport
         text.AppendLine("Only the selected capture contributes to the measurements below. Other retained sessions remain in tach-intervals.ndjson.");
         text.AppendLine("Game FPS, GPU presentation and the physical display are not measured. Applied/changed values are not displayed frames.");
         text.AppendLine(NeedleRoutePolicy);
+        text.AppendLine(RendererPolicy);
         text.AppendLine("A steady RPM or native angle can correctly produce few changed values. These measurements alone cannot establish a renderer or Windows root cause.");
         if (capture is null)
         {
@@ -120,6 +145,7 @@ internal static class TachDiagnosticReport
             text.AppendLine($"Raw input startup/recent: {capture.InputStartup.Length}/{capture.InputRecent.Length}; recent overwritten: {capture.InputOverwritten}.");
             text.AppendLine($"Raw native startup/recent: {capture.NativeStartup.Length}/{capture.NativeRecent.Length}; recent overwritten: {capture.NativeOverwritten}.");
             text.AppendLine($"Raw needle startup/recent: {capture.NeedleStartup.Length}/{capture.NeedleRecent.Length}; recent overwritten: {capture.NeedleOverwritten}.");
+            text.AppendLine($"Raw renderer startup/recent: {capture.RendererStartup.Length}/{capture.RendererRecent.Length}; recent overwritten: {capture.RendererOverwritten}.");
             text.AppendLine($"Lifecycle retained: {capture.Lifecycle.Length}; overwritten: {capture.LifecycleOverwritten}.");
             text.AppendLine($"Collector contention omissions: {capture.ContentionOmissions}; native details sampled out: {capture.NativeDetailSampledOut}.");
             text.AppendLine("Startup is the first 60 seconds per stream, subject to capacity. Startup and recent histories overlap; consult tach-manifest.json before combining them.");
@@ -137,6 +163,7 @@ internal static class TachDiagnosticReport
         text.AppendLine($"Input received/drained/accepted/rejected/UI-selected: {Total(selected, interval => interval.InputReceived)}/{Total(selected, interval => interval.InputDrained)}/{Total(selected, interval => interval.InputAccepted)}/{Total(selected, interval => interval.InputRejected)}/{Total(selected, interval => interval.UiSelected)}.");
         text.AppendLine($"Accepted input rate: {Number(selected.Sum(interval => (double)interval.InputAccepted) / Math.Max(seconds, 0.001))}/second; observed RPM changes: {Total(selected, interval => interval.RpmChanges)}; maximum accepted gap: {Number(selected.Max(interval => interval.MaximumAcceptedGapMilliseconds))} ms.");
         text.AppendLine($"Fractional worker waits/deadline already due/signaled wakeups: {Total(selected, interval => interval.FractionalWaits)}/{Total(selected, interval => interval.DeadlineAlreadyDue)}/{Total(selected, interval => interval.WaitWakeups)}; maximum wait: {Number(selected.Max(interval => interval.MaximumWaitMilliseconds))} ms.");
+        AppendRenderer(text, selected);
         text.AppendLine("Native reads (all observed attempts; details are capped at 60 Hz plus state changes):");
         foreach (var group in selected.SelectMany(interval => interval.NativeReads)
                      .GroupBy(read => (read.Stage, read.Failure, read.Cache, read.Route)).Take(64))
@@ -156,6 +183,45 @@ internal static class TachDiagnosticReport
         text.AppendLine("Compare times with health.ndjson and your observation. One-second observations can miss brief focus changes; a low changed count alone is not evidence of lag.");
         return text.ToString();
     }
+
+    private static void AppendRenderer(StringBuilder text, TachIntervalDiagnostic[] selected)
+    {
+        var observations = selected.SelectMany(interval => interval.Renderer).ToArray();
+        text.AppendLine($"Renderer cumulative omissions (contention/aggregate capacity/invalid timing): {selected.Max(interval => interval.RendererContentionOmissions)}/{selected.Max(interval => interval.RendererAggregateOmissions)}/{selected.Max(interval => interval.RendererInvalidOmissions)}.");
+        if (observations.Length == 0)
+        {
+            text.AppendLine("No renderer-stage observations in these intervals. Older builds did not record these timings; absence is not zero rendering work.");
+            return;
+        }
+        text.AppendLine($"Present attempts submitted/busy/occluded/error: {RendererTotal(observations, "present", "submitted")}/{RendererTotal(observations, "present", "busy")}/{RendererTotal(observations, "present", "occluded")}/{RendererTotal(observations, "present", "error")}; frame-wait timeouts: {RendererTotal(observations, "frame_wait", "timeout")}.");
+        var longest = observations.Where(value => value.Count > 0)
+            .OrderByDescending(value => value.MaximumMilliseconds).FirstOrDefault();
+        if (longest is not null)
+            text.AppendLine($"Longest observed renderer operation: {longest.Stage}/{longest.Result}, {Number(longest.MaximumMilliseconds)} ms (control {longest.ControlId}, window handle {longest.HostWindowHandle}). This identifies where time was observed, not why the operation waited.");
+        text.AppendLine("Renderer stages by control and outcome (CPU-side elapsed time, including waits):");
+        foreach (var group in observations.GroupBy(value => (value.ControlId, value.HostWindowHandle, value.Stage, value.Result, value.HResult)).Take(256))
+        {
+            var count = group.Sum(value => (double)value.Count);
+            var mean = group.Sum(value => value.MeanMilliseconds * value.Count) / Math.Max(1, count);
+            var queueSamples = group.Sum(value => (double)value.QueueAgeSamples);
+            var queueAge = group.Sum(value => value.MeanQueueAgeMilliseconds * value.QueueAgeSamples) / Math.Max(1, queueSamples);
+            text.AppendLine($"  Control {group.Key.ControlId}, window handle {group.Key.HostWindowHandle}, {group.Key.Stage}/{group.Key.Result}, HRESULT 0x{group.Key.HResult:X8}: {Number(count)} operations; {Number(mean)} ms mean, {Number(group.Max(value => value.MaximumMilliseconds))} ms maximum.");
+            text.AppendLine($"    Draw commands/maps: {Number(group.Sum(value => (double)value.DrawCommands))}/{Number(group.Sum(value => (double)value.MapCount))}; total scene/setup/native draw/map/present: {Number(group.Sum(value => value.TotalSceneMilliseconds))}/{Number(group.Sum(value => value.TotalNativeSetupMilliseconds))}/{Number(group.Sum(value => value.TotalNativeDrawMilliseconds))}/{Number(group.Sum(value => value.TotalMapMilliseconds))}/{Number(group.Sum(value => value.TotalNativePresentMilliseconds))} ms; maximum single map: {Number(group.Max(value => value.MaximumMapMilliseconds))} ms.");
+            text.AppendLine($"    Queue age: {Number(queueAge)} ms mean, {Number(group.Max(value => value.MaximumQueueAgeMilliseconds))} ms maximum ({Number(queueSamples)} observations); discarded queued inputs: {Number(group.Sum(value => (double)value.QueueDropped))}.");
+        }
+    }
+
+    private static string RendererTotal(IEnumerable<TachRendererCounts> values, string stage, string result) =>
+        Number(values.Where(value => value.Stage == stage && value.Result == result).Sum(value => (double)value.Count));
+
+    private static bool ValidRendererCounts(TachRendererCounts value) =>
+        value.Count >= 0 && value.DrawCommands >= 0 && value.MapCount >= 0 && value.QueueDropped >= 0 &&
+        value.QueueAgeSamples >= 0 && value.ReceiveAgeSamples >= 0 && value.SampleAgeSamples >= 0 && value.CpuThreadSamples >= 0 &&
+        new[] { value.MeanMilliseconds, value.MaximumMilliseconds, value.TotalMapMilliseconds, value.MaximumMapMilliseconds,
+            value.TotalSceneMilliseconds, value.TotalNativeSetupMilliseconds, value.TotalNativeDrawMilliseconds,
+            value.TotalNativePresentMilliseconds, value.MeanQueueAgeMilliseconds, value.MaximumQueueAgeMilliseconds,
+            value.MeanReceiveAgeMilliseconds, value.MaximumReceiveAgeMilliseconds, value.MeanSampleAgeMilliseconds,
+            value.MaximumSampleAgeMilliseconds, value.TotalCpuThreadMilliseconds }.All(number => double.IsFinite(number) && number >= 0);
 
     internal static object Coverage<T>(T[] startup, T[] recent, long overwritten,
         int startupCapacity, int recentCapacity, Func<T, long> timestamp) where T : struct => new

--- a/src/Wisp.App/DebugLogging/TachDiagnostics.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnostics.cs
@@ -50,6 +50,7 @@ internal readonly record struct TachLifecycleDiagnostic(
 internal readonly record struct TachRendererDiagnostic
 {
     public int ControlId { get; init; }
+    public uint? NativeThreadId { get; init; }
     public long HostWindowHandle { get; init; }
     public long Sequence { get; init; }
     public string Stage { get; init; }
@@ -70,6 +71,12 @@ internal readonly record struct TachRendererDiagnostic
     public int HResult { get; init; }
     public int QueueDropped { get; init; }
     public long? CpuThreadTicks { get; init; }
+    public long? NativeWaitTicks { get; init; }
+    public long? WaitPrecheckTicks { get; init; }
+    public long? WaitCallTicks { get; init; }
+    public long? WaitPostcheckTicks { get; init; }
+    public uint? SwapChainGeneration { get; init; }
+    public uint? WaitReturnCode { get; init; }
 }
 
 internal sealed record TachRendererCounts(
@@ -83,6 +90,20 @@ internal sealed record TachRendererCounts(
     long CpuThreadSamples, double TotalCpuThreadMilliseconds)
 {
     public int HResult { get; init; }
+    public uint? NativeThreadId { get; init; }
+    public long NativeWaitSamples { get; init; }
+    public double? TotalNativeWaitMilliseconds { get; init; }
+    public long WaitPrecheckSamples { get; init; }
+    public double? TotalWaitPrecheckMilliseconds { get; init; }
+    public long WaitCallSamples { get; init; }
+    public double? TotalWaitCallMilliseconds { get; init; }
+    public double? MaximumWaitCallMilliseconds { get; init; }
+    public long WaitPostcheckSamples { get; init; }
+    public double? TotalWaitPostcheckMilliseconds { get; init; }
+    public long SwapChainGenerationSamples { get; init; }
+    public uint? MinimumSwapChainGeneration { get; init; }
+    public uint? MaximumSwapChainGeneration { get; init; }
+    public uint? WaitReturnCode { get; init; }
 }
 
 internal sealed record TachNativeCounts(string Stage, string Failure, string Cache, string Route,
@@ -360,7 +381,13 @@ internal static class TachDiagnostics
                 NativeDrawTicks = Math.Max(0, sample.NativeDrawTicks),
                 NativePresentTicks = Math.Max(0, sample.NativePresentTicks),
                 QueueDropped = Math.Max(0, sample.QueueDropped),
-                CpuThreadTicks = sample.CpuThreadTicks is >= 0 ? sample.CpuThreadTicks : null
+                CpuThreadTicks = sample.CpuThreadTicks is >= 0 ? sample.CpuThreadTicks : null,
+                NativeThreadId = sample.NativeThreadId is > 0 ? sample.NativeThreadId : null,
+                NativeWaitTicks = sample.NativeWaitTicks is >= 0 ? sample.NativeWaitTicks : null,
+                WaitPrecheckTicks = sample.WaitPrecheckTicks is >= 0 ? sample.WaitPrecheckTicks : null,
+                WaitCallTicks = sample.WaitCallTicks is >= 0 ? sample.WaitCallTicks : null,
+                WaitPostcheckTicks = sample.WaitPostcheckTicks is >= 0 ? sample.WaitPostcheckTicks : null,
+                SwapChainGeneration = sample.SwapChainGeneration is > 0 ? sample.SwapChainGeneration : null
             };
             capture.Renderer.Add(clean, clean.CompletedTimestamp);
             var index = 0;
@@ -485,14 +512,22 @@ internal static class TachDiagnostics
         private long _queueSamples, _receiveSamples, _sampleSamples, _cpuSamples;
         private double _queueAge, _receiveAge, _sampleAge;
         private long _maxQueueAge, _maxReceiveAge, _maxSampleAge;
+        private long _nativeWaitSamples, _precheckSamples, _waitCallSamples, _postcheckSamples, _generationSamples;
+        private double _nativeWaitTicks, _precheckTicks, _waitCallTicks, _postcheckTicks;
+        private long _maxWaitCallTicks;
+        private uint? _minimumGeneration, _maximumGeneration, _waitReturnCode, _nativeThreadId;
 
         internal readonly bool Matches(in TachRendererDiagnostic value) =>
-            _controlId == value.ControlId && _window == value.HostWindowHandle && _stage == value.Stage && _result == value.Result && _hResult == value.HResult;
+            _controlId == value.ControlId && _window == value.HostWindowHandle && _stage == value.Stage &&
+            _result == value.Result && _hResult == value.HResult && _waitReturnCode == value.WaitReturnCode &&
+            _nativeThreadId == value.NativeThreadId;
 
         internal void Observe(in TachRendererDiagnostic value)
         {
             _controlId = value.ControlId; _window = value.HostWindowHandle; _stage = value.Stage; _result = value.Result;
             _hResult = value.HResult;
+            _waitReturnCode = value.WaitReturnCode;
+            _nativeThreadId = value.NativeThreadId;
             _count++;
             var elapsed = value.CompletedTimestamp - value.StartedTimestamp;
             _ticks += elapsed; _maximum = Math.Max(_maximum, elapsed);
@@ -504,6 +539,20 @@ internal static class TachDiagnostics
             Age(value.StartedTimestamp, value.ReceivedTimestamp, ref _receiveSamples, ref _receiveAge, ref _maxReceiveAge);
             Age(value.StartedTimestamp, value.SampleTimestamp, ref _sampleSamples, ref _sampleAge, ref _maxSampleAge);
             if (value.CpuThreadTicks is { } cpu) { _cpuSamples++; _cpuTicks += cpu; }
+            if (value.NativeWaitTicks is { } nativeWait) { _nativeWaitSamples++; _nativeWaitTicks += nativeWait; }
+            if (value.WaitPrecheckTicks is { } precheck) { _precheckSamples++; _precheckTicks += precheck; }
+            if (value.WaitCallTicks is { } waitCall)
+            {
+                _waitCallSamples++; _waitCallTicks += waitCall;
+                _maxWaitCallTicks = Math.Max(_maxWaitCallTicks, waitCall);
+            }
+            if (value.WaitPostcheckTicks is { } postcheck) { _postcheckSamples++; _postcheckTicks += postcheck; }
+            if (value.SwapChainGeneration is { } generation)
+            {
+                _generationSamples++;
+                _minimumGeneration = _minimumGeneration is { } minimum ? Math.Min(minimum, generation) : generation;
+                _maximumGeneration = _maximumGeneration is { } maximum ? Math.Max(maximum, generation) : generation;
+            }
         }
 
         private static void Age(long now, long? origin, ref long samples, ref double sum, ref long maximum)
@@ -519,7 +568,23 @@ internal static class TachDiagnostics
             _queueSamples, Ms(_queueAge) / Math.Max(1, _queueSamples), Milliseconds(_maxQueueAge),
             _receiveSamples, Ms(_receiveAge) / Math.Max(1, _receiveSamples), Milliseconds(_maxReceiveAge),
             _sampleSamples, Ms(_sampleAge) / Math.Max(1, _sampleSamples), Milliseconds(_maxSampleAge), _cpuSamples, Ms(_cpuTicks))
-        { HResult = _hResult };
+        {
+            HResult = _hResult,
+            NativeThreadId = _nativeThreadId,
+            NativeWaitSamples = _nativeWaitSamples,
+            TotalNativeWaitMilliseconds = _nativeWaitSamples > 0 ? Ms(_nativeWaitTicks) : null,
+            WaitPrecheckSamples = _precheckSamples,
+            TotalWaitPrecheckMilliseconds = _precheckSamples > 0 ? Ms(_precheckTicks) : null,
+            WaitCallSamples = _waitCallSamples,
+            TotalWaitCallMilliseconds = _waitCallSamples > 0 ? Ms(_waitCallTicks) : null,
+            MaximumWaitCallMilliseconds = _waitCallSamples > 0 ? Milliseconds(_maxWaitCallTicks) : null,
+            WaitPostcheckSamples = _postcheckSamples,
+            TotalWaitPostcheckMilliseconds = _postcheckSamples > 0 ? Ms(_postcheckTicks) : null,
+            SwapChainGenerationSamples = _generationSamples,
+            MinimumSwapChainGeneration = _minimumGeneration,
+            MaximumSwapChainGeneration = _maximumGeneration,
+            WaitReturnCode = _waitReturnCode
+        };
 
         private static double Ms(double ticks) => ticks * 1000d / Stopwatch.Frequency;
     }

--- a/src/Wisp.App/DebugLogging/TachDiagnostics.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnostics.cs
@@ -47,6 +47,44 @@ internal readonly record struct TachLifecycleDiagnostic(
     long Timestamp, int ControlId, string ControlKind, string HostKind, long HostWindowHandle,
     bool IsLoaded, bool IsVisible, bool IsLive);
 
+internal readonly record struct TachRendererDiagnostic
+{
+    public int ControlId { get; init; }
+    public long HostWindowHandle { get; init; }
+    public long Sequence { get; init; }
+    public string Stage { get; init; }
+    public string Result { get; init; }
+    public long StartedTimestamp { get; init; }
+    public long CompletedTimestamp { get; init; }
+    public long? SampleTimestamp { get; init; }
+    public long? ReceivedTimestamp { get; init; }
+    public long? QueuedTimestamp { get; init; }
+    public int DrawCommands { get; init; }
+    public int MapCount { get; init; }
+    public long MapTicks { get; init; }
+    public long MaxMapTicks { get; init; }
+    public long SceneTicks { get; init; }
+    public long NativeSetupTicks { get; init; }
+    public long NativeDrawTicks { get; init; }
+    public long NativePresentTicks { get; init; }
+    public int HResult { get; init; }
+    public int QueueDropped { get; init; }
+    public long? CpuThreadTicks { get; init; }
+}
+
+internal sealed record TachRendererCounts(
+    int ControlId, long HostWindowHandle, string Stage, string Result, long Count,
+    double MeanMilliseconds, double MaximumMilliseconds, long DrawCommands, long MapCount,
+    double TotalMapMilliseconds, double MaximumMapMilliseconds, double TotalSceneMilliseconds,
+    double TotalNativeSetupMilliseconds, double TotalNativeDrawMilliseconds, double TotalNativePresentMilliseconds,
+    long QueueDropped, long QueueAgeSamples, double MeanQueueAgeMilliseconds, double MaximumQueueAgeMilliseconds,
+    long ReceiveAgeSamples, double MeanReceiveAgeMilliseconds, double MaximumReceiveAgeMilliseconds,
+    long SampleAgeSamples, double MeanSampleAgeMilliseconds, double MaximumSampleAgeMilliseconds,
+    long CpuThreadSamples, double TotalCpuThreadMilliseconds)
+{
+    public int HResult { get; init; }
+}
+
 internal sealed record TachNativeCounts(string Stage, string Failure, string Cache, string Route,
     long Count, double MeanReadMilliseconds, double MaximumReadMilliseconds)
 {
@@ -65,7 +103,13 @@ internal sealed record TachIntervalDiagnostic(
     long RpmChanges, double MaximumAcceptedGapMilliseconds, long FractionalWaits,
     long DeadlineAlreadyDue, long WaitWakeups, double MaximumWaitMilliseconds,
     long ContentionOmissions, long NativeDetailSampledOut,
-    TachNativeCounts[] NativeReads, TachNeedleCounts[] Needles);
+    TachNativeCounts[] NativeReads, TachNeedleCounts[] Needles)
+{
+    public TachRendererCounts[] Renderer { get; init; } = [];
+    public long RendererContentionOmissions { get; init; }
+    public long RendererAggregateOmissions { get; init; }
+    public long RendererInvalidOmissions { get; init; }
+}
 
 internal sealed record TachCaptureExport(
     string CaptureId, DateTimeOffset StartedAtUtc, long StartedTimestamp, long ExportedTimestamp,
@@ -76,6 +120,12 @@ internal sealed record TachCaptureExport(
     TachLifecycleDiagnostic[] Lifecycle, long LifecycleOverwritten)
 {
     public TachNativeContext[] NativeContexts { get; init; } = [];
+    public TachRendererDiagnostic[] RendererStartup { get; init; } = [];
+    public TachRendererDiagnostic[] RendererRecent { get; init; } = [];
+    public long RendererOverwritten { get; init; }
+    public long RendererContentionOmissions { get; init; }
+    public long RendererAggregateOmissions { get; init; }
+    public long RendererInvalidOmissions { get; init; }
 }
 
 internal sealed record TachNativeContext(long Timestamp, string PackId, int Revision, string GameVersion,
@@ -87,6 +137,9 @@ internal sealed record TachNativeContext(long Timestamp, string PackId, int Revi
 /// </summary>
 internal static class TachDiagnostics
 {
+    internal const int RendererStartupCapacity = 18_000;
+    internal const int RendererRecentCapacity = 45_000;
+    internal const int RendererAggregateCapacity = 256;
     private static readonly object LifecycleGate = new();
     private static Capture? _capture;
     private static int _enabled;
@@ -278,6 +331,58 @@ internal static class TachDiagnostics
         finally { Monitor.Exit(capture.Gate); }
     }
 
+    internal static void RecordRenderer(in TachRendererDiagnostic sample)
+    {
+        if (!IsEnabled || Volatile.Read(ref _capture) is not { } capture) return;
+        if (!Monitor.TryEnter(capture.Gate))
+        {
+            Interlocked.Increment(ref capture.ContentionOmissions);
+            Interlocked.Increment(ref capture.RendererContentionOmissions);
+            return;
+        }
+        try
+        {
+            if (sample.StartedTimestamp <= 0 || sample.CompletedTimestamp < sample.StartedTimestamp)
+            {
+                capture.RendererInvalidOmissions++;
+                return;
+            }
+            var clean = sample with
+            {
+                Stage = RendererStage(sample.Stage),
+                Result = RendererResult(sample.Result),
+                DrawCommands = Math.Max(0, sample.DrawCommands),
+                MapCount = Math.Max(0, sample.MapCount),
+                MapTicks = Math.Max(0, sample.MapTicks),
+                MaxMapTicks = Math.Max(0, sample.MaxMapTicks),
+                SceneTicks = Math.Max(0, sample.SceneTicks),
+                NativeSetupTicks = Math.Max(0, sample.NativeSetupTicks),
+                NativeDrawTicks = Math.Max(0, sample.NativeDrawTicks),
+                NativePresentTicks = Math.Max(0, sample.NativePresentTicks),
+                QueueDropped = Math.Max(0, sample.QueueDropped),
+                CpuThreadTicks = sample.CpuThreadTicks is >= 0 ? sample.CpuThreadTicks : null
+            };
+            capture.Renderer.Add(clean, clean.CompletedTimestamp);
+            var index = 0;
+            for (; index < capture.RendererCount; index++)
+                if (capture.RendererCounts[index].Matches(in clean)) break;
+            if (index == capture.RendererCount)
+            {
+                if (index == capture.RendererCounts.Length)
+                {
+                    capture.RendererAggregateOmissions++;
+                    return;
+                }
+                capture.RendererCount++;
+            }
+            capture.RendererCounts[index].Observe(in clean);
+        }
+        finally { Monitor.Exit(capture.Gate); }
+    }
+
+    internal static string RendererStage(string? value) => value is "frame_wait" or "draw" or "present" or "retry_wait" or "state" ? value : "unknown";
+    internal static string RendererResult(string? value) => value is "ready" or "timeout" or "cancelled" or "submitted" or "busy" or "occluded" or "error" or "discarded" or "created" or "resized" or "resumed" ? value : "unknown";
+
     internal static TachIntervalDiagnostic? CollectInterval(DateTimeOffset utcNow)
     {
         if (!IsEnabled || Volatile.Read(ref _capture) is not { } capture) return null;
@@ -293,12 +398,20 @@ internal static class TachDiagnostics
                     pair.Key.Cache.ToString(), pair.Key.Route, pair.Value.Count,
                     Milliseconds(pair.Value.Ticks) / Math.Max(1, pair.Value.Count), Milliseconds(pair.Value.MaximumTicks))
                 { Changed = pair.Value.Changed }).ToArray(),
-                capture.NeedleCounts.Select(pair => pair.Value.Snapshot(pair.Key)).ToArray());
+                capture.NeedleCounts.Select(pair => pair.Value.Snapshot(pair.Key)).ToArray())
+            {
+                Renderer = capture.RendererCounts.Take(capture.RendererCount).Select(count => count.Snapshot()).ToArray(),
+                RendererContentionOmissions = Interlocked.Read(ref capture.RendererContentionOmissions),
+                RendererAggregateOmissions = capture.RendererAggregateOmissions,
+                RendererInvalidOmissions = capture.RendererInvalidOmissions
+            };
             capture.LastInterval = now;
             capture.InputReceived = capture.InputDrained = capture.InputAccepted = capture.InputRejected = capture.UiSelected = 0;
             capture.RpmChanges = capture.MaximumAcceptedGap = capture.FractionalWaits = capture.DeadlineAlreadyDue = capture.WaitWakeups = capture.MaximumWait = 0;
             capture.NativeCounts.Clear();
             foreach (var count in capture.NeedleCounts.Values) count.ResetInterval();
+            Array.Clear(capture.RendererCounts, 0, capture.RendererCount);
+            capture.RendererCount = 0;
             return result;
         }
     }
@@ -314,7 +427,15 @@ internal static class TachDiagnostics
                 capture.Native.Startup(), capture.Native.Recent(), capture.Native.Overwritten,
                 capture.Needle.Startup(), capture.Needle.Recent(), capture.Needle.Overwritten,
                 capture.Lifecycle.Recent(), capture.Lifecycle.Overwritten)
-            { NativeContexts = capture.NativeContexts.ToArray() };
+            {
+                NativeContexts = capture.NativeContexts.ToArray(),
+                RendererStartup = capture.Renderer.Startup(),
+                RendererRecent = capture.Renderer.Recent(),
+                RendererOverwritten = capture.Renderer.Overwritten,
+                RendererContentionOmissions = Interlocked.Read(ref capture.RendererContentionOmissions),
+                RendererAggregateOmissions = capture.RendererAggregateOmissions,
+                RendererInvalidOmissions = capture.RendererInvalidOmissions
+            };
         }
     }
 
@@ -332,6 +453,10 @@ internal static class TachDiagnostics
         internal readonly History<TachNativeDiagnostic> Native = new(18_000, 6_000);
         internal readonly History<TachNeedleDiagnostic> Needle = new(45_000, 18_000);
         internal readonly History<TachLifecycleDiagnostic> Lifecycle = new(1024, 0);
+        internal readonly History<TachRendererDiagnostic> Renderer = new(RendererRecentCapacity, RendererStartupCapacity);
+        internal readonly RendererCounter[] RendererCounts = new RendererCounter[RendererAggregateCapacity];
+        internal int RendererCount;
+        internal long RendererContentionOmissions, RendererAggregateOmissions, RendererInvalidOmissions;
         internal readonly Dictionary<(NativeGaugeReadStage Stage, NativeGaugeReadFailure Failure, NativeGaugeCacheOutcome Cache, string Route), NativeCounter> NativeCounts = new();
         internal readonly Dictionary<int, NeedleCounter> NeedleCounts = new();
         internal (NativeGaugeReadStage Stage, NativeGaugeReadFailure Failure, NativeGaugeCacheOutcome Cache, string Route) LastNativeKey;
@@ -348,6 +473,55 @@ internal static class TachDiagnostics
     private sealed class NativeCounter
     {
         internal long Count, Changed, Ticks, MaximumTicks;
+    }
+
+    private struct RendererCounter
+    {
+        private int _controlId, _hResult;
+        private long _window;
+        private string _stage, _result;
+        private long _count, _maximum, _draws, _maps, _maxMap, _dropped;
+        private double _ticks, _mapTicks, _sceneTicks, _setupTicks, _drawTicks, _presentTicks, _cpuTicks;
+        private long _queueSamples, _receiveSamples, _sampleSamples, _cpuSamples;
+        private double _queueAge, _receiveAge, _sampleAge;
+        private long _maxQueueAge, _maxReceiveAge, _maxSampleAge;
+
+        internal readonly bool Matches(in TachRendererDiagnostic value) =>
+            _controlId == value.ControlId && _window == value.HostWindowHandle && _stage == value.Stage && _result == value.Result && _hResult == value.HResult;
+
+        internal void Observe(in TachRendererDiagnostic value)
+        {
+            _controlId = value.ControlId; _window = value.HostWindowHandle; _stage = value.Stage; _result = value.Result;
+            _hResult = value.HResult;
+            _count++;
+            var elapsed = value.CompletedTimestamp - value.StartedTimestamp;
+            _ticks += elapsed; _maximum = Math.Max(_maximum, elapsed);
+            _draws += value.DrawCommands; _maps += value.MapCount; _mapTicks += value.MapTicks;
+            _maxMap = Math.Max(_maxMap, value.MaxMapTicks); _sceneTicks += value.SceneTicks;
+            _setupTicks += value.NativeSetupTicks; _drawTicks += value.NativeDrawTicks; _presentTicks += value.NativePresentTicks;
+            _dropped += value.QueueDropped;
+            Age(value.StartedTimestamp, value.QueuedTimestamp, ref _queueSamples, ref _queueAge, ref _maxQueueAge);
+            Age(value.StartedTimestamp, value.ReceivedTimestamp, ref _receiveSamples, ref _receiveAge, ref _maxReceiveAge);
+            Age(value.StartedTimestamp, value.SampleTimestamp, ref _sampleSamples, ref _sampleAge, ref _maxSampleAge);
+            if (value.CpuThreadTicks is { } cpu) { _cpuSamples++; _cpuTicks += cpu; }
+        }
+
+        private static void Age(long now, long? origin, ref long samples, ref double sum, ref long maximum)
+        {
+            if (origin is not > 0 || origin.Value > now) return;
+            var age = now - origin.Value;
+            samples++; sum += age; maximum = Math.Max(maximum, age);
+        }
+
+        internal readonly TachRendererCounts Snapshot() => new(_controlId, _window, _stage, _result, _count,
+            Ms(_ticks) / Math.Max(1, _count), Milliseconds(_maximum), _draws, _maps, Ms(_mapTicks), Milliseconds(_maxMap),
+            Ms(_sceneTicks), Ms(_setupTicks), Ms(_drawTicks), Ms(_presentTicks), _dropped,
+            _queueSamples, Ms(_queueAge) / Math.Max(1, _queueSamples), Milliseconds(_maxQueueAge),
+            _receiveSamples, Ms(_receiveAge) / Math.Max(1, _receiveSamples), Milliseconds(_maxReceiveAge),
+            _sampleSamples, Ms(_sampleAge) / Math.Max(1, _sampleSamples), Milliseconds(_maxSampleAge), _cpuSamples, Ms(_cpuTicks))
+        { HResult = _hResult };
+
+        private static double Ms(double ticks) => ticks * 1000d / Stopwatch.Frequency;
     }
 
     private sealed class NeedleCounter

--- a/src/Wisp.App/DebugLogging/TachDiagnostics.cs
+++ b/src/Wisp.App/DebugLogging/TachDiagnostics.cs
@@ -49,6 +49,7 @@ internal readonly record struct TachLifecycleDiagnostic(
 
 internal readonly record struct TachRendererDiagnostic
 {
+    public bool? CpuRendering { get; init; }
     public int ControlId { get; init; }
     public uint? NativeThreadId { get; init; }
     public long HostWindowHandle { get; init; }

--- a/src/Wisp.App/DiagnosticsViewModel.cs
+++ b/src/Wisp.App/DiagnosticsViewModel.cs
@@ -96,6 +96,8 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     private bool _startMinimizedWithForza;
     private bool _animatedBackground;
     private bool _automaticApplicationUpdateChecks;
+    private bool _cpuRenderingEnabled;
+    private string _cpuRenderingChangeStatus = "";
     private bool _debugLoggingEnabled;
     private string _debugLoggingStatus = "Off — no debug files are created";
     private bool _tractionCueEnabled;
@@ -158,6 +160,8 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
         _startMinimizedWithForza = settings.StartMinimizedWithForza;
         _animatedBackground = settings.AnimatedBackground;
         _automaticApplicationUpdateChecks = settings.AutomaticApplicationUpdateChecks;
+        _cpuRenderingEnabled = settings.CpuRenderingEnabled;
+        ActiveCpuRendering = settings.CpuRenderingEnabled;
         _debugLoggingEnabled = settings.DebugLoggingEnabled;
         if (_debugLoggingEnabled && settings.DebugLoggingExpiresAtUtc is { } expiresAtUtc)
         {
@@ -218,6 +222,16 @@ public sealed class DiagnosticsViewModel : INotifyPropertyChanged
     public string NativeCompatibilityUpdates { get => _nativeCompatibilityUpdates; private set => Set(ref _nativeCompatibilityUpdates, value); }
     public bool CanCheckNativeCompatibility { get => _canCheckNativeCompatibility; private set => Set(ref _canCheckNativeCompatibility, value); }
     public bool CanImportNativeCompatibility { get => _canImportNativeCompatibility; private set => Set(ref _canImportNativeCompatibility, value); }
+    public bool ActiveCpuRendering { get; }
+    public bool CpuRenderingEnabled { get => _cpuRenderingEnabled; private set => Set(ref _cpuRenderingEnabled, value); }
+    public string CpuRenderingChangeStatus { get => _cpuRenderingChangeStatus; private set => Set(ref _cpuRenderingChangeStatus, value); }
+    internal void UpdateCpuRendering(bool enabled, bool saved)
+    {
+        CpuRenderingEnabled = enabled;
+        CpuRenderingChangeStatus = !saved ? "Could not save the renderer option. Try again."
+            : enabled != ActiveCpuRendering ? "Restart Wisp to apply this change." : "";
+    }
+
     public bool DebugLoggingEnabled { get => _debugLoggingEnabled; private set => Set(ref _debugLoggingEnabled, value); }
     public string DebugLoggingStatus { get => _debugLoggingStatus; private set => Set(ref _debugLoggingStatus, value); }
     public string LateralGText { get => _lateralGText; private set => Set(ref _lateralGText, value); }

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1450,12 +1450,14 @@
                                                               ToolTip="Opt in for up to 24 hours. No files are created while this is off." />
                                                 </WrapPanel>
                                                 <StackPanel Margin="0,14,0,0">
-                                                    <CheckBox x:Name="CpuRenderingToggle" Content="CPU rendering (Analogue tachometer)"
+                                                    <CheckBox x:Name="CpuRenderingToggle" Content="CPU rendering"
                                                               IsChecked="{Binding CpuRenderingEnabled, Mode=OneWay}" Click="CpuRenderingToggle_Click"
                                                               Style="{StaticResource ToggleSwitchStyle}" FontSize="11"
                                                               AutomationProperties.Name="CPU rendering for the Analogue tachometer"
-                                                              AutomationProperties.HelpText="Requires restarting Wisp. Off uses the GPU. Windows still uses the GPU to composite the overlay." />
-                                                    <TextBlock Text="Requires restarting Wisp. Off uses the GPU; on draws the Analogue tachometer on the CPU. Other gauges and Windows composition still use their existing rendering paths. CPU usage may increase."
+                                                              AutomationProperties.HelpText="Please enable CPU rendering if you are experiencing lag or hitching in the overlay. Applies to the Analogue tachometer. Restart Wisp to apply." />
+                                                    <TextBlock Text="Please enable CPU rendering if you are experiencing lag or hitching in the overlay."
+                                                               Foreground="{DynamicResource MutedBrush}" TextWrapping="Wrap" FontSize="11" Margin="0,6,0,0" />
+                                                    <TextBlock Text="Applies to the Analogue tachometer. Exit Wisp from the tray icon and reopen it to apply. CPU usage may increase."
                                                                Foreground="{DynamicResource FaintBrush}" TextWrapping="Wrap" FontSize="10" Margin="0,6,0,0" />
                                                     <TextBlock Text="{Binding CpuRenderingChangeStatus}" TextWrapping="Wrap" FontSize="11"
                                                                Foreground="{DynamicResource TextBrush}" Margin="0,4,0,0" AutomationProperties.LiveSetting="Polite" />

--- a/src/Wisp.App/MainWindow.xaml
+++ b/src/Wisp.App/MainWindow.xaml
@@ -1449,6 +1449,17 @@
                                                               AutomationProperties.HelpText="Opt in for up to 24 hours. No files are created while this is off."
                                                               ToolTip="Opt in for up to 24 hours. No files are created while this is off." />
                                                 </WrapPanel>
+                                                <StackPanel Margin="0,14,0,0">
+                                                    <CheckBox x:Name="CpuRenderingToggle" Content="CPU rendering (Analogue tachometer)"
+                                                              IsChecked="{Binding CpuRenderingEnabled, Mode=OneWay}" Click="CpuRenderingToggle_Click"
+                                                              Style="{StaticResource ToggleSwitchStyle}" FontSize="11"
+                                                              AutomationProperties.Name="CPU rendering for the Analogue tachometer"
+                                                              AutomationProperties.HelpText="Requires restarting Wisp. Off uses the GPU. Windows still uses the GPU to composite the overlay." />
+                                                    <TextBlock Text="Requires restarting Wisp. Off uses the GPU; on draws the Analogue tachometer on the CPU. Other gauges and Windows composition still use their existing rendering paths. CPU usage may increase."
+                                                               Foreground="{DynamicResource FaintBrush}" TextWrapping="Wrap" FontSize="10" Margin="0,6,0,0" />
+                                                    <TextBlock Text="{Binding CpuRenderingChangeStatus}" TextWrapping="Wrap" FontSize="11"
+                                                               Foreground="{DynamicResource TextBrush}" Margin="0,4,0,0" AutomationProperties.LiveSetting="Polite" />
+                                                </StackPanel>
                                                 <Border BorderBrush="{DynamicResource StrokeBrush}" BorderThickness="0,1,0,0"
                                                         Margin="0,10,0,0" Padding="0,10,0,0">
                                                     <StackPanel>

--- a/src/Wisp.App/MainWindow.xaml.cs
+++ b/src/Wisp.App/MainWindow.xaml.cs
@@ -751,6 +751,12 @@ public partial class MainWindow : Window
         }
     }
 
+    private void CpuRenderingToggle_Click(object sender, RoutedEventArgs e)
+    {
+        _controller.SetCpuRenderingEnabled(CpuRenderingToggle.IsChecked == true);
+        CpuRenderingToggle.GetBindingExpression(System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty)?.UpdateTarget();
+    }
+
     private async void DebugLoggingToggle_Click(object sender, RoutedEventArgs e)
     {
         DebugLoggingToggle.IsEnabled = false;

--- a/src/Wisp.App/NativeAnalogSpeedometer.xaml.cs
+++ b/src/Wisp.App/NativeAnalogSpeedometer.xaml.cs
@@ -374,7 +374,9 @@ public partial class NativeAnalogSpeedometer : UserControl
         if (ready)
         {
             if (Content is UIElement content) content.Visibility = Visibility.Hidden;
-            SetRendererStatus("Analogue renderer: Direct3D 11 / DirectComposition");
+            SetRendererStatus((DataContext as DiagnosticsViewModel)?.ActiveCpuRendering == true
+                ? "Analogue renderer: CPU (WARP) / DirectComposition"
+                : "Analogue renderer: Direct3D 11 / DirectComposition");
             return;
         }
         _directCompositionFailed = true;

--- a/src/Wisp.App/NativeNeedlePlayback.cs
+++ b/src/Wisp.App/NativeNeedlePlayback.cs
@@ -26,6 +26,7 @@ internal sealed class NativeNeedlePlayback
     internal double PlaybackDelayMilliseconds(long timestamp) => _angle.PlaybackDelayMilliseconds(timestamp);
     internal long ReseedCount => _angle.ReseedCount;
     internal long StarvationReseedCount => _angle.StarvationReseedCount;
+    internal bool HasFreshState(long timestamp) => _hasNativeState && IsFresh(timestamp);
 
     public bool Observe(
         int carOrdinal,

--- a/src/Wisp.App/NativeRendering/AnalogHudPlayback.cs
+++ b/src/Wisp.App/NativeRendering/AnalogHudPlayback.cs
@@ -14,13 +14,19 @@ internal sealed class AnalogHudPlayback
     private double _previousAngle = double.NaN;
     private long _previousTimestamp;
 
-    internal void Observe(NativeGaugeFrame frame, long timestamp)
+    internal bool HasNativeNeedle(long timestamp) => _usingNative && _native.HasFreshState(timestamp);
+
+    internal void Observe(NativeGaugeFrame frame, long timestamp) => ObserveQueued(frame, timestamp, timestamp);
+
+    internal void ObserveQueued(NativeGaugeFrame frame, long publicationTimestamp, long consumptionTimestamp)
     {
         _frame = frame;
         _hasFrame = true;
+        // A queued frame may predate the previous render sample without the
+        // clock rewinding. Check freshness at consumption, retaining source time.
         var native = _native.Observe(frame.CarOrdinal, frame.GameTimestampMilliseconds,
-            frame.NativeNeedleAngleDegrees, frame.NativeNeedleBlurAmount, timestamp,
-            frame.NativeGaugeObservedTimestamp > 0 ? frame.NativeGaugeObservedTimestamp : null,
+            frame.NativeNeedleAngleDegrees, frame.NativeNeedleBlurAmount, consumptionTimestamp,
+            frame.NativeGaugeObservedTimestamp > 0 ? frame.NativeGaugeObservedTimestamp : publicationTimestamp,
             frame.NativeGaugeSourceInvalidated, out _);
         if (native != _usingNative)
         {
@@ -30,7 +36,7 @@ internal sealed class AnalogHudPlayback
 
         var previousCar = _rpm.AcceptedCarOrdinal;
         _rpm.Observe(frame.CarOrdinal, frame.GameTimestampMilliseconds, frame.EngineRpm,
-            timestamp, frame.ReceivedTimestamp);
+            consumptionTimestamp, frame.ReceivedTimestamp ?? publicationTimestamp);
         if (previousCar is int previous && _rpm.AcceptedCarOrdinal is int current && previous != current)
             ResetBlur();
     }

--- a/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
+++ b/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Wisp.App.DebugLogging;
 
 namespace Wisp.App.NativeRendering;
@@ -79,6 +80,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
 
     private void Run()
     {
+        var nativeThreadId = GetCurrentThreadId();
         DirectCompositionDevice? device = null;
         var playback = new AnalogHudPlayback();
         var batch = new (NativeGaugeFrame Frame, long Timestamp)[64];
@@ -90,6 +92,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
         NativeGaugeFrame latestFrame = default;
         long queuedTimestamp = 0, sequence = 0, operationStarted = 0;
         string operation = "state";
+        DirectCompositionWaitMetrics waitMetrics = default;
         try
         {
             while (!_stop.WaitOne(0))
@@ -180,7 +183,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 if (!frameReady)
                 {
                     BeginOperation("frame_wait");
-                    var ready = device.WaitForNextFrame(100, _stop.SafeWaitHandle);
+                    var ready = device.WaitForNextFrame(100, _stop.SafeWaitHandle, measure, out waitMetrics);
                     RecordStage(operation, ready switch
                     {
                         DirectCompositionWaitResult.Ready => "ready",
@@ -262,6 +265,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 {
                     operation = stage;
                     operationStarted = measure ? Stopwatch.GetTimestamp() : 0;
+                    waitMetrics = default;
                 }
 
                 void RetryWait(int milliseconds)
@@ -308,9 +312,11 @@ internal sealed class AnalogHudRenderWorker : IDisposable
             DirectCompositionPresentMetrics presentMetrics = default, int dropped = 0, int hResult = 0)
         {
             if (started == 0 || !TachDiagnostics.IsEnabled) return;
+            var hasWaitDetails = stage == "frame_wait" && waitMetrics.TotalTicks > 0;
             var diagnostic = new TachRendererDiagnostic
             {
                 ControlId = _controlId,
+                NativeThreadId = nativeThreadId,
                 HostWindowHandle = _window.ToInt64(),
                 Sequence = pending?.Sequence ?? sequence + 1,
                 Stage = stage,
@@ -328,12 +334,22 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 NativeSetupTicks = drawMetrics.SetupTicks,
                 NativeDrawTicks = drawMetrics.TotalTicks,
                 NativePresentTicks = presentMetrics.DurationTicks,
+                NativeWaitTicks = hasWaitDetails ? waitMetrics.TotalTicks : null,
+                WaitPrecheckTicks = hasWaitDetails ? waitMetrics.PrecheckTicks : null,
+                WaitCallTicks = hasWaitDetails ? waitMetrics.WaitCallTicks : null,
+                WaitPostcheckTicks = hasWaitDetails ? waitMetrics.PostcheckTicks : null,
+                SwapChainGeneration = hasWaitDetails && waitMetrics.SwapChainGeneration > 0 ? waitMetrics.SwapChainGeneration : null,
+                WaitReturnCode = hasWaitDetails ? waitMetrics.WaitResult : null,
+                CpuThreadTicks = hasWaitDetails ? waitMetrics.CpuThreadStopwatchTicks : null,
                 HResult = hResult != 0 ? hResult : presentMetrics.HResult,
                 QueueDropped = dropped
             };
             TachDiagnostics.RecordRenderer(in diagnostic);
         }
     }
+
+    [DllImport("kernel32.dll", ExactSpelling = true)]
+    private static extern uint GetCurrentThreadId();
 
     internal static void Transform(DirectCompositionDrawCommand[] commands, AnalogHudPresentation presentation)
     {

--- a/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
+++ b/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
@@ -17,6 +17,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
     private readonly AutoResetEvent _changed = new(false);
     private readonly IntPtr _window;
     private readonly int _controlId;
+    private readonly bool _cpuRendering;
     private readonly IReadOnlyList<AnalogHudTexture> _textures;
     private readonly Action<bool, int> _status;
     private readonly Thread _thread;
@@ -26,10 +27,11 @@ internal sealed class AnalogHudRenderWorker : IDisposable
     private int _queueDropped;
 
     internal AnalogHudRenderWorker(IntPtr window, int controlId, IReadOnlyList<AnalogHudTexture> textures,
-        AnalogHudPresentation presentation, Action<bool, int> status)
+        AnalogHudPresentation presentation, Action<bool, int> status, bool cpuRendering = false)
     {
         _window = window;
         _controlId = controlId;
+        _cpuRendering = cpuRendering;
         _textures = textures;
         _presentation = presentation;
         _status = status;
@@ -146,7 +148,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 if (device is null)
                 {
                     BeginOperation("state");
-                    device = DirectCompositionDevice.Create(_window, presentation.Width, presentation.Height);
+                    device = DirectCompositionDevice.Create(_window, presentation.Width, presentation.Height, _cpuRendering);
                     foreach (var texture in _textures)
                         device.UploadTexture(texture.Id, texture.Width, texture.Height, texture.Stride, texture.Pixels.ToArray());
                     width = presentation.Width;
@@ -317,6 +319,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
             {
                 ControlId = _controlId,
                 NativeThreadId = nativeThreadId,
+                CpuRendering = _cpuRendering,
                 HostWindowHandle = _window.ToInt64(),
                 Sequence = pending?.Sequence ?? sequence + 1,
                 Stage = stage,

--- a/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
+++ b/src/Wisp.App/NativeRendering/AnalogHudRenderWorker.cs
@@ -22,6 +22,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
     private AnalogHudPresentation _presentation;
     private bool _reset;
     private bool _disposed;
+    private int _queueDropped;
 
     internal AnalogHudRenderWorker(IntPtr window, int controlId, IReadOnlyList<AnalogHudTexture> textures,
         AnalogHudPresentation presentation, Action<bool, int> status)
@@ -43,6 +44,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
             if (_frames.Count == 64)
             {
                 // An old backlog must never play after a render/device stall.
+                _queueDropped += _frames.Count;
                 _frames.Clear();
                 _reset = true;
             }
@@ -83,12 +85,18 @@ internal sealed class AnalogHudRenderWorker : IDisposable
         var waitHandles = new WaitHandle[] { _stop, _changed };
         bool announced = false, hasFrame = false, wasActive = false, frameReady = false;
         int width = 0, height = 0;
+        float appliedOpacity = float.NaN;
+        AnalogHudPendingFrame? pending = null;
+        NativeGaugeFrame latestFrame = default;
+        long queuedTimestamp = 0, sequence = 0, operationStarted = 0;
+        string operation = "state";
         try
         {
             while (!_stop.WaitOne(0))
             {
                 AnalogHudPresentation presentation;
-                int count = 0;
+                int count = 0, queueDropped;
+                bool measure = TachDiagnostics.IsEnabled;
                 lock (_gate)
                 {
                     presentation = _presentation;
@@ -96,19 +104,27 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                     {
                         playback.Reset();
                         hasFrame = false;
+                        pending = null;
                         _reset = false;
                     }
+                    queueDropped = _queueDropped;
+                    _queueDropped = 0;
                     while (_frames.Count > 0) batch[count++] = _frames.Dequeue();
                 }
+                if (queueDropped > 0)
+                    RecordStage("state", "discarded", Stopwatch.GetTimestamp(), dropped: queueDropped);
                 if (!presentation.Active)
                 {
                     if (device is not null && wasActive)
                     {
                         // Clear the independent surface before the parent can
                         // be shown again in a different layout.
+                        BeginOperation("state");
                         device.SetVisible(false);
+                        RecordStage(operation, "ready", operationStarted);
                     }
                     wasActive = false;
+                    pending = null;
                     playback.Reset();
                     hasFrame = false;
                     WaitHandle.WaitAny(waitHandles);
@@ -116,7 +132,7 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 }
                 for (int i = 0; i < count; i++)
                 {
-                    playback.Observe(batch[i].Frame, batch[i].Timestamp);
+                    Observe(batch[i]);
                     hasFrame = true;
                 }
                 if (!hasFrame)
@@ -126,27 +142,51 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 }
                 if (device is null)
                 {
+                    BeginOperation("state");
                     device = DirectCompositionDevice.Create(_window, presentation.Width, presentation.Height);
                     foreach (var texture in _textures)
                         device.UploadTexture(texture.Id, texture.Width, texture.Height, texture.Stride, texture.Pixels.ToArray());
                     width = presentation.Width;
                     height = presentation.Height;
+                    RecordStage(operation, "created", operationStarted);
                 }
                 if (width != presentation.Width || height != presentation.Height)
                 {
+                    pending = null;
+                    BeginOperation("state");
                     device.Resize(presentation.Width, presentation.Height);
                     width = presentation.Width;
                     height = presentation.Height;
+                    RecordStage(operation, "resized", operationStarted);
                 }
                 // A previously hidden surface can still contain the old car.
                 // Resume with a transparent swapchain before making it visible.
-                if (!wasActive && device.PrepareForResume()) frameReady = false;
-                device.SetOpacity(presentation.Opacity);
-                device.SetVisible(true);
+                if (!wasActive)
+                {
+                    BeginOperation("state");
+                    if (device.PrepareForResume()) frameReady = false;
+                    pending = null;
+                    RecordStage(operation, "resumed", operationStarted);
+                }
+                if (appliedOpacity != presentation.Opacity || !wasActive)
+                {
+                    BeginOperation("state");
+                    device.SetOpacity(presentation.Opacity);
+                    device.SetVisible(true);
+                    appliedOpacity = presentation.Opacity;
+                    RecordStage(operation, "ready", operationStarted);
+                }
                 wasActive = true;
                 if (!frameReady)
                 {
+                    BeginOperation("frame_wait");
                     var ready = device.WaitForNextFrame(100, _stop.SafeWaitHandle);
+                    RecordStage(operation, ready switch
+                    {
+                        DirectCompositionWaitResult.Ready => "ready",
+                        DirectCompositionWaitResult.Cancelled => "cancelled",
+                        _ => "timeout"
+                    }, operationStarted);
                     if (ready == DirectCompositionWaitResult.Cancelled) break;
                     if (ready == DirectCompositionWaitResult.Timeout) continue;
                     frameReady = true;
@@ -156,8 +196,8 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                 // after the frame wait. Keep its readiness until Present succeeds;
                 // waiting again without presenting can stall the swapchain.
 
-                // Fresh samples received while awaiting the swapchain belong
-                // to this frame; never render an earlier queued snapshot.
+                // Consume input received during the wait before drawing a new
+                // frame or checking whether pending pixels remain valid.
                 lock (_gate)
                 {
                     if (_reset || !_presentation.Active) continue;
@@ -165,35 +205,76 @@ internal sealed class AnalogHudRenderWorker : IDisposable
                     count = 0;
                     while (_frames.Count > 0) batch[count++] = _frames.Dequeue();
                 }
-                for (int i = 0; i < count; i++) playback.Observe(batch[i].Frame, batch[i].Timestamp);
+                for (int i = 0; i < count; i++) Observe(batch[i]);
                 if (width != presentation.Width || height != presentation.Height) continue;
-                var sample = playback.Sample(Stopwatch.GetTimestamp());
-                var commands = AnalogHudScene.Build(sample.Frame, sample.Angle, sample.Blur,
-                    sample.NeedleVisible, presentation.TractionActive, presentation.TractionColor,
-                    presentation.Layout, sample.AppliedRpm);
-                Transform(commands, presentation);
-                if (!device.RenderPresent(commands, commands.Length))
+                if (pending is { } old && !old.CanReuse(presentation, latestFrame,
+                    playback.HasNativeNeedle(Stopwatch.GetTimestamp())))
+                {
+                    RecordStage("state", "discarded", Stopwatch.GetTimestamp());
+                    pending = null;
+                }
+                if (pending is null)
+                {
+                    BeginOperation("draw");
+                    var sample = playback.Sample(Stopwatch.GetTimestamp());
+                    var commands = AnalogHudScene.Build(sample.Frame, sample.Angle, sample.Blur,
+                        sample.NeedleVisible, presentation.TractionActive, presentation.TractionColor,
+                        presentation.Layout, sample.AppliedRpm);
+                    Transform(commands, presentation);
+                    var sceneTicks = measure ? Stopwatch.GetTimestamp() - operationStarted : 0;
+                    pending = new(sample, presentation, queuedTimestamp, ++sequence);
+                    device.DrawForPresentation(commands, commands.Length, measure, out var drawMetrics);
+                    RecordStage(operation, "ready", operationStarted, sceneTicks: sceneTicks,
+                        drawCommands: commands.Length, drawMetrics: drawMetrics);
+                }
+                // A busy Present has not consumed these pixels. Retry only the
+                // submission; rebuilding here repeats GPU work and samples blur
+                // for frames that were never submitted. New input still enters
+                // playback above, ready for the next frame after success.
+                BeginOperation("present");
+                var submitted = device.TryPresent(measure, out var presentMetrics);
+                RecordStage(operation, submitted ? "submitted" : device.LastRenderWasOccluded ? "occluded" : "busy",
+                    operationStarted, presentMetrics: presentMetrics);
+                if (!submitted)
                 {
                     if (device.LastRenderWasOccluded)
                     {
                         // Initialization succeeded even when Windows cannot show
                         // this HWND. Do not count this as a submitted needle frame.
                         AnnounceReady();
-                        _stop.WaitOne(100);
+                        RetryWait(100);
+                        // Once the surface becomes visible, sample current
+                        // input instead of showing a frame held while occluded.
+                        pending = null;
                         continue;
                     }
                     // DO_NOT_WAIT can race another compositor consumer. Yield
                     // to cancellation instead of spinning or accumulating work.
-                    _stop.WaitOne(1);
+                    RetryWait(1);
                     continue;
                 }
                 frameReady = false;
                 AnnounceReady();
-                Record(sample);
+                Record(pending.Value.Sample);
+                pending = null;
+
+                void BeginOperation(string stage)
+                {
+                    operation = stage;
+                    operationStarted = measure ? Stopwatch.GetTimestamp() : 0;
+                }
+
+                void RetryWait(int milliseconds)
+                {
+                    BeginOperation("retry_wait");
+                    var cancelled = _stop.WaitOne(milliseconds);
+                    RecordStage(operation, cancelled ? "cancelled" : "ready", operationStarted);
+                }
             }
         }
         catch (Exception error) when (error is not OutOfMemoryException and not StackOverflowException)
         {
+            RecordStage(operation, "error", operationStarted, hResult: error.HResult);
             if (!_stop.WaitOne(0)) _status(false, error.HResult);
         }
         finally
@@ -213,6 +294,44 @@ internal sealed class AnalogHudRenderWorker : IDisposable
             if (announced) return;
             announced = true;
             _status(true, 0);
+        }
+
+        void Observe((NativeGaugeFrame Frame, long Timestamp) item)
+        {
+            playback.ObserveQueued(item.Frame, item.Timestamp, Stopwatch.GetTimestamp());
+            latestFrame = item.Frame;
+            queuedTimestamp = item.Timestamp;
+        }
+
+        void RecordStage(string stage, string result, long started, long sceneTicks = 0,
+            int drawCommands = 0, DirectCompositionDrawMetrics drawMetrics = default,
+            DirectCompositionPresentMetrics presentMetrics = default, int dropped = 0, int hResult = 0)
+        {
+            if (started == 0 || !TachDiagnostics.IsEnabled) return;
+            var diagnostic = new TachRendererDiagnostic
+            {
+                ControlId = _controlId,
+                HostWindowHandle = _window.ToInt64(),
+                Sequence = pending?.Sequence ?? sequence + 1,
+                Stage = stage,
+                Result = result,
+                StartedTimestamp = started,
+                CompletedTimestamp = Stopwatch.GetTimestamp(),
+                SampleTimestamp = pending?.Sample.Timestamp,
+                ReceivedTimestamp = pending?.Sample.Frame.ReceivedTimestamp ?? latestFrame.ReceivedTimestamp,
+                QueuedTimestamp = pending?.QueuedTimestamp ?? (queuedTimestamp > 0 ? queuedTimestamp : null),
+                SceneTicks = sceneTicks,
+                DrawCommands = drawCommands,
+                MapCount = (int)drawMetrics.MapCount,
+                MapTicks = drawMetrics.MapTicks,
+                MaxMapTicks = drawMetrics.MaximumMapTicks,
+                NativeSetupTicks = drawMetrics.SetupTicks,
+                NativeDrawTicks = drawMetrics.TotalTicks,
+                NativePresentTicks = presentMetrics.DurationTicks,
+                HResult = hResult != 0 ? hResult : presentMetrics.HResult,
+                QueueDropped = dropped
+            };
+            TachDiagnostics.RecordRenderer(in diagnostic);
         }
     }
 
@@ -266,4 +385,23 @@ internal sealed class AnalogHudRenderWorker : IDisposable
         };
         TachDiagnostics.RecordNeedle(in diagnostic);
     }
+}
+
+internal readonly record struct AnalogHudPendingFrame(
+    AnalogHudSample Sample, AnalogHudPresentation Presentation, long QueuedTimestamp, long Sequence)
+{
+    internal bool CanReuse(AnalogHudPresentation presentation, NativeGaugeFrame frame, bool nativeNeedle) =>
+        presentation.Active &&
+        presentation.Width == Presentation.Width && presentation.Height == Presentation.Height &&
+        presentation.OriginX == Presentation.OriginX && presentation.OriginY == Presentation.OriginY &&
+        presentation.AxisXX == Presentation.AxisXX && presentation.AxisXY == Presentation.AxisXY &&
+        presentation.AxisYX == Presentation.AxisYX && presentation.AxisYY == Presentation.AxisYY &&
+        presentation.TractionActive == Presentation.TractionActive &&
+        presentation.TractionColor == Presentation.TractionColor && presentation.Layout == Presentation.Layout &&
+        frame.CarOrdinal == Sample.Frame.CarOrdinal && frame.IsElectric == Sample.Frame.IsElectric &&
+        frame.Unit == Sample.Frame.Unit && frame.GearDisplayMode == Sample.Frame.GearDisplayMode &&
+        nativeNeedle == Sample.Native &&
+        frame.ExactRedline == Sample.Frame.ExactRedline &&
+        frame.TachometerMaximumRpm.Equals(Sample.Frame.TachometerMaximumRpm) &&
+        frame.NativeGaugeSourceInvalidated == Sample.Frame.NativeGaugeSourceInvalidated;
 }

--- a/src/Wisp.App/NativeRendering/DirectCompositionAnalogHost.cs
+++ b/src/Wisp.App/NativeRendering/DirectCompositionAnalogHost.cs
@@ -100,7 +100,8 @@ internal sealed class DirectCompositionAnalogHost : IDisposable
         if (_worker is null)
         {
             var textures = AnalogHudAssets.LoadOnUiThread();
-            _worker = new AnalogHudRenderWorker(source.Handle, _controlId, textures, _presentation, ReportStatus);
+            _worker = new AnalogHudRenderWorker(source.Handle, _controlId, textures, _presentation, ReportStatus,
+                (_owner.DataContext as DiagnosticsViewModel)?.ActiveCpuRendering == true);
         }
         else _worker.UpdatePresentation(_presentation);
     }

--- a/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
+++ b/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -43,6 +44,17 @@ internal struct DirectCompositionPresentMetrics
     public long DurationTicks;
     public int HResult;
     public uint Reserved;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+internal struct DirectCompositionWaitMetrics
+{
+    public long TotalTicks, PrecheckTicks, WaitCallTicks, PostcheckTicks, CpuTime100ns;
+    public uint SwapChainGeneration, WaitResult;
+
+    // GetThreadTimes uses coarse 100 ns execution accounting, not elapsed QPC time.
+    public readonly long? CpuThreadStopwatchTicks => CpuTime100ns < 0 ? null :
+        (long)(CpuTime100ns * (Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond));
 }
 
 // The render worker owns this device. The HWND remains owned by WPF's UI thread.
@@ -149,8 +161,13 @@ internal sealed class DirectCompositionDevice : IDisposable
         return result == 0;
     }
 
-    public DirectCompositionWaitResult WaitForNextFrame(int timeoutMilliseconds, SafeWaitHandle? cancellationHandle = null)
+    public DirectCompositionWaitResult WaitForNextFrame(int timeoutMilliseconds, SafeWaitHandle? cancellationHandle = null) =>
+        WaitForNextFrame(timeoutMilliseconds, cancellationHandle, false, out _);
+
+    public DirectCompositionWaitResult WaitForNextFrame(int timeoutMilliseconds, SafeWaitHandle? cancellationHandle,
+        bool measure, out DirectCompositionWaitMetrics metrics)
     {
+        metrics = default;
         ThrowIfDisposed();
         if (timeoutMilliseconds is < 0 or > 1000) throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds));
         bool addRef = false;
@@ -158,7 +175,11 @@ internal sealed class DirectCompositionDevice : IDisposable
         {
             cancellationHandle?.DangerousAddRef(ref addRef);
             var cancel = cancellationHandle?.DangerousGetHandle() ?? IntPtr.Zero;
-            Marshal.ThrowExceptionForHR(Native.WaitForFrame(_handle, (uint)timeoutMilliseconds, cancel, out var result));
+            DirectCompositionWaitResult result;
+            var hresult = measure
+                ? Native.WaitForFrameMeasured(_handle, (uint)timeoutMilliseconds, cancel, 1, out result, out metrics)
+                : Native.WaitForFrame(_handle, (uint)timeoutMilliseconds, cancel, out result);
+            Marshal.ThrowExceptionForHR(hresult);
             return result;
         }
         finally
@@ -250,6 +271,9 @@ internal sealed class DirectCompositionDevice : IDisposable
         [DllImport(Library, EntryPoint = "WispRendererWaitForFrame", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int WaitForFrame(RendererHandle renderer, uint timeoutMilliseconds, IntPtr cancellation,
             out DirectCompositionWaitResult result);
+        [DllImport(Library, EntryPoint = "WispRendererWaitForFrameMeasured", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int WaitForFrameMeasured(RendererHandle renderer, uint timeoutMilliseconds, IntPtr cancellation,
+            int measure, out DirectCompositionWaitResult result, out DirectCompositionWaitMetrics metrics);
         [DllImport(Library, EntryPoint = "WispRendererCapture", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Capture(RendererHandle renderer, [Out] byte[] pixels, uint byteCount, uint stride);
         [DllImport(Library, EntryPoint = "WispRendererDeviceRemovedReason", CallingConvention = CallingConvention.Cdecl)]

--- a/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
+++ b/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
@@ -29,6 +29,22 @@ internal struct DirectCompositionDrawCommand
     public float ParameterX, ParameterY, ParameterZ, ParameterW;
 }
 
+// CPU elapsed QPC ticks; these do not measure GPU execution or physical display.
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+internal struct DirectCompositionDrawMetrics
+{
+    public long TotalTicks, SetupTicks, MapTicks, MaximumMapTicks;
+    public uint MapCount, DrawCount;
+}
+
+[StructLayout(LayoutKind.Sequential, Pack = 8)]
+internal struct DirectCompositionPresentMetrics
+{
+    public long DurationTicks;
+    public int HResult;
+    public uint Reserved;
+}
+
 // The render worker owns this device. The HWND remains owned by WPF's UI thread.
 internal sealed class DirectCompositionDevice : IDisposable
 {
@@ -104,12 +120,30 @@ internal sealed class DirectCompositionDevice : IDisposable
         Marshal.ThrowExceptionForHR(Native.RemoveTexture(_handle, id));
     }
 
-    // A busy presentation queue returns false; the caller retries with the latest state.
+    // Legacy combined draw/present entry point for renderer contract checks.
     public bool RenderPresent(DirectCompositionDrawCommand[] commands, int count)
     {
         ValidateCommands(commands, count);
         LastRenderWasOccluded = false;
         var result = Native.Render(_handle, commands, (uint)count, 1);
+        LastRenderWasOccluded = result == 2;
+        Marshal.ThrowExceptionForHR(result);
+        return result == 0;
+    }
+
+    public void DrawForPresentation(DirectCompositionDrawCommand[] commands, int count, bool measure,
+        out DirectCompositionDrawMetrics metrics)
+    {
+        ValidateCommands(commands, count);
+        Marshal.ThrowExceptionForHR(Native.DrawForPresentation(_handle, commands, (uint)count, measure ? 1 : 0, out metrics));
+    }
+
+    // Retry a busy presentation without issuing another clear, map, or draw.
+    public bool TryPresent(bool measure, out DirectCompositionPresentMetrics metrics)
+    {
+        ThrowIfDisposed();
+        LastRenderWasOccluded = false;
+        var result = Native.TryPresent(_handle, measure ? 1 : 0, out metrics);
         LastRenderWasOccluded = result == 2;
         Marshal.ThrowExceptionForHR(result);
         return result == 0;
@@ -208,6 +242,11 @@ internal sealed class DirectCompositionDevice : IDisposable
         internal static extern int RemoveTexture(RendererHandle renderer, uint id);
         [DllImport(Library, EntryPoint = "WispRendererRender", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Render(RendererHandle renderer, [In] DirectCompositionDrawCommand[] commands, uint count, int present);
+        [DllImport(Library, EntryPoint = "WispRendererDrawForPresentation", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int DrawForPresentation(RendererHandle renderer, [In] DirectCompositionDrawCommand[] commands,
+            uint count, int measure, out DirectCompositionDrawMetrics metrics);
+        [DllImport(Library, EntryPoint = "WispRendererTryPresent", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int TryPresent(RendererHandle renderer, int measure, out DirectCompositionPresentMetrics metrics);
         [DllImport(Library, EntryPoint = "WispRendererWaitForFrame", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int WaitForFrame(RendererHandle renderer, uint timeoutMilliseconds, IntPtr cancellation,
             out DirectCompositionWaitResult result);

--- a/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
+++ b/src/Wisp.App/NativeRendering/DirectCompositionDevice.cs
@@ -72,11 +72,11 @@ internal sealed class DirectCompositionDevice : IDisposable
         _height = height;
     }
 
-    public static DirectCompositionDevice Create(IntPtr hwnd, int width, int height)
+    public static DirectCompositionDevice Create(IntPtr hwnd, int width, int height, bool cpuRendering = false)
     {
         ValidateSize(width, height);
         if (hwnd == IntPtr.Zero) throw new ArgumentException("A live overlay window is required.", nameof(hwnd));
-        Marshal.ThrowExceptionForHR(Native.Create(hwnd, (uint)width, (uint)height, out var handle));
+        Marshal.ThrowExceptionForHR(Native.CreateWithMode(hwnd, (uint)width, (uint)height, cpuRendering ? 1u : 0u, out var handle));
         return new DirectCompositionDevice(handle, width, height);
     }
 
@@ -244,6 +244,9 @@ internal sealed class DirectCompositionDevice : IDisposable
     private static class Native
     {
         private const string Library = "Wisp.NativeRenderer.dll";
+        [DllImport(Library, EntryPoint = "WispRendererCreateWithMode", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int CreateWithMode(IntPtr hwnd, uint width, uint height, uint cpuRendering, out RendererHandle renderer);
+
         [DllImport(Library, EntryPoint = "WispRendererCreate", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Create(IntPtr hwnd, uint width, uint height, out RendererHandle renderer);
         [DllImport(Library, EntryPoint = "WispRendererDestroy", CallingConvention = CallingConvention.Cdecl)]

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -16,18 +16,21 @@ public static class ReleaseNotesCatalog
     [
         new(
             "1.2.1",
-            "September 9, 2026",
-            "TACHOMETER TEST BUILD",
-            "Corrects queued needle timing and busy frame retries, with detailed diagnostics for remaining choppiness reports.",
+            "September 10, 2026",
+            "ANALOGUE RENDERING",
+            "Optional CPU rendering for Analogue tachometer lag or hitching, with fixes for queued needle updates and busy frame submissions.",
             true,
             [
-                Group("Analogue tachometer",
+                Group("CPU rendering",
+                    "If the Analogue tachometer lags or hitches, enable CPU rendering in Diagnostics.",
+                    "To apply the change, right-click Wisp's tray icon, choose Exit Wisp, then reopen the app.",
+                    "CPU mode reuses the unchanged dial background to reduce repeated drawing work while the needle and live readings continue updating.",
+                    "GPU rendering remains the default. CPU mode can increase CPU usage; other gauges keep their existing renderers, and Windows still uses the GPU to compose the overlay."),
+                Group("Fixes and diagnostics",
                     "Keeps queued telemetry arrival times separate from the render clock, preventing a late-consumed sample from falsely resetting needle playback.",
                     "Retries a busy frame submission using the already drawn HUD, avoiding repeated drawing work while Windows cannot accept the frame.",
-                    "Retains the existing needle interpolation, artwork, settings and Record and Compare Runs features."),
-                Group("Test feedback",
-                    "Debug exports now separate frame-readiness waits, scene building, drawing, buffer mapping and presentation attempts, including busy retries and queued sample ages.",
-                    "This is a test candidate for remaining choppiness under game load. Improvement still needs confirmation on affected PCs.")
+                    "Bounded local debug exports identify the active rendering mode and separate native frame waits from their surrounding checks, along with drawing and presentation attempts. These are CPU-side timings, not displayed FPS.",
+                    "Preserves the existing needle interpolation, artwork, HUD settings and Record and Compare Runs features.")
             ]),
         new(
             "1.2",

--- a/src/Wisp.App/ReleaseNotesCatalog.cs
+++ b/src/Wisp.App/ReleaseNotesCatalog.cs
@@ -15,11 +15,26 @@ public static class ReleaseNotesCatalog
     public static IReadOnlyList<ReleaseNoteEntry> Entries { get; } =
     [
         new(
+            "1.2.1",
+            "September 9, 2026",
+            "TACHOMETER TEST BUILD",
+            "Corrects queued needle timing and busy frame retries, with detailed diagnostics for remaining choppiness reports.",
+            true,
+            [
+                Group("Analogue tachometer",
+                    "Keeps queued telemetry arrival times separate from the render clock, preventing a late-consumed sample from falsely resetting needle playback.",
+                    "Retries a busy frame submission using the already drawn HUD, avoiding repeated drawing work while Windows cannot accept the frame.",
+                    "Retains the existing needle interpolation, artwork, settings and Record and Compare Runs features."),
+                Group("Test feedback",
+                    "Debug exports now separate frame-readiness waits, scene building, drawing, buffer mapping and presentation attempts, including busy retries and queued sample ages.",
+                    "This is a test candidate for remaining choppiness under game load. Improvement still needs confirmation on affected PCs.")
+            ]),
+        new(
             "1.2",
             "September 9, 2026",
             "RECORD & COMPARE RUNS",
             "Record a drive, review what happened, and compare it with another run inside Wisp.",
-            true,
+            false,
             [
                 Group("Record a run",
                     "Start and stop from Dashboard or Runs, with an optional keyboard shortcut while driving.",

--- a/src/Wisp.App/Wisp.App.csproj
+++ b/src/Wisp.App/Wisp.App.csproj
@@ -11,9 +11,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp</AssemblyTitle>
     <Description>Wheel-indicated speed and G-force display for Forza Horizon 6.</Description>
-    <Version>1.2.0</Version>
-    <FileVersion>1.2.0.0</FileVersion>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <Version>1.2.1</Version>
+    <FileVersion>1.2.1.0</FileVersion>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Core\Wisp.Core.csproj" />

--- a/src/Wisp.App/app.manifest
+++ b/src/Wisp.App/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.2.0.0" name="Wisp.App" />
+  <assemblyIdentity version="1.2.1.0" name="Wisp.App" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>

--- a/src/Wisp.NativeRenderer/Build-NativeRenderer.ps1
+++ b/src/Wisp.NativeRenderer/Build-NativeRenderer.ps1
@@ -70,4 +70,4 @@ $sha256 = [Security.Cryptography.SHA256]::Create()
 $dllStream = [IO.File]::OpenRead($dll)
 try { $dllHash = [BitConverter]::ToString($sha256.ComputeHash($dllStream)).Replace('-', '').ToLowerInvariant() }
 finally { $dllStream.Dispose(); $sha256.Dispose() }
-[ordered]@{ built=$true; architecture='x64'; hardwareOnly=$true; dllSha256=$dllHash } | ConvertTo-Json -Compress
+[ordered]@{ built=$true; architecture='x64'; gpuDefault=$true; supportsCpuRendering=$true; dllSha256=$dllHash } | ConvertTo-Json -Compress

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <thread>
 #include <cmath>
+#include <dxgi.h>
 
 static int failures = 0;
 static void Require(bool passed, const char* name)
@@ -90,6 +91,46 @@ int main()
     uint32_t waited = 99;
     Require(SUCCEEDED(WispRendererWaitForFrame(renderer, 100, cancellation, &waited)) && waited == 2, "cancellation wins over frame readiness");
     CloseHandle(cancellation);
+    WispDrawMetrics drawMetrics{};
+    WispPresentMetrics presentMetrics{};
+    Require(WispRendererTryPresent(renderer, 1, &presentMetrics) == HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        "capture-only target cannot be presented");
+    Require(presentMetrics.hResult == HRESULT_FROM_WIN32(ERROR_INVALID_STATE), "invalid presentation status is recorded");
+    Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, overlap, 2, 1, &drawMetrics)), "separate measured draw");
+    Require(drawMetrics.drawCount == 2 && drawMetrics.mapCount == 2 && drawMetrics.totalTicks > 0 &&
+        drawMetrics.setupTicks > 0 && drawMetrics.mapTicks >= drawMetrics.maximumMapTicks &&
+        drawMetrics.totalTicks >= drawMetrics.setupTicks + drawMetrics.mapTicks,
+        "CPU draw metrics include setup and each constant map");
+    Require(WispRendererCapture(renderer, pixels.data(), static_cast<uint32_t>(pixels.size()), 1152) == E_INVALIDARG,
+        "presentation draw does not enable readback");
+    const HRESULT separatePresent = WispRendererTryPresent(renderer, 1, &presentMetrics);
+    Require(separatePresent == S_OK || separatePresent == S_FALSE || separatePresent == 2, "separate presentation result");
+    Require(presentMetrics.durationTicks > 0 && presentMetrics.hResult ==
+        (separatePresent == S_FALSE ? DXGI_ERROR_WAS_STILL_DRAWING : separatePresent == 2 ? DXGI_STATUS_OCCLUDED : S_OK),
+        "presentation metrics preserve original DXGI status");
+    const HRESULT repeatedPresent = WispRendererTryPresent(renderer, 0, &presentMetrics);
+    Require(separatePresent == S_OK ? repeatedPresent == HRESULT_FROM_WIN32(ERROR_INVALID_STATE) :
+        repeatedPresent == S_OK || repeatedPresent == S_FALSE || repeatedPresent == 2,
+        "successful presentation consumes the frame; busy or occluded can retry without drawing");
+    Require(presentMetrics.durationTicks == 0 && presentMetrics.hResult == 0 && presentMetrics.reserved == 0,
+        "disabled presentation metrics stay zero");
+    Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, overlap, 2, 0, &drawMetrics)) &&
+        drawMetrics.totalTicks == 0 && drawMetrics.setupTicks == 0 && drawMetrics.mapTicks == 0 &&
+        drawMetrics.maximumMapTicks == 0 && drawMetrics.mapCount == 0 && drawMetrics.drawCount == 0,
+        "disabled draw metrics stay zero");
+    Require(SUCCEEDED(WispRendererSetVisible(renderer, 0)) &&
+        WispRendererTryPresent(renderer, 0, &presentMetrics) == HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        "hide invalidates a pending presentation even when already hidden");
+    Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, overlap, 2, 0, &drawMetrics)) &&
+        SUCCEEDED(WispRendererResize(renderer, 288, 288, 2.5f, 3.5f)) &&
+        WispRendererTryPresent(renderer, 0, &presentMetrics) == HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        "resize invalidates a pending presentation");
+    Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, overlap, 2, 0, &drawMetrics)) &&
+        SUCCEEDED(WispRendererRender(renderer, overlap, 2, 0)) &&
+        WispRendererTryPresent(renderer, 0, &presentMetrics) == HRESULT_FROM_WIN32(ERROR_INVALID_STATE),
+        "capture draw replaces and invalidates pending presentation");
+    Require(WispRendererDrawForPresentation(renderer, overlap, 2, 1, nullptr) == E_POINTER &&
+        WispRendererTryPresent(renderer, 1, nullptr) == E_POINTER, "metrics output is required");
     Require(SUCCEEDED(WispRendererSetVisible(renderer, 1)) && SUCCEEDED(WispRendererSetVisible(renderer, 0)), "independent visual show and hide");
     Require(SUCCEEDED(WispRendererSetVisible(renderer, 0)), "hide before visible-HWND readiness check");
     SetWindowPos(window, HWND_BOTTOM, GetSystemMetrics(SM_XVIRTUALSCREEN)+40, GetSystemMetrics(SM_YVIRTUALSCREEN)+40,

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -1,6 +1,7 @@
 #define WISP_RENDERER_IMPORT
 #include "Wisp.NativeRenderer.h"
 #include <cstdio>
+#include <cstring>
 #include <vector>
 #include <thread>
 #include <cmath>
@@ -122,8 +123,10 @@ static void CheckVisiblePacing(void* renderer, HWND window)
         "presentation throughput remains bounded by display cadence");
 }
 
-int main()
+int main(int argc, char** argv)
 {
+    const bool cpuRendering = argc == 2 && std::strcmp(argv[1], "--cpu") == 0;
+    if (argc > 1 && !cpuRendering) return 2;
     HWND window = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_NOREDIRECTIONBITMAP,
         L"STATIC", L"Wisp native renderer contract", WS_POPUP, -32000, -32000, 288, 288,
         nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
@@ -131,8 +134,10 @@ int main()
     if (!window) return 1;
     HWND foregroundBefore = GetForegroundWindow();
     void* renderer = nullptr;
-    HRESULT result = WispRendererCreate(window, 32, 32, &renderer);
-    Require(SUCCEEDED(result) && renderer, "hardware D3D11 and DirectComposition creation");
+    Require(WispRendererCreateWithMode(window, 32, 32, 2, &renderer) == E_INVALIDARG && !renderer, "invalid renderer mode rejected");
+    HRESULT result = cpuRendering ? WispRendererCreateWithMode(window, 32, 32, 1, &renderer)
+        : WispRendererCreate(window, 32, 32, &renderer);
+    Require(SUCCEEDED(result) && renderer, "selected D3D11 driver and DirectComposition creation");
     if (!renderer) { DestroyWindow(window); return 1; }
     uint32_t initialReady = 99;
     WispWaitMetrics waitMetrics{};
@@ -312,6 +317,6 @@ int main()
     WispRendererDestroy(renderer);
     Require(GetForegroundWindow() == foregroundBefore, "no foreground changes");
     DestroyWindow(window);
-    std::printf("{\"contractFailures\":%d,\"hardwareOnly\":true,\"testWindowShown\":true}\n", failures);
+    std::printf("{\"contractFailures\":%d,\"cpuRendering\":%s,\"testWindowShown\":true}\n", failures, cpuRendering ? "true" : "false");
     return failures ? 1 : 0;
 }

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -24,6 +24,97 @@ static WispDrawCommand Sprite(float x, float y, float width, float height, uint3
     return command;
 }
 
+static void CheckDialCache(void* renderer, bool cpuRendering)
+{
+    uint32_t width = 288, height = 288;
+    WispDrawCommand commands[] = {Sprite(12.25f, -7.5f, 266.5f, 277.25f), Sprite(130, 130, 24, 19, 1)};
+    commands[0].shader = 1;
+    commands[0].parameterX = .8f;
+    commands[0].parameterY = .1f;
+    commands[0].tintA = .73f;
+    auto transparent = Sprite(0, 0, 1, 1);
+    transparent.tintA = 0;
+    std::vector<uint8_t> pixels, expected;
+    auto capture = [&](const WispDrawCommand* draws, uint32_t count, std::vector<uint8_t>& output)
+    {
+        output.resize(static_cast<size_t>(width) * height * 4);
+        Require(SUCCEEDED(WispRendererRender(renderer, draws, count, 0)), "cache pixel comparison draw");
+        Require(SUCCEEDED(WispRendererCapture(renderer, output.data(), static_cast<uint32_t>(output.size()), width * 4)),
+            "cache pixel comparison readback");
+    };
+    auto compare = [&]
+    {
+        // A transparent first sprite forces the original full-draw path without
+        // changing the image or the order of either visible command.
+        WispDrawCommand reference[] = {transparent, commands[0], commands[1]};
+        capture(reference, 3, expected);
+        capture(commands, 2, pixels);
+        Require(pixels == expected, "CPU dial cache preserves exact uncached pixels");
+        capture(commands, 2, pixels);
+        Require(pixels == expected, "reused dial preserves exact uncached pixels");
+    };
+    auto measure = [&](uint32_t expectedDraws)
+    {
+        WispDrawMetrics metrics{};
+        Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, commands, 2, 1, &metrics)), "measured cache draw");
+        Require(metrics.drawCount == expectedDraws && metrics.mapCount == expectedDraws,
+            "cache metrics count only actual draws and maps");
+        Require(metrics.totalTicks >= metrics.setupTicks + metrics.mapTicks,
+            "cache setup and maps remain disjoint nested timings");
+    };
+    const uint32_t cachedDraws = cpuRendering ? 1u : 2u;
+    compare();
+    measure(cachedDraws);
+    const auto previous = pixels;
+    commands[1].originX = 20;
+    commands[1].originY = 210;
+    commands[1].tintA = .5f;
+    measure(cachedDraws);
+    compare();
+    Require(pixels != previous, "dynamic pixels remain live when the dial is cached");
+
+    commands[0].parameterX = .42f;
+    commands[0].parameterY = .125f;
+    measure(2);
+    compare();
+    commands[0].originX += .5f;
+    commands[0].axisXY = 13.5f;
+    commands[0].uvLeft = .05f;
+    commands[0].tintG = .7f;
+    measure(2);
+    compare();
+
+    commands[0].textureId = 1;
+    measure(2);
+    compare();
+    const uint8_t replacement[] = {16, 8, 4, 64};
+    Require(SUCCEEDED(WispRendererUploadTexture(renderer, 1, 1, 1, 4, replacement, 4)), "cache source texture replacement");
+    measure(2);
+    compare();
+    Require(SUCCEEDED(WispRendererRemoveTexture(renderer, 1)), "cache source texture removal");
+    Require(WispRendererRender(renderer, commands, 2, 0) == E_INVALIDARG,
+        "cached pixels never bypass missing texture validation");
+    const uint8_t original[] = {64, 32, 16, 128};
+    Require(SUCCEEDED(WispRendererUploadTexture(renderer, 1, 1, 1, 4, original, 4)), "restore source texture");
+    measure(2);
+    compare();
+
+    width = 320; height = 304;
+    Require(SUCCEEDED(WispRendererResize(renderer, width, height, 2.5f, 3.5f)), "resize releases old cache target");
+    measure(2);
+    compare();
+    measure(cachedDraws);
+    Require(SUCCEEDED(WispRendererResize(renderer, 8192, 513, 0, 0)), "oversized cache uses normal drawing");
+    measure(2);
+    measure(2);
+    width = height = 288;
+    Require(SUCCEEDED(WispRendererResize(renderer, width, height, 2.5f, 3.5f)), "restore target after cache bound check");
+    measure(2);
+    compare();
+    measure(cachedDraws);
+    capture(commands, 2, pixels);
+}
+
 static void CheckVisiblePacing(void* renderer, HWND window)
 {
     MONITORINFOEXW monitor{};
@@ -198,6 +289,7 @@ int main(int argc, char** argv)
     visible = 0; for (size_t index = 3; index < pixels.size(); index += 4) if (pixels[index]) ++visible;
     std::printf("needleVisible=%zu\n", visible);
     Require(visible > 100 && visible < 110*180, "needle blur has bounded coverage");
+    CheckDialCache(renderer, cpuRendering);
     HRESULT wrongThread = S_OK;
     std::thread other([&] { wrongThread = WispRendererRender(renderer, nullptr, 0, 0); }); other.join();
     Require(wrongThread == RPC_E_WRONG_THREAD, "render worker ownership enforced");

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <thread>
 #include <cmath>
+#include <algorithm>
 #include <dxgi.h>
 
 static int failures = 0;
@@ -21,6 +22,106 @@ static WispDrawCommand Sprite(float x, float y, float width, float height, uint3
     command.tintR = command.tintG = command.tintB = command.tintA = 1;
     return command;
 }
+
+static void CheckVisiblePacing(void* renderer, HWND window)
+{
+    MONITORINFOEXW monitor{};
+    monitor.cbSize = sizeof(monitor);
+    DEVMODEW mode{};
+    mode.dmSize = sizeof(mode);
+    const bool hasRefresh = GetMonitorInfoW(MonitorFromWindow(window, MONITOR_DEFAULTTONEAREST), &monitor) &&
+        EnumDisplaySettingsW(monitor.szDevice, ENUM_CURRENT_SETTINGS, &mode) && mode.dmDisplayFrequency > 1;
+    Require(hasRefresh, "visible pacing has a known display refresh rate");
+    if (!hasRefresh) return;
+
+    Require(SUCCEEDED(WispRendererSetVisible(renderer, 0)) &&
+        WispRendererPrepareForResume(renderer) == S_OK, "pacing starts with a fresh queue");
+    Require(SUCCEEDED(WispRendererSetOpacity(renderer, .12f)), "pacing surface has low opacity");
+    Require(SUCCEEDED(WispRendererSetVisible(renderer, 1)), "pacing surface is visible");
+    SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    Require(IsWindowVisible(window) && GetForegroundWindow() != window, "pacing window does not activate");
+
+    LARGE_INTEGER frequency{}, started{}, now{};
+    QueryPerformanceFrequency(&frequency);
+    const double ticksPerSecond = static_cast<double>(frequency.QuadPart);
+    QueryPerformanceCounter(&started);
+    now = started;
+    uint32_t submitted = 0, busy = 0, occluded = 0, timeouts = 0;
+    bool ready = false, pending = false;
+    std::vector<double> waits;
+    waits.reserve(2048);
+    WispWaitMetrics waitMetrics{};
+    WispDrawMetrics drawMetrics{};
+    WispPresentMetrics presentMetrics{};
+    while (now.QuadPart - started.QuadPart < frequency.QuadPart * 3 && submitted < 10000)
+    {
+        if (!ready)
+        {
+            uint32_t waitResult = 99;
+            const HRESULT result = WispRendererWaitForFrameMeasured(renderer, 100, nullptr, 1, &waitResult, &waitMetrics);
+            Require(SUCCEEDED(result), "pacing wait remains healthy");
+            if (FAILED(result)) break;
+            waits.push_back(static_cast<double>(waitMetrics.totalTicks) * 1000.0 / ticksPerSecond);
+            if (waitResult == 1) ++timeouts;
+            else ready = waitResult == 0;
+        }
+        if (ready)
+        {
+            if (!pending)
+            {
+                auto sample = Sprite(64.0f + static_cast<float>(submitted % 80), 96, 24, 24);
+                sample.tintR = .2f;
+                sample.tintB = .7f;
+                const HRESULT result = WispRendererDrawForPresentation(renderer, &sample, 1, 0, &drawMetrics);
+                Require(SUCCEEDED(result), "pacing draw remains healthy");
+                if (FAILED(result)) break;
+                pending = true;
+            }
+            const HRESULT result = WispRendererTryPresent(renderer, 0, &presentMetrics);
+            if (result == S_OK)
+            {
+                ++submitted;
+                ready = pending = false;
+            }
+            else if (result == S_FALSE)
+            {
+                ++busy;
+                Sleep(1);
+            }
+            else if (result == 2)
+            {
+                ++occluded;
+                pending = false;
+                Sleep(100);
+            }
+            else
+            {
+                Require(false, "pacing presentation remains healthy");
+                break;
+            }
+        }
+        MSG message{};
+        while (PeekMessageW(&message, window, 0, 0, PM_REMOVE))
+        {
+            TranslateMessage(&message);
+            DispatchMessageW(&message);
+        }
+        QueryPerformanceCounter(&now);
+    }
+    SetWindowPos(window, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    const double seconds = static_cast<double>(now.QuadPart - started.QuadPart) / ticksPerSecond;
+    std::sort(waits.begin(), waits.end());
+    const double p95 = waits.empty() ? 0 : waits[(waits.size() - 1) * 95 / 100];
+    std::printf("pacingSeconds=%.3f;displayHz=%lu;submittedPerSecond=%.3f;waitP95Ms=%.3f;busy=%u;occluded=%u;timeouts=%u\n",
+        seconds, mode.dmDisplayFrequency, submitted / seconds, p95, busy, occluded, timeouts);
+    // This checks actual submissions, not displayed frames. Allow initial queue
+    // credits and clock variance, but fail an accidentally unthrottled loop.
+    Require(submitted >= 2, "visible pacing successfully submits frames");
+    Require(submitted <= mode.dmDisplayFrequency * seconds * 1.25 + 4,
+        "presentation throughput remains bounded by display cadence");
+}
+
 int main()
 {
     HWND window = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_NOREDIRECTIONBITMAP,
@@ -34,7 +135,15 @@ int main()
     Require(SUCCEEDED(result) && renderer, "hardware D3D11 and DirectComposition creation");
     if (!renderer) { DestroyWindow(window); return 1; }
     uint32_t initialReady = 99;
-    Require(SUCCEEDED(WispRendererWaitForFrame(renderer, 100, nullptr, &initialReady)), "initial queue wait");
+    WispWaitMetrics waitMetrics{};
+    Require(SUCCEEDED(WispRendererWaitForFrameMeasured(renderer, 100, nullptr, 1, &initialReady, &waitMetrics)),
+        "initial measured queue wait");
+    Require(waitMetrics.totalTicks > 0 && waitMetrics.precheckTicks >= 0 && waitMetrics.waitCallTicks > 0 &&
+        waitMetrics.postcheckTicks >= 0 && waitMetrics.totalTicks >=
+        waitMetrics.precheckTicks + waitMetrics.waitCallTicks + waitMetrics.postcheckTicks &&
+        waitMetrics.cpuTime100ns >= -1 && waitMetrics.swapChainGeneration == 1 &&
+        waitMetrics.waitResult == (initialReady == 1 ? WAIT_TIMEOUT : WAIT_OBJECT_0),
+        "wait metrics partition wall time and record initial swapchain generation");
     std::printf("initialHiddenWait=%u\n", initialReady);
     Require(WispRendererPrepareForResume(renderer) == S_FALSE,
         "fresh resume preserves the current chain and acquired readiness");
@@ -88,8 +197,40 @@ int main()
     std::thread other([&] { wrongThread = WispRendererRender(renderer, nullptr, 0, 0); }); other.join();
     Require(wrongThread == RPC_E_WRONG_THREAD, "render worker ownership enforced");
     HANDLE cancellation = CreateEventW(nullptr, TRUE, TRUE, nullptr);
+    Require(cancellation != nullptr, "cancellation event creation");
     uint32_t waited = 99;
     Require(SUCCEEDED(WispRendererWaitForFrame(renderer, 100, cancellation, &waited)) && waited == 2, "cancellation wins over frame readiness");
+    Require(SUCCEEDED(WispRendererWaitForFrameMeasured(renderer, 100, cancellation, 1, &waited, &waitMetrics)) &&
+        waited == 2 && waitMetrics.totalTicks > 0 && waitMetrics.precheckTicks >= 0 &&
+        waitMetrics.waitCallTicks == 0 && waitMetrics.postcheckTicks == 0 &&
+        waitMetrics.totalTicks >= waitMetrics.precheckTicks && waitMetrics.cpuTime100ns >= -1 &&
+        waitMetrics.swapChainGeneration == 1 && waitMetrics.waitResult == WAIT_OBJECT_0,
+        "measured cancellation returns before the frame wait");
+    waitMetrics = {1,1,1,1,1,1,1};
+    Require(SUCCEEDED(WispRendererWaitForFrameMeasured(renderer, 100, cancellation, 0, &waited, &waitMetrics)) &&
+        waited == 2 && waitMetrics.totalTicks == 0 && waitMetrics.precheckTicks == 0 &&
+        waitMetrics.waitCallTicks == 0 && waitMetrics.postcheckTicks == 0 && waitMetrics.cpuTime100ns == 0 &&
+        waitMetrics.swapChainGeneration == 0 && waitMetrics.waitResult == 0,
+        "disabled wait metrics stay zero without changing cancellation");
+    std::thread otherWait([&] {
+        wrongThread = WispRendererWaitForFrameMeasured(renderer, 100, cancellation, 1, &waited, &waitMetrics);
+    });
+    otherWait.join();
+    Require(wrongThread == RPC_E_WRONG_THREAD && waitMetrics.totalTicks > 0 && waitMetrics.precheckTicks >= 0 &&
+        waitMetrics.waitCallTicks == 0 && waitMetrics.postcheckTicks == 0 &&
+        waitMetrics.swapChainGeneration == 0 && waitMetrics.waitResult == WAIT_FAILED,
+        "failed ownership check preserves measured timing without waiting");
+    Require(WispRendererWaitForFrameMeasured(renderer, 100, cancellation, 1, &waited, nullptr) == E_POINTER,
+        "wait metrics output is required");
+    Require(WispRendererWaitForFrameMeasured(renderer, 1001, cancellation, 1, &waited, &waitMetrics) == E_INVALIDARG &&
+        waitMetrics.waitResult == WAIT_FAILED && waitMetrics.swapChainGeneration == 0 && waitMetrics.waitCallTicks == 0,
+        "invalid measured timeout is rejected before waiting");
+    Require(WispRendererWaitForFrameMeasured(renderer, 100, cancellation, 1, nullptr, &waitMetrics) == E_INVALIDARG &&
+        waitMetrics.waitResult == WAIT_FAILED && waitMetrics.waitCallTicks == 0,
+        "measured wait requires its result output");
+    Require(WispRendererWaitForFrameMeasured(nullptr, 100, cancellation, 1, &waited, &waitMetrics) == E_POINTER &&
+        waitMetrics.totalTicks > 0 && waitMetrics.swapChainGeneration == 0 && waitMetrics.waitResult == WAIT_FAILED,
+        "missing renderer preserves failure timing and an unknown generation");
     CloseHandle(cancellation);
     WispDrawMetrics drawMetrics{};
     WispPresentMetrics presentMetrics{};
@@ -152,7 +293,9 @@ int main()
         Require(freshTransparent, "fresh resume target contains no previous colored frame");
         Require(SUCCEEDED(WispRendererSetVisible(renderer, 1)), "show fresh transparent chain before waiting");
         uint32_t resumed = 99;
-        Require(SUCCEEDED(WispRendererWaitForFrame(renderer, 100, nullptr, &resumed)), "fresh queue wait");
+        Require(SUCCEEDED(WispRendererWaitForFrameMeasured(renderer, 100, nullptr, 1, &resumed, &waitMetrics)), "fresh queue wait");
+        Require(waitMetrics.swapChainGeneration == index + 2,
+            "only successful swapchain replacements advance the measured generation");
         if (resumed != 0) ++transitionTimeouts;
         transition.tintR = (index & 1) ? 1.0f : 0.0f;
         transition.tintB = (index & 1) ? 0.0f : 1.0f;
@@ -162,6 +305,7 @@ int main()
     }
     Require(transitionTimeouts == 0, "fresh queue has no resume readiness deadlock");
     std::printf("resumeTimeouts=%u;occludedFrames=%u\n", transitionTimeouts, occludedFrames);
+    CheckVisiblePacing(renderer, window);
     Require(SUCCEEDED(WispRendererSetOpacity(renderer, .5f)), "group opacity accepts half alpha");
     Require(WispRendererSetOpacity(renderer, 1.5f) == E_INVALIDARG, "invalid group opacity rejected");
     Require(SUCCEEDED(WispRendererDeviceRemovedReason(renderer)), "device remains healthy");

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
@@ -30,6 +30,29 @@ namespace
     };
     static_assert(sizeof(Constants) == 80, "Shader constant layout mismatch.");
 
+    int64_t Counter() noexcept
+    {
+        LARGE_INTEGER value{};
+        QueryPerformanceCounter(&value);
+        return value.QuadPart;
+    }
+
+    class CpuTimer final
+    {
+        int64_t* destination;
+        int64_t started;
+    public:
+        explicit CpuTimer(int64_t* ticks) noexcept : destination(ticks), started(ticks ? Counter() : 0) { }
+        ~CpuTimer() { if (destination) *destination = Counter() - started; }
+        int64_t Started() const noexcept { return started; }
+    };
+
+    HRESULT PresentationResult(HRESULT result) noexcept
+    {
+        if (result == DXGI_ERROR_WAS_STILL_DRAWING) return S_FALSE;
+        return result == DXGI_STATUS_OCCLUDED ? static_cast<HRESULT>(2) : result;
+    }
+
     class Renderer final
     {
     public:
@@ -41,6 +64,7 @@ namespace
         bool visible = false;
         float opacity = 1.0f;
         bool hasDrawn = false;
+        bool pendingPresentation = false;
         ComPtr<ID3D11Device> device;
         ComPtr<ID3D11DeviceContext> context;
         ComPtr<IDXGISwapChain2> swapChain;
@@ -172,6 +196,7 @@ namespace
         {
             CHECK_HR(CheckThread());
             if (visible) return HRESULT_FROM_WIN32(ERROR_INVALID_STATE);
+            pendingPresentation = false;
             if (!hasDrawn) return S_FALSE;
             ComPtr<IDXGIDevice> dxgiDevice;
             ComPtr<IDXGIAdapter> adapter;
@@ -215,6 +240,7 @@ namespace
             CHECK_HR(CheckThread());
             if (!ValidSize(targetWidth, targetHeight) || !std::isfinite(offsetX) || !std::isfinite(offsetY)) return E_INVALIDARG;
             captureReady = false;
+            pendingPresentation = false;
             if (width != targetWidth || height != targetHeight)
             {
                 context->OMSetRenderTargets(0, nullptr, nullptr);
@@ -252,9 +278,11 @@ namespace
             return S_OK;
         }
 
-        HRESULT Render(const WispDrawCommand* commands, uint32_t count, bool present)
+        HRESULT Draw(const WispDrawCommand* commands, uint32_t count, bool forPresentation, WispDrawMetrics* metrics)
         {
             CHECK_HR(CheckThread());
+            pendingPresentation = false;
+            CpuTimer drawTimer(metrics ? &metrics->totalTicks : nullptr);
             if ((count && !commands) || count > 4096 || !renderTarget) return E_INVALIDARG;
             for (uint32_t index = 0; index < count; ++index)
             {
@@ -288,6 +316,7 @@ namespace
             context->PSSetConstantBuffers(0, 1, &constantBuffer);
             ID3D11SamplerState* sample = sampler.Get();
             context->PSSetSamplers(0, 1, &sample);
+            if (metrics) metrics->setupTicks = Counter() - drawTimer.Started();
             for (uint32_t index = 0; index < count; ++index)
             {
                 const auto& c = commands[index];
@@ -298,20 +327,45 @@ namespace
                     {c.parameterX,c.parameterY,c.parameterZ,c.parameterW}
                 };
                 D3D11_MAPPED_SUBRESOURCE mapping{};
-                CHECK_HR(context->Map(constants.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapping));
+                const int64_t mapStarted = metrics ? Counter() : 0;
+                const HRESULT mapped = context->Map(constants.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapping);
+                if (metrics)
+                {
+                    const int64_t elapsed = Counter() - mapStarted;
+                    metrics->mapTicks += elapsed;
+                    if (elapsed > metrics->maximumMapTicks) metrics->maximumMapTicks = elapsed;
+                    ++metrics->mapCount;
+                }
+                CHECK_HR(mapped);
                 std::memcpy(mapping.pData, &data, sizeof(data));
                 context->Unmap(constants.Get(), 0);
                 ID3D11ShaderResourceView* view = textures.at(c.textureId).Get();
                 context->PSSetShaderResources(0, 1, &view);
                 context->PSSetShader(pixelShaders[c.shader].Get(), nullptr, 0);
                 context->Draw(6, 0);
+                if (metrics) ++metrics->drawCount;
             }
             hasDrawn = true;
             CHECK_HR(device->GetDeviceRemovedReason());
-            if (!present) { captureReady = true; return S_OK; }
+            captureReady = !forPresentation;
+            pendingPresentation = forPresentation;
+            return S_OK;
+        }
+
+        HRESULT TryPresent(WispPresentMetrics* metrics)
+        {
+            CHECK_HR(CheckThread());
+            if (!pendingPresentation) return HRESULT_FROM_WIN32(ERROR_INVALID_STATE);
+            CpuTimer presentTimer(metrics ? &metrics->durationTicks : nullptr);
             const HRESULT result = swapChain->Present(1, DXGI_PRESENT_DO_NOT_WAIT);
-            if (result == DXGI_ERROR_WAS_STILL_DRAWING) return S_FALSE;
-            return result == DXGI_STATUS_OCCLUDED ? static_cast<HRESULT>(2) : result;
+            if (result == S_OK) pendingPresentation = false;
+            return result;
+        }
+
+        HRESULT Render(const WispDrawCommand* commands, uint32_t count, bool present)
+        {
+            CHECK_HR(Draw(commands, count, present, nullptr));
+            return present ? PresentationResult(TryPresent(nullptr)) : S_OK;
         }
 
         HRESULT Capture(uint8_t* pixels, uint32_t byteCount, uint32_t stride)
@@ -361,7 +415,7 @@ HRESULT __cdecl WispRendererPrepareForResume(void* renderer) noexcept
 HRESULT __cdecl WispRendererSetOpacity(void* renderer, float opacity) noexcept
 { return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); if (!std::isfinite(opacity) || opacity < 0 || opacity > 1) return E_INVALIDARG; if (r.opacity == opacity) return S_OK; if (r.visible) { CHECK_HR(r.opacityEffect->SetOpacity(opacity)); CHECK_HR(r.composition->Commit()); } r.opacity = opacity; return S_OK; }); }
 HRESULT __cdecl WispRendererSetVisible(void* renderer, int visible) noexcept
-{ return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); const bool show = visible != 0; if (r.visible == show) return S_OK; CHECK_HR(r.opacityEffect->SetOpacity(show ? r.opacity : 0.0f)); CHECK_HR(r.composition->Commit()); r.visible = show; return S_OK; }); }
+{ return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); const bool show = visible != 0; if (!show) r.pendingPresentation = false; if (r.visible == show) return S_OK; CHECK_HR(r.opacityEffect->SetOpacity(show ? r.opacity : 0.0f)); CHECK_HR(r.composition->Commit()); r.visible = show; return S_OK; }); }
 HRESULT __cdecl WispRendererResize(void* renderer, uint32_t width, uint32_t height, float x, float y) noexcept
 { return Invoke(renderer, [&](Renderer& r) { return r.Resize(width,height,x,y); }); }
 HRESULT __cdecl WispRendererUploadTexture(void* renderer, uint32_t id, uint32_t width, uint32_t height,
@@ -371,6 +425,21 @@ HRESULT __cdecl WispRendererRemoveTexture(void* renderer, uint32_t id) noexcept
 { return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); if (!id) return E_INVALIDARG; r.textures.erase(id); return S_OK; }); }
 HRESULT __cdecl WispRendererRender(void* renderer, const WispDrawCommand* commands, uint32_t count, int present) noexcept
 { return Invoke(renderer, [&](Renderer& r) { return r.Render(commands,count,present != 0); }); }
+HRESULT __cdecl WispRendererDrawForPresentation(void* renderer, const WispDrawCommand* commands,
+    uint32_t count, int measure, WispDrawMetrics* metrics) noexcept
+{
+    if (!metrics) return E_POINTER;
+    *metrics = {};
+    return Invoke(renderer, [&](Renderer& r) { return r.Draw(commands, count, true, measure ? metrics : nullptr); });
+}
+HRESULT __cdecl WispRendererTryPresent(void* renderer, int measure, WispPresentMetrics* metrics) noexcept
+{
+    if (!metrics) return E_POINTER;
+    *metrics = {};
+    const HRESULT result = Invoke(renderer, [&](Renderer& r) { return r.TryPresent(measure ? metrics : nullptr); });
+    if (measure) metrics->hResult = result;
+    return PresentationResult(result);
+}
 HRESULT __cdecl WispRendererWaitForFrame(void* renderer, uint32_t timeout, HANDLE cancellation, uint32_t* result) noexcept
 {
     if (!result || timeout > 1000) return E_INVALIDARG;

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
@@ -23,6 +23,7 @@ namespace
     // Present remains synchronized, and the waitable queue still bounds the work.
     constexpr UINT SwapChainBufferCount = 3;
     constexpr UINT MaximumFrameLatency = 2;
+    constexpr uint64_t MaximumDialCacheBytes = 16ull * 1024 * 1024;
 
     bool ValidSize(uint32_t width, uint32_t height) noexcept
     {
@@ -95,6 +96,11 @@ namespace
         float opacity = 1.0f;
         bool hasDrawn = false;
         bool pendingPresentation = false;
+        bool cacheDialOnCpu = false;
+        bool dialCacheValid = false;
+        bool dialCacheUnavailable = false;
+        WispDrawCommand cachedDial{};
+        ComPtr<ID3D11Texture2D> dialCache;
         ComPtr<ID3D11Device> device;
         ComPtr<ID3D11DeviceContext> context;
         ComPtr<IDXGISwapChain2> swapChain;
@@ -133,12 +139,33 @@ namespace
             return device->CreateRenderTargetView(buffer.Get(), nullptr, &renderTarget);
         }
 
+        bool PrepareDialCache(const WispDrawCommand* commands, uint32_t count)
+        {
+            if (!cacheDialOnCpu || count == 0 || commands[0].shader != 1 || dialCacheUnavailable ||
+                static_cast<uint64_t>(width) * height * 4 > MaximumDialCacheBytes) return false;
+            if (dialCache) return true;
+            D3D11_TEXTURE2D_DESC description{};
+            description.Width = width; description.Height = height;
+            description.MipLevels = description.ArraySize = 1;
+            description.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            description.SampleDesc.Count = 1;
+            description.Usage = D3D11_USAGE_DEFAULT;
+            if (FAILED(device->CreateTexture2D(&description, nullptr, &dialCache)))
+            {
+                // An optional cache must not turn memory pressure into a HUD failure.
+                dialCacheUnavailable = true;
+                return false;
+            }
+            return true;
+        }
+
         HRESULT Initialize(HWND window, uint32_t targetWidth, uint32_t targetHeight, bool cpuRendering)
         {
             DWORD process = 0;
             if (!IsWindow(window) || !GetWindowThreadProcessId(window, &process) || process != GetCurrentProcessId()
                 || !ValidSize(targetWidth, targetHeight)) return E_INVALIDARG;
             hwnd = window; width = targetWidth; height = targetHeight;
+            cacheDialOnCpu = cpuRendering;
             const D3D_FEATURE_LEVEL requested[] = { D3D_FEATURE_LEVEL_11_0 };
             D3D_FEATURE_LEVEL obtained{};
             // Use only the explicitly selected driver; failure must not silently change modes.
@@ -227,6 +254,7 @@ namespace
             CHECK_HR(CheckThread());
             if (visible) return HRESULT_FROM_WIN32(ERROR_INVALID_STATE);
             pendingPresentation = false;
+            dialCacheValid = false;
             if (!hasDrawn) return S_FALSE;
             ComPtr<IDXGIDevice> dxgiDevice;
             ComPtr<IDXGIAdapter> adapter;
@@ -272,8 +300,11 @@ namespace
             if (!ValidSize(targetWidth, targetHeight) || !std::isfinite(offsetX) || !std::isfinite(offsetY)) return E_INVALIDARG;
             captureReady = false;
             pendingPresentation = false;
+            dialCacheValid = false;
             if (width != targetWidth || height != targetHeight)
             {
+                dialCache.Reset();
+                dialCacheUnavailable = false;
                 context->OMSetRenderTargets(0, nullptr, nullptr);
                 renderTarget.Reset();
                 CHECK_HR(swapChain->ResizeBuffers(SwapChainBufferCount, targetWidth, targetHeight, DXGI_FORMAT_B8G8R8A8_UNORM,
@@ -306,6 +337,7 @@ namespace
             CHECK_HR(device->CreateTexture2D(&description, &initial, &texture));
             CHECK_HR(device->CreateShaderResourceView(texture.Get(), nullptr, &view));
             textures[id] = std::move(view);
+            dialCacheValid = false;
             return S_OK;
         }
 
@@ -326,8 +358,23 @@ namespace
                     || (command.shader == 1 && command.parameterY <= 0)) return E_INVALIDARG;
             }
             captureReady = false;
+            const bool cacheDial = PrepareDialCache(commands, count);
+            const bool reuseDial = cacheDial && dialCacheValid &&
+                std::memcmp(&cachedDial, commands, sizeof(cachedDial)) == 0;
+            ComPtr<ID3D11Resource> frameBuffer;
+            if (cacheDial) renderTarget->GetResource(&frameBuffer);
             const float clear[4]{};
-            context->ClearRenderTargetView(renderTarget.Get(), clear);
+            if (reuseDial)
+            {
+                // Copy exact target pixels: no second sampling pass or changed AA.
+                context->OMSetRenderTargets(0, nullptr, nullptr);
+                context->CopyResource(frameBuffer.Get(), dialCache.Get());
+            }
+            else
+            {
+                context->ClearRenderTargetView(renderTarget.Get(), clear);
+                if (cacheDial) dialCacheValid = false;
+            }
             ID3D11RenderTargetView* targetView = renderTarget.Get();
             context->OMSetRenderTargets(1, &targetView, nullptr);
             const float factors[4]{};
@@ -348,7 +395,7 @@ namespace
             ID3D11SamplerState* sample = sampler.Get();
             context->PSSetSamplers(0, 1, &sample);
             if (metrics) metrics->setupTicks = Counter() - drawTimer.Started();
-            for (uint32_t index = 0; index < count; ++index)
+            for (uint32_t index = reuseDial ? 1u : 0u; index < count; ++index)
             {
                 const auto& c = commands[index];
                 const Constants data{
@@ -375,6 +422,15 @@ namespace
                 context->PSSetShader(pixelShaders[c.shader].Get(), nullptr, 0);
                 context->Draw(6, 0);
                 if (metrics) ++metrics->drawCount;
+                if (cacheDial && index == 0)
+                {
+                    // Only the first dial is static; every later quad remains live.
+                    context->OMSetRenderTargets(0, nullptr, nullptr);
+                    context->CopyResource(dialCache.Get(), frameBuffer.Get());
+                    context->OMSetRenderTargets(1, &targetView, nullptr);
+                    cachedDial = commands[0];
+                    dialCacheValid = true;
+                }
             }
             hasDrawn = true;
             CHECK_HR(device->GetDeviceRemovedReason());
@@ -510,7 +566,7 @@ HRESULT __cdecl WispRendererUploadTexture(void* renderer, uint32_t id, uint32_t 
     uint32_t stride, const uint8_t* pixels, uint32_t bytes) noexcept
 { if (!id) return E_INVALIDARG; return Invoke(renderer, [&](Renderer& r) { return r.Upload(id,width,height,stride,pixels,bytes); }); }
 HRESULT __cdecl WispRendererRemoveTexture(void* renderer, uint32_t id) noexcept
-{ return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); if (!id) return E_INVALIDARG; r.textures.erase(id); return S_OK; }); }
+{ return Invoke(renderer, [&](Renderer& r) { CHECK_HR(r.CheckThread()); if (!id) return E_INVALIDARG; r.textures.erase(id); r.dialCacheValid = false; return S_OK; }); }
 HRESULT __cdecl WispRendererRender(void* renderer, const WispDrawCommand* commands, uint32_t count, int present) noexcept
 { return Invoke(renderer, [&](Renderer& r) { return r.Render(commands,count,present != 0); }); }
 HRESULT __cdecl WispRendererDrawForPresentation(void* renderer, const WispDrawCommand* commands,

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
@@ -133,7 +133,7 @@ namespace
             return device->CreateRenderTargetView(buffer.Get(), nullptr, &renderTarget);
         }
 
-        HRESULT Initialize(HWND window, uint32_t targetWidth, uint32_t targetHeight)
+        HRESULT Initialize(HWND window, uint32_t targetWidth, uint32_t targetHeight, bool cpuRendering)
         {
             DWORD process = 0;
             if (!IsWindow(window) || !GetWindowThreadProcessId(window, &process) || process != GetCurrentProcessId()
@@ -141,8 +141,8 @@ namespace
             hwnd = window; width = targetWidth; height = targetHeight;
             const D3D_FEATURE_LEVEL requested[] = { D3D_FEATURE_LEVEL_11_0 };
             D3D_FEATURE_LEVEL obtained{};
-            // Hardware failure is returned to Wisp; silently switching to WARP would hide a regression.
-            CHECK_HR(D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+            // Use only the explicitly selected driver; failure must not silently change modes.
+            CHECK_HR(D3D11CreateDevice(nullptr, cpuRendering ? D3D_DRIVER_TYPE_WARP : D3D_DRIVER_TYPE_HARDWARE, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT,
                 requested, ARRAYSIZE(requested), D3D11_SDK_VERSION, &device, &obtained, &context));
             ComPtr<IDXGIDevice> dxgiDevice;
             ComPtr<IDXGIAdapter> adapter;
@@ -483,11 +483,16 @@ namespace
 
 HRESULT __cdecl WispRendererCreate(HWND hwnd, uint32_t width, uint32_t height, void** output) noexcept
 {
+    return WispRendererCreateWithMode(hwnd, width, height, 0, output);
+}
+HRESULT __cdecl WispRendererCreateWithMode(HWND hwnd, uint32_t width, uint32_t height, uint32_t cpuRendering, void** output) noexcept
+{
     if (!output) return E_POINTER;
     *output = nullptr;
+    if (cpuRendering > 1) return E_INVALIDARG;
     try {
         auto renderer = std::make_unique<Renderer>();
-        CHECK_HR(renderer->Initialize(hwnd, width, height));
+        CHECK_HR(renderer->Initialize(hwnd, width, height, cpuRendering != 0));
         *output = renderer.release();
         return S_OK;
     } catch (const std::bad_alloc&) { return E_OUTOFMEMORY; } catch (...) { return E_FAIL; }

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.cpp
@@ -19,6 +19,11 @@ using Microsoft::WRL::ComPtr;
 
 namespace
 {
+    // Keep one additional frame in flight so drawing can overlap presentation.
+    // Present remains synchronized, and the waitable queue still bounds the work.
+    constexpr UINT SwapChainBufferCount = 3;
+    constexpr UINT MaximumFrameLatency = 2;
+
     bool ValidSize(uint32_t width, uint32_t height) noexcept
     {
         return width > 0 && height > 0 && width <= 8192 && height <= 8192;
@@ -47,6 +52,30 @@ namespace
         int64_t Started() const noexcept { return started; }
     };
 
+    int64_t ThreadCpuTime100ns() noexcept
+    {
+        FILETIME created{}, exited{}, kernel{}, user{};
+        if (!GetThreadTimes(GetCurrentThread(), &created, &exited, &kernel, &user)) return -1;
+        const uint64_t kernelTime = (static_cast<uint64_t>(kernel.dwHighDateTime) << 32) | kernel.dwLowDateTime;
+        const uint64_t userTime = (static_cast<uint64_t>(user.dwHighDateTime) << 32) | user.dwLowDateTime;
+        return static_cast<int64_t>(kernelTime + userTime);
+    }
+
+    class ThreadCpuTimer final
+    {
+        int64_t* destination;
+        int64_t started;
+    public:
+        explicit ThreadCpuTimer(int64_t* time) noexcept
+            : destination(time), started(time ? ThreadCpuTime100ns() : -1) { }
+        ~ThreadCpuTimer()
+        {
+            if (!destination || started < 0) return;
+            const int64_t ended = ThreadCpuTime100ns();
+            if (ended >= started) *destination = ended - started;
+        }
+    };
+
     HRESULT PresentationResult(HRESULT result) noexcept
     {
         if (result == DXGI_ERROR_WAS_STILL_DRAWING) return S_FALSE;
@@ -59,6 +88,7 @@ namespace
         DWORD threadId = GetCurrentThreadId();
         HWND hwnd = nullptr;
         uint32_t width = 0, height = 0;
+        uint32_t swapChainGeneration = 1;
         HANDLE latency = nullptr;
         bool captureReady = false;
         bool visible = false;
@@ -125,7 +155,7 @@ namespace
             description.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
             description.SampleDesc.Count = 1;
             description.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
-            description.BufferCount = 2;
+            description.BufferCount = SwapChainBufferCount;
             description.Scaling = DXGI_SCALING_STRETCH;
             description.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
             description.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
@@ -133,7 +163,7 @@ namespace
             ComPtr<IDXGISwapChain1> chain;
             CHECK_HR(factory->CreateSwapChainForComposition(device.Get(), &description, nullptr, &chain));
             CHECK_HR(chain.As(&swapChain));
-            CHECK_HR(swapChain->SetMaximumFrameLatency(1));
+            CHECK_HR(swapChain->SetMaximumFrameLatency(MaximumFrameLatency));
             latency = swapChain->GetFrameLatencyWaitableObject();
             if (!latency) return HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE);
             CHECK_HR(CreateTarget());
@@ -210,7 +240,7 @@ namespace
             ComPtr<IDXGISwapChain2> replacement;
             CHECK_HR(factory->CreateSwapChainForComposition(device.Get(), &description, nullptr, &created));
             CHECK_HR(created.As(&replacement));
-            CHECK_HR(replacement->SetMaximumFrameLatency(1));
+            CHECK_HR(replacement->SetMaximumFrameLatency(MaximumFrameLatency));
             HANDLE replacementLatency = replacement->GetFrameLatencyWaitableObject();
             if (!replacementLatency) return HRESULT_FROM_WIN32(ERROR_INVALID_HANDLE);
             ComPtr<ID3D11Texture2D> buffer;
@@ -232,6 +262,7 @@ namespace
             latency = replacementLatency;
             captureReady = true;
             hasDrawn = false;
+            ++swapChainGeneration;
             return S_OK;
         }
 
@@ -245,7 +276,7 @@ namespace
             {
                 context->OMSetRenderTargets(0, nullptr, nullptr);
                 renderTarget.Reset();
-                CHECK_HR(swapChain->ResizeBuffers(2, targetWidth, targetHeight, DXGI_FORMAT_B8G8R8A8_UNORM,
+                CHECK_HR(swapChain->ResizeBuffers(SwapChainBufferCount, targetWidth, targetHeight, DXGI_FORMAT_B8G8R8A8_UNORM,
                     DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT));
                 width = targetWidth; height = targetHeight;
                 CHECK_HR(CreateTarget());
@@ -396,6 +427,58 @@ namespace
         catch (const std::bad_alloc&) { return E_OUTOFMEMORY; }
         catch (...) { return E_FAIL; }
     }
+
+    HRESULT WaitForFrame(void* renderer, uint32_t timeout, HANDLE cancellation,
+        uint32_t* result, WispWaitMetrics* metrics) noexcept
+    {
+        if (metrics)
+        {
+            metrics->cpuTime100ns = -1;
+            metrics->waitResult = WAIT_FAILED;
+        }
+        CpuTimer totalTimer(metrics ? &metrics->totalTicks : nullptr);
+        ThreadCpuTimer cpuTimer(metrics ? &metrics->cpuTime100ns : nullptr);
+        if (!result || timeout > 1000) return E_INVALIDARG;
+        return Invoke(renderer, [&](Renderer& r) {
+            {
+                CpuTimer precheckTimer(metrics ? &metrics->precheckTicks : nullptr);
+                CHECK_HR(r.CheckThread());
+                if (metrics) metrics->swapChainGeneration = r.swapChainGeneration;
+                if (cancellation)
+                {
+                    const DWORD cancelled = WaitForSingleObject(cancellation, 0);
+                    if (cancelled == WAIT_OBJECT_0)
+                    {
+                        if (metrics) metrics->waitResult = cancelled;
+                        *result = 2;
+                        return S_OK;
+                    }
+                    if (cancelled == WAIT_FAILED) return HRESULT_FROM_WIN32(GetLastError());
+                }
+                CHECK_HR(r.device->GetDeviceRemovedReason());
+            }
+            HANDLE handles[2] = { cancellation ? cancellation : r.latency, r.latency };
+            DWORD waited;
+            DWORD waitError = ERROR_SUCCESS;
+            {
+                CpuTimer waitTimer(metrics ? &metrics->waitCallTicks : nullptr);
+                waited = WaitForMultipleObjects(cancellation ? 2 : 1, handles, FALSE, timeout);
+                // Preserve the original failure before diagnostic clock calls run.
+                if (waited == WAIT_FAILED) waitError = GetLastError();
+            }
+            if (metrics) metrics->waitResult = waited;
+            {
+                CpuTimer postcheckTimer(metrics ? &metrics->postcheckTicks : nullptr);
+                if (cancellation && waited == WAIT_OBJECT_0) { *result = 2; return S_OK; }
+                if (waited == WAIT_FAILED) return HRESULT_FROM_WIN32(waitError);
+                CHECK_HR(r.device->GetDeviceRemovedReason());
+                if (waited == WAIT_TIMEOUT) { *result = 1; return S_OK; }
+                if (waited == WAIT_OBJECT_0) { *result = 0; return S_OK; }
+                if (cancellation && waited == WAIT_OBJECT_0 + 1) { *result = 0; return S_OK; }
+                return E_UNEXPECTED;
+            }
+        });
+    }
 }
 
 HRESULT __cdecl WispRendererCreate(HWND hwnd, uint32_t width, uint32_t height, void** output) noexcept
@@ -442,26 +525,14 @@ HRESULT __cdecl WispRendererTryPresent(void* renderer, int measure, WispPresentM
 }
 HRESULT __cdecl WispRendererWaitForFrame(void* renderer, uint32_t timeout, HANDLE cancellation, uint32_t* result) noexcept
 {
-    if (!result || timeout > 1000) return E_INVALIDARG;
-    return Invoke(renderer, [&](Renderer& r) {
-        CHECK_HR(r.CheckThread());
-        if (cancellation)
-        {
-            const DWORD cancelled = WaitForSingleObject(cancellation, 0);
-            if (cancelled == WAIT_OBJECT_0) { *result = 2; return S_OK; }
-            if (cancelled == WAIT_FAILED) return HRESULT_FROM_WIN32(GetLastError());
-        }
-        CHECK_HR(r.device->GetDeviceRemovedReason());
-        HANDLE handles[2] = { cancellation ? cancellation : r.latency, r.latency };
-        const DWORD waited = WaitForMultipleObjects(cancellation ? 2 : 1, handles, FALSE, timeout);
-        if (cancellation && waited == WAIT_OBJECT_0) { *result = 2; return S_OK; }
-        if (waited == WAIT_FAILED) return HRESULT_FROM_WIN32(GetLastError());
-        CHECK_HR(r.device->GetDeviceRemovedReason());
-        if (waited == WAIT_TIMEOUT) { *result = 1; return S_OK; }
-        if (waited == WAIT_OBJECT_0) { *result = 0; return S_OK; }
-        if (cancellation && waited == WAIT_OBJECT_0 + 1) { *result = 0; return S_OK; }
-        return E_UNEXPECTED;
-    });
+    return WaitForFrame(renderer, timeout, cancellation, result, nullptr);
+}
+HRESULT __cdecl WispRendererWaitForFrameMeasured(void* renderer, uint32_t timeout, HANDLE cancellation,
+    int measure, uint32_t* result, WispWaitMetrics* metrics) noexcept
+{
+    if (!metrics) return E_POINTER;
+    *metrics = {};
+    return WaitForFrame(renderer, timeout, cancellation, result, measure ? metrics : nullptr);
 }
 HRESULT __cdecl WispRendererCapture(void* renderer, uint8_t* pixels, uint32_t bytes, uint32_t stride) noexcept
 { return Invoke(renderer, [&](Renderer& r) { return r.Capture(pixels,bytes,stride); }); }

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
@@ -23,8 +23,14 @@ struct WispPresentMetrics
     int32_t hResult;
     uint32_t reserved;
 };
+struct WispWaitMetrics
+{
+    int64_t totalTicks, precheckTicks, waitCallTicks, postcheckTicks, cpuTime100ns;
+    uint32_t swapChainGeneration, waitResult;
+};
 static_assert(sizeof(WispDrawMetrics) == 40, "Managed/native draw metrics ABI mismatch.");
 static_assert(sizeof(WispPresentMetrics) == 16, "Managed/native present metrics ABI mismatch.");
+static_assert(sizeof(WispWaitMetrics) == 48, "Managed/native wait metrics ABI mismatch.");
 
 #ifdef WISP_RENDERER_IMPORT
 #define WISP_API extern "C" __declspec(dllimport)
@@ -48,5 +54,9 @@ WISP_API HRESULT __cdecl WispRendererDrawForPresentation(void* renderer, const W
 // A busy/occluded result retains the drawn frame for retry; successful presentation consumes it.
 WISP_API HRESULT __cdecl WispRendererTryPresent(void* renderer, int measure, WispPresentMetrics* metrics) noexcept;
 WISP_API HRESULT __cdecl WispRendererWaitForFrame(void* renderer, uint32_t timeoutMilliseconds, HANDLE cancellation, uint32_t* result) noexcept;
+// Wall times use QPC ticks; coarse thread execution time uses 100 ns units (-1 if unavailable).
+// waitResult is the raw Win32 wait result, or WAIT_FAILED before a wait/error.
+WISP_API HRESULT __cdecl WispRendererWaitForFrameMeasured(void* renderer, uint32_t timeoutMilliseconds,
+    HANDLE cancellation, int measure, uint32_t* result, WispWaitMetrics* metrics) noexcept;
 WISP_API HRESULT __cdecl WispRendererCapture(void* renderer, uint8_t* pixels, uint32_t byteCount, uint32_t stride) noexcept;
 WISP_API HRESULT __cdecl WispRendererDeviceRemovedReason(void* renderer) noexcept;

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
@@ -12,6 +12,20 @@ struct WispDrawCommand
 };
 static_assert(sizeof(WispDrawCommand) == 80, "Managed/native draw ABI mismatch.");
 
+struct WispDrawMetrics
+{
+    int64_t totalTicks, setupTicks, mapTicks, maximumMapTicks;
+    uint32_t mapCount, drawCount;
+};
+struct WispPresentMetrics
+{
+    int64_t durationTicks;
+    int32_t hResult;
+    uint32_t reserved;
+};
+static_assert(sizeof(WispDrawMetrics) == 40, "Managed/native draw metrics ABI mismatch.");
+static_assert(sizeof(WispPresentMetrics) == 16, "Managed/native present metrics ABI mismatch.");
+
 #ifdef WISP_RENDERER_IMPORT
 #define WISP_API extern "C" __declspec(dllimport)
 #else
@@ -28,6 +42,11 @@ WISP_API HRESULT __cdecl WispRendererUploadTexture(void* renderer, uint32_t id, 
     uint32_t stride, const uint8_t* pixels, uint32_t byteCount) noexcept;
 WISP_API HRESULT __cdecl WispRendererRemoveTexture(void* renderer, uint32_t id) noexcept;
 WISP_API HRESULT __cdecl WispRendererRender(void* renderer, const WispDrawCommand* commands, uint32_t count, int present) noexcept;
+// Optional CPU timings use QPC ticks. Disabled measurement returns zeroed metrics without reading QPC.
+WISP_API HRESULT __cdecl WispRendererDrawForPresentation(void* renderer, const WispDrawCommand* commands,
+    uint32_t count, int measure, WispDrawMetrics* metrics) noexcept;
+// A busy/occluded result retains the drawn frame for retry; successful presentation consumes it.
+WISP_API HRESULT __cdecl WispRendererTryPresent(void* renderer, int measure, WispPresentMetrics* metrics) noexcept;
 WISP_API HRESULT __cdecl WispRendererWaitForFrame(void* renderer, uint32_t timeoutMilliseconds, HANDLE cancellation, uint32_t* result) noexcept;
 WISP_API HRESULT __cdecl WispRendererCapture(void* renderer, uint8_t* pixels, uint32_t byteCount, uint32_t stride) noexcept;
 WISP_API HRESULT __cdecl WispRendererDeviceRemovedReason(void* renderer) noexcept;

--- a/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
+++ b/src/Wisp.NativeRenderer/Wisp.NativeRenderer.h
@@ -38,6 +38,8 @@ static_assert(sizeof(WispWaitMetrics) == 48, "Managed/native wait metrics ABI mi
 #define WISP_API extern "C" __declspec(dllexport)
 #endif
 WISP_API HRESULT __cdecl WispRendererCreate(HWND hwnd, uint32_t width, uint32_t height, void** renderer) noexcept;
+// cpuRendering: 0 = hardware, 1 = WARP; no automatic driver fallback.
+WISP_API HRESULT __cdecl WispRendererCreateWithMode(HWND hwnd, uint32_t width, uint32_t height, uint32_t cpuRendering, void** renderer) noexcept;
 WISP_API void __cdecl WispRendererDestroy(void* renderer) noexcept;
 // S_OK replaces the swapchain; S_FALSE preserves an already fresh chain.
 WISP_API HRESULT __cdecl WispRendererPrepareForResume(void* renderer) noexcept;

--- a/src/Wisp.Updater/Wisp.Updater.csproj
+++ b/src/Wisp.Updater/Wisp.Updater.csproj
@@ -12,9 +12,9 @@
     <Product>Wisp</Product>
     <AssemblyTitle>Wisp Update Helper</AssemblyTitle>
     <Description>Applies verified Wisp updates after the app exits.</Description>
-    <Version>1.2.0</Version>
-    <FileVersion>1.2.0.0</FileVersion>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <Version>1.2.1</Version>
+    <FileVersion>1.2.1.0</FileVersion>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Wisp.Update\Wisp.Update.csproj" />

--- a/tests/Wisp.App.Tests/AnalogHudPendingFrameTests.cs
+++ b/tests/Wisp.App.Tests/AnalogHudPendingFrameTests.cs
@@ -1,0 +1,188 @@
+using System.Diagnostics;
+using Wisp.App.NativeRendering;
+using Wisp.Core;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class AnalogHudPendingFrameTests
+{
+    [Fact]
+    public void FreshTelemetryKeepsPendingPixelsWhilePlaybackConsumesItsOriginalSourceTime()
+    {
+        var playback = new AnalogHudPlayback();
+        for (int ms = 0; ms <= 40; ms += 10)
+            playback.Observe(Frame(ms, 1_000 + ms * 100), Timestamp(ms));
+        var presentation = Presentation();
+        var pending = new AnalogHudPendingFrame(playback.Sample(Timestamp(50)), presentation, Timestamp(40), 7);
+        var queued = Frame(49, 5_900) with { Speed = 125, Gear = TransmissionGear.Third };
+
+        playback.ObserveQueued(queued, Timestamp(49), Timestamp(52));
+
+        Assert.True(pending.CanReuse(presentation, queued, false));
+        Assert.Equal(2_000, pending.Sample.AppliedRpm);
+        Assert.Equal(Timestamp(50), pending.Sample.Timestamp);
+        Assert.Equal(Timestamp(40), pending.QueuedTimestamp);
+        Assert.Equal(7, pending.Sequence);
+        var next = playback.Sample(Timestamp(85));
+        Assert.Equal(5_500, next.AppliedRpm!.Value, 6);
+        Assert.Equal(queued, next.Frame);
+        Assert.Equal(Timestamp(49), next.Frame.ReceivedTimestamp);
+        Assert.Equal(pending.Sample.ReseedCount, next.ReseedCount);
+    }
+
+    [Theory]
+    [InlineData("car")]
+    [InlineData("electric")]
+    [InlineData("redline")]
+    [InlineData("missing-scale")]
+    [InlineData("maximum-rpm")]
+    [InlineData("native-invalidated")]
+    [InlineData("speed-unit")]
+    [InlineData("gear-mode")]
+    public void ChangedCarOrNeedleValidityDiscardsPendingPixels(string change)
+    {
+        var pending = Pending();
+        var original = pending.Sample.Frame;
+        var changed = change switch
+        {
+            "car" => original with { CarOrdinal = original.CarOrdinal + 1 },
+            "electric" => original with { IsElectric = true },
+            "redline" => original with { ExactRedline = ExactRedlineResult.Exact(6_000 * 2 * Math.PI / 60) },
+            "missing-scale" => original with { ExactRedline = ExactRedlineResult.Unavailable() },
+            "maximum-rpm" => original with { TachometerMaximumRpm = 9_000 },
+            "speed-unit" => original with { Unit = SpeedUnit.KilometersPerHour },
+            "gear-mode" => original with { GearDisplayMode = GearDisplayMode.Automatic },
+            _ => original with { NativeGaugeSourceInvalidated = true }
+        };
+
+        Assert.False(pending.CanReuse(pending.Presentation, changed, false));
+    }
+
+    [Fact]
+    public void RestoredNativeValidityAlsoDiscardsAnInvalidatedPendingFrame()
+    {
+        var pending = Pending();
+        pending = pending with
+        {
+            Sample = pending.Sample with
+            {
+                Frame = pending.Sample.Frame with { NativeGaugeSourceInvalidated = true }
+            }
+        };
+
+        Assert.False(pending.CanReuse(pending.Presentation,
+            pending.Sample.Frame with { NativeGaugeSourceInvalidated = false }, false));
+    }
+
+    [Theory]
+    [InlineData("hidden")]
+    [InlineData("width")]
+    [InlineData("height")]
+    [InlineData("origin")]
+    [InlineData("transform")]
+    [InlineData("layout")]
+    [InlineData("traction")]
+    [InlineData("traction-color")]
+    public void ChangedPresentationDiscardsPendingPixels(string change)
+    {
+        var pending = Pending();
+        var original = pending.Presentation;
+        var changed = change switch
+        {
+            "hidden" => original with { Active = false },
+            "width" => original with { Width = 900 },
+            "height" => original with { Height = 700 },
+            "origin" => original with { OriginY = 12 },
+            "transform" => original with { AxisXX = 1.25f },
+            "layout" => original with { Layout = original.Layout! with { NeedlePivot = new(145, 143) } },
+            "traction" => original with { TractionActive = true },
+            _ => original with { TractionColor = new(255, 80, 80) }
+        };
+
+        Assert.False(pending.CanReuse(changed, pending.Sample.Frame, false));
+    }
+
+    [Fact]
+    public void AnEquivalentPresentationSnapshotDoesNotForceAnotherDraw()
+    {
+        var pending = Pending();
+        var equivalent = pending.Presentation with { Layout = pending.Presentation.Layout! with { } };
+
+        Assert.NotSame(pending.Presentation, equivalent);
+        Assert.NotSame(pending.Presentation.Layout, equivalent.Layout);
+        Assert.True(pending.CanReuse(equivalent, pending.Sample.Frame, false));
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(.5f)]
+    [InlineData(1f)]
+    public void CompositionOpacityDoesNotInvalidateAlreadyDrawnPixels(float opacity)
+    {
+        var pending = Pending();
+
+        Assert.True(pending.CanReuse(pending.Presentation with { Opacity = opacity }, pending.Sample.Frame, false));
+    }
+
+    [Fact]
+    public void NewlyAvailableNativePairDiscardsPendingRpmPixelsWithoutAnInvalidationFlagChange()
+    {
+        var playback = new AnalogHudPlayback();
+        playback.Observe(Frame(0, 4_000), Timestamp(0));
+        var pending = new AnalogHudPendingFrame(playback.Sample(Timestamp(1)), Presentation(), Timestamp(0), 1);
+        var native = Frame(10, 4_000) with
+        {
+            NativeNeedleAngleDegrees = 320,
+            NativeNeedleBlurAmount = -.4,
+            NativeGaugeObservedTimestamp = Timestamp(10)
+        };
+
+        playback.ObserveQueued(native, Timestamp(10), Timestamp(12));
+
+        Assert.False(pending.Sample.Native);
+        Assert.True(playback.HasNativeNeedle(Timestamp(12)));
+        Assert.Equal(pending.Sample.Frame.NativeGaugeSourceInvalidated, native.NativeGaugeSourceInvalidated);
+        Assert.False(pending.CanReuse(pending.Presentation, native, playback.HasNativeNeedle(Timestamp(12))));
+    }
+
+    [Fact]
+    public void NativePixelsRemainReusableUntilTheExactPairExpiresWithoutNewTelemetry()
+    {
+        var playback = new AnalogHudPlayback();
+        var native = Frame(0, 4_000) with
+        {
+            NativeNeedleAngleDegrees = 320,
+            NativeNeedleBlurAmount = -.4,
+            NativeGaugeObservedTimestamp = Timestamp(0)
+        };
+        playback.Observe(native, Timestamp(0));
+        var pending = new AnalogHudPendingFrame(playback.Sample(Timestamp(1)), Presentation(), Timestamp(0), 1);
+        var lastFresh = Timestamp(NativeNeedlePlayback.NativeSampleFreshnessMilliseconds);
+        var expired = lastFresh + 1;
+
+        Assert.True(pending.Sample.Native);
+        Assert.True(playback.HasNativeNeedle(lastFresh));
+        Assert.True(pending.CanReuse(pending.Presentation, native, playback.HasNativeNeedle(lastFresh)));
+        Assert.False(playback.HasNativeNeedle(expired));
+        Assert.False(pending.CanReuse(pending.Presentation, native, playback.HasNativeNeedle(expired)));
+    }
+
+    private static AnalogHudPendingFrame Pending()
+    {
+        var playback = new AnalogHudPlayback();
+        playback.Observe(Frame(0, 4_000), Timestamp(0));
+        return new(playback.Sample(Timestamp(1)), Presentation(), Timestamp(0), 1);
+    }
+
+    private static AnalogHudPresentation Presentation() => new(800, 600, 0, 0, 1, 0, 0, 1, 1,
+        true, false, new(85, 230, 193), AnalogHudLayout.Authored);
+
+    private static NativeGaugeFrame Frame(int milliseconds, double rpm) => new(
+        true, 100, rpm, 8_000, TransmissionGear.Neutral, SpeedUnit.MilesPerHour,
+        ExactRedlineResult.Exact(7_000 * 2 * Math.PI / 60), CarOrdinal: 314,
+        GameTimestampMilliseconds: (uint)(1_000 + milliseconds), ReceivedTimestamp: Timestamp(milliseconds));
+
+    private static long Timestamp(double milliseconds) =>
+        (long)Math.Round((1_000 + milliseconds) * Stopwatch.Frequency / 1_000d);
+}

--- a/tests/Wisp.App.Tests/AnalogHudPlaybackTests.cs
+++ b/tests/Wisp.App.Tests/AnalogHudPlaybackTests.cs
@@ -59,6 +59,139 @@ public sealed class AnalogHudPlaybackTests
         Assert.Equal(0, playback.Sample(Timestamp(400)).Blur);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void QueuedRpmFrameCrossingThePreviousSampleDoesNotReseedOrShiftItsSourceTime(bool hasReceivedTimestamp)
+    {
+        var playback = new AnalogHudPlayback();
+        for (int ms = 0; ms <= 40; ms += 10)
+            playback.Observe(Frame(ms, 1_000 + ms * 100), Timestamp(ms));
+        var before = playback.Sample(Timestamp(50));
+        var queued = Frame(49, 5_900) with { ReceivedTimestamp = hasReceivedTimestamp ? Timestamp(49) : null };
+
+        playback.ObserveQueued(queued, Timestamp(49), Timestamp(52));
+        var after = playback.Sample(Timestamp(52));
+
+        Assert.Equal(before.ReseedCount, after.ReseedCount);
+        Assert.Equal(before.StarvationReseedCount, after.StarvationReseedCount);
+        Assert.Equal(2_200, after.AppliedRpm!.Value, 6);
+        Assert.Equal(5_900, after.Frame.EngineRpm);
+        Assert.Equal(40, after.PlaybackTargetDelayMilliseconds, 6);
+        Assert.Equal(5_500, playback.Sample(Timestamp(85)).AppliedRpm!.Value, 6);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void QueuedNativePairCrossingThePreviousSampleRetainsBothOriginalChannels(bool hasNativeTimestamp)
+    {
+        var playback = new AnalogHudPlayback();
+        for (int ms = 0; ms <= 40; ms += 10)
+            playback.Observe(Frame(ms, 4_000) with
+            {
+                NativeNeedleAngleDegrees = 120 + ms,
+                NativeNeedleBlurAmount = -.2 + ms * .005
+            }, Timestamp(ms));
+        var before = playback.Sample(Timestamp(50));
+        var queued = Frame(49, 4_000) with
+        {
+            NativeNeedleAngleDegrees = 169,
+            NativeNeedleBlurAmount = .045,
+            NativeGaugeObservedTimestamp = hasNativeTimestamp ? Timestamp(49) : 0
+        };
+
+        playback.ObserveQueued(queued, Timestamp(49), Timestamp(52));
+        var after = playback.Sample(Timestamp(52));
+
+        Assert.True(after.Native);
+        Assert.Equal(before.ReseedCount, after.ReseedCount);
+        Assert.Equal(132, after.Angle, 6);
+        Assert.Equal(-.14, after.Blur, 6);
+        var later = playback.Sample(Timestamp(85));
+        Assert.True(later.Native);
+        Assert.Equal(165, later.Angle, 6);
+        Assert.Equal(.025, later.Blur, 6);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WaitingInTheQueueCannotRefreshAnExpiredNativePair(bool hasNativeTimestamp)
+    {
+        var playback = new AnalogHudPlayback();
+        var queued = Frame(0, 4_000) with
+        {
+            NativeNeedleAngleDegrees = 320,
+            NativeNeedleBlurAmount = -.4,
+            NativeGaugeObservedTimestamp = hasNativeTimestamp ? Timestamp(0) : 0
+        };
+
+        playback.ObserveQueued(queued, Timestamp(10), Timestamp(100));
+        var after = playback.Sample(Timestamp(100));
+
+        Assert.False(after.Native);
+        Assert.Equal(4_000, after.AppliedRpm);
+        Assert.Equal(240, after.Angle);
+        Assert.Equal(0, after.Blur);
+    }
+
+    [Fact]
+    public void OlderQueuedRpmCannotRetargetOrReseedPlayback()
+    {
+        var playback = new AnalogHudPlayback();
+        for (int ms = 0; ms <= 40; ms += 10)
+            playback.Observe(Frame(ms, 1_000 + ms * 100), Timestamp(ms));
+        var before = playback.Sample(Timestamp(50));
+
+        playback.ObserveQueued(Frame(20, 7_000), Timestamp(49), Timestamp(52));
+        var after = playback.Sample(Timestamp(52));
+
+        Assert.Equal(before.ReseedCount, after.ReseedCount);
+        Assert.Equal(2_200, after.AppliedRpm!.Value, 6);
+        Assert.Equal(5_000, playback.Sample(Timestamp(85)).AppliedRpm!.Value, 6);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ATrueConsumptionClockRewindStillReseedsTheSelectedSource(bool native)
+    {
+        var playback = new AnalogHudPlayback();
+        NativeGaugeFrame Source(int ms, double value) => native
+            ? Frame(ms, 4_000) with { NativeNeedleAngleDegrees = value, NativeNeedleBlurAmount = -.1 }
+            : Frame(ms, value);
+        playback.Observe(Source(0, native ? 150 : 1_000), Timestamp(0));
+        playback.Observe(Source(40, native ? 300 : 7_000), Timestamp(40));
+        var before = playback.Sample(Timestamp(50));
+
+        playback.ObserveQueued(Source(10, native ? 240 : 900), Timestamp(10), Timestamp(11));
+        var after = playback.Sample(Timestamp(11));
+
+        Assert.Equal(before.ReseedCount + 1, after.ReseedCount);
+        Assert.Equal(native, after.Native);
+        if (native) { Assert.Equal(240, after.Angle); Assert.Equal(-.1, after.Blur); }
+        else { Assert.Equal(900, after.AppliedRpm); Assert.Equal(0, after.Blur); }
+    }
+
+    [Fact]
+    public void QueuedCarChangeStillSnapsWithoutBlendingTheOldEngine()
+    {
+        var playback = new AnalogHudPlayback();
+        playback.Observe(Frame(0, 1_000), Timestamp(0));
+        playback.Observe(Frame(40, 7_000), Timestamp(40));
+        var before = playback.Sample(Timestamp(50));
+        var queued = Frame(49, 900) with { CarOrdinal = 3766 };
+
+        playback.ObserveQueued(queued, Timestamp(49), Timestamp(52));
+        var after = playback.Sample(Timestamp(52));
+
+        Assert.Equal(before.ReseedCount + 1, after.ReseedCount);
+        Assert.Equal(queued.CarOrdinal, after.Frame.CarOrdinal);
+        Assert.Equal(900, after.AppliedRpm);
+        Assert.Equal(0, after.Blur);
+    }
+
     [Fact]
     public void NativeAngleAndSignedBlurRemainTheExactPairedPlaybackChannels()
     {
@@ -74,6 +207,52 @@ public sealed class AnalogHudPlaybackTests
         Assert.Equal(.10, sample.Blur, 6);
         Assert.Equal(5_000, sample.Frame.EngineRpm);
         Assert.Equal(40, sample.PlaybackTargetDelayMilliseconds, 6);
+    }
+
+    [Fact]
+    public void NativeAvailabilityChecksDoNotAdvanceOrResetEitherPlaybackChannel()
+    {
+        var actual = new AnalogHudPlayback();
+        var reference = new AnalogHudPlayback();
+        foreach (var playback in new[] { actual, reference })
+        {
+            playback.Observe(Frame(0, 1_000) with { NativeNeedleAngleDegrees = 120, NativeNeedleBlurAmount = -.2 }, Timestamp(0));
+            playback.Observe(Frame(20, 5_000) with { NativeNeedleAngleDegrees = 240, NativeNeedleBlurAmount = .4 }, Timestamp(20));
+            Assert.True(playback.Sample(Timestamp(50)).Native);
+        }
+
+        Assert.True(actual.HasNativeNeedle(Timestamp(60)));
+        Assert.False(actual.HasNativeNeedle(Timestamp(200)));
+        Assert.True(actual.HasNativeNeedle(Timestamp(50)));
+
+        var afterChecks = actual.Sample(Timestamp(55));
+        Assert.Equal(reference.Sample(Timestamp(55)), afterChecks);
+        Assert.Equal(210, afterChecks.Angle, 6);
+        Assert.Equal(.25, afterChecks.Blur, 6);
+    }
+
+    [Fact]
+    public void NativeAvailabilityUsesExactObservationAgeAndRejectsFallbackAndResetState()
+    {
+        var playback = new AnalogHudPlayback();
+        Assert.False(playback.HasNativeNeedle(Timestamp(0)));
+        playback.Observe(Frame(0, 4_000), Timestamp(0));
+        Assert.False(playback.HasNativeNeedle(Timestamp(1)));
+        playback.Observe(Frame(20, 4_000) with
+        {
+            NativeNeedleAngleDegrees = 240,
+            NativeNeedleBlurAmount = -.1
+        }, Timestamp(20));
+        var observedAt = Timestamp(20);
+        var lastFresh = Timestamp(20 + NativeNeedlePlayback.NativeSampleFreshnessMilliseconds);
+
+        Assert.False(playback.HasNativeNeedle(observedAt - 1));
+        Assert.True(playback.HasNativeNeedle(observedAt));
+        Assert.True(playback.HasNativeNeedle(lastFresh));
+        Assert.False(playback.HasNativeNeedle(lastFresh + 1));
+        Assert.True(playback.HasNativeNeedle(observedAt));
+        playback.Reset();
+        Assert.False(playback.HasNativeNeedle(observedAt));
     }
 
     [Fact]

--- a/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
+++ b/tests/Wisp.App.Tests/ApplicationVersionInfoTests.cs
@@ -21,12 +21,12 @@ public sealed class ApplicationVersionInfoTests
     [Fact]
     public void CurrentVersionLabelsShareTheAssemblyVersion()
     {
-        Assert.Equal("1.2.0", ApplicationVersionInfo.MachineVersion);
-        Assert.Equal("1.2", ApplicationVersionInfo.DisplayVersion);
+        Assert.Equal("1.2.1", ApplicationVersionInfo.MachineVersion);
+        Assert.Equal("1.2.1", ApplicationVersionInfo.DisplayVersion);
         Assert.Null(ApplicationVersionInfo.DiagnosticBuildId);
         Assert.Null(ApplicationVersionInfo.DiagnosticBuildLabel);
-        Assert.EndsWith("PANEL 1.2", ApplicationVersionInfo.FooterText);
-        Assert.Contains("The current 1.2 entry covers this release.", ApplicationVersionInfo.ReleaseHistoryIntroduction);
+        Assert.EndsWith("PANEL 1.2.1", ApplicationVersionInfo.FooterText);
+        Assert.Contains("The current 1.2.1 entry covers this release.", ApplicationVersionInfo.ReleaseHistoryIntroduction);
         Assert.Equal(ApplicationVersionInfo.DisplayVersion, ReleaseNotesCatalog.Entries[0].Version);
     }
 }

--- a/tests/Wisp.App.Tests/CpuRenderingSettingsTests.cs
+++ b/tests/Wisp.App.Tests/CpuRenderingSettingsTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using Wisp.App;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class CpuRenderingSettingsTests
+{
+    [Fact]
+    public void ExistingSettingsDefaultToGpuWithoutChangingLayout()
+    {
+        var settings = JsonSerializer.Deserialize<AppSettings>("{\"SettingsRevision\":9,\"OverlayOpacity\":0.7,\"NativeGaugeMode\":1}")!;
+        settings.MigrateSettings();
+        Assert.False(settings.CpuRenderingEnabled);
+        Assert.Equal(0.7, settings.OverlayOpacity);
+        Assert.Equal(NativeGaugeMode.Analogue, settings.NativeGaugeMode);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void RendererSelectionRoundTripsAndOnlyAppliesAfterRestart(bool activeCpu)
+    {
+        var settings = new AppSettings { CpuRenderingEnabled = activeCpu };
+        var viewModel = new DiagnosticsViewModel(settings);
+        viewModel.UpdateCpuRendering(!activeCpu, saved: true);
+        Assert.Equal(activeCpu, viewModel.ActiveCpuRendering);
+        Assert.Equal(!activeCpu, viewModel.CpuRenderingEnabled);
+        Assert.Contains("Restart Wisp", viewModel.CpuRenderingChangeStatus);
+        settings.CpuRenderingEnabled = !activeCpu;
+        var restored = JsonSerializer.Deserialize<AppSettings>(JsonSerializer.Serialize(settings))!;
+        restored.MigrateSettings();
+        var restarted = new DiagnosticsViewModel(restored);
+        Assert.Equal(!activeCpu, restarted.ActiveCpuRendering);
+        Assert.Empty(restarted.CpuRenderingChangeStatus);
+        viewModel.UpdateCpuRendering(activeCpu, saved: true);
+        Assert.Empty(viewModel.CpuRenderingChangeStatus);
+    }
+    internal static void AssertControllerPersistenceOnCurrentDispatcher()
+    {
+        var settings = new AppSettings
+        {
+            StartWithWindows = false,
+            AutomaticApplicationUpdateChecks = false,
+            SetupCompletion = new SetupCompletionRecord
+            {
+                Version = SetupCompletionRecord.CurrentVersion,
+                CompletedAtUtc = DateTimeOffset.UtcNow,
+                ValidatedUdpPort = 5500,
+                ValidatedPackets = SetupCompletionRecord.MinimumPackets,
+                MovingPackets = SetupCompletionRecord.MinimumMovingPackets,
+                ValidatedElapsedMilliseconds = SetupCompletionRecord.MinimumElapsedMilliseconds,
+                DataOutConfirmed = true, DisplayModeConfirmed = true, StockHudConfirmed = true
+            }
+        };
+        bool failSave = false;
+        bool? savedCpu = null;
+        var controller = new AppController(settings, value =>
+        {
+            if (failSave) throw new System.IO.IOException("Test storage unavailable");
+            savedCpu = value.CpuRenderingEnabled;
+        }, new NoStartupRegistration());
+        try
+        {
+            controller.SetCpuRenderingEnabled(true);
+            Assert.True(savedCpu);
+            Assert.True(settings.CpuRenderingEnabled);
+            Assert.True(controller.ViewModel.CpuRenderingEnabled);
+            Assert.False(controller.ViewModel.ActiveCpuRendering);
+            failSave = true;
+            controller.SetCpuRenderingEnabled(false);
+            Assert.True(settings.CpuRenderingEnabled);
+            Assert.True(controller.ViewModel.CpuRenderingEnabled);
+            Assert.Contains("Could not save", controller.ViewModel.CpuRenderingChangeStatus);
+            failSave = false;
+            controller.SetCpuRenderingEnabled(false);
+            Assert.False(savedCpu);
+            Assert.Empty(controller.ViewModel.CpuRenderingChangeStatus);
+        }
+        finally { controller.DisposeAsync().AsTask().GetAwaiter().GetResult(); }
+    }
+
+    private sealed class NoStartupRegistration : IStartupRegistrationService
+    {
+        public void Apply(bool startWithWindows, bool startWithForza) { }
+    }
+}

--- a/tests/Wisp.App.Tests/CpuRenderingSettingsTests.cs
+++ b/tests/Wisp.App.Tests/CpuRenderingSettingsTests.cs
@@ -50,7 +50,9 @@ public sealed class CpuRenderingSettingsTests
                 ValidatedPackets = SetupCompletionRecord.MinimumPackets,
                 MovingPackets = SetupCompletionRecord.MinimumMovingPackets,
                 ValidatedElapsedMilliseconds = SetupCompletionRecord.MinimumElapsedMilliseconds,
-                DataOutConfirmed = true, DisplayModeConfirmed = true, StockHudConfirmed = true
+                DataOutConfirmed = true,
+                DisplayModeConfirmed = true,
+                StockHudConfirmed = true
             }
         };
         bool failSave = false;

--- a/tests/Wisp.App.Tests/DirectCompositionWaitMetricsTests.cs
+++ b/tests/Wisp.App.Tests/DirectCompositionWaitMetricsTests.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Wisp.App.NativeRendering;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+public sealed class DirectCompositionWaitMetricsTests
+{
+    [Fact]
+    public void LayoutMatchesNativeWaitMetrics()
+    {
+        Assert.Equal(48, Marshal.SizeOf<DirectCompositionWaitMetrics>());
+        Assert.Equal(32, Marshal.OffsetOf<DirectCompositionWaitMetrics>(nameof(DirectCompositionWaitMetrics.CpuTime100ns)).ToInt32());
+        Assert.Equal(40, Marshal.OffsetOf<DirectCompositionWaitMetrics>(nameof(DirectCompositionWaitMetrics.SwapChainGeneration)).ToInt32());
+        Assert.Equal(44, Marshal.OffsetOf<DirectCompositionWaitMetrics>(nameof(DirectCompositionWaitMetrics.WaitResult)).ToInt32());
+    }
+
+    [Fact]
+    public void ThreadAccountingConvertsToDiagnosticClockAndPreservesUnavailable()
+    {
+        var metrics = new DirectCompositionWaitMetrics { CpuTime100ns = TimeSpan.TicksPerSecond };
+        Assert.Equal(Stopwatch.Frequency, metrics.CpuThreadStopwatchTicks);
+        metrics.CpuTime100ns = 0;
+        Assert.Equal(0, metrics.CpuThreadStopwatchTicks);
+        metrics.CpuTime100ns = -1;
+        Assert.Null(metrics.CpuThreadStopwatchTicks);
+    }
+}

--- a/tests/Wisp.App.Tests/InstallerPackagingContractTests.cs
+++ b/tests/Wisp.App.Tests/InstallerPackagingContractTests.cs
@@ -257,7 +257,7 @@ public sealed class InstallerPackagingContractTests
         Assert.Contains("$artifactVersion = $projectVersion", packaging, StringComparison.Ordinal);
         Assert.Contains("& $innoExecutable \"/O$stageDirectory\" $innoScript", packaging, StringComparison.Ordinal);
         Assert.Contains("Write-BuildProvenance $repository $publishFullPath", packaging, StringComparison.Ordinal);
-        Assert.Contains("#define MyAppVersion \"1.2.0\"", inno, StringComparison.Ordinal);
+        Assert.Contains("#define MyAppVersion \"1.2.1\"", inno, StringComparison.Ordinal);
         Assert.Contains("#define MyAppOutputVersion MyAppVersion", inno, StringComparison.Ordinal);
         Assert.Contains("UpdatingExistingInstallation := UpdateSwitchPresent() and ExistingInstallationPresent();", inno,
             StringComparison.Ordinal);

--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -159,6 +159,21 @@ internal static class NativeRendererIntegrationTests
                         .DistinctBy(row => (row.ControlId, row.AppliedTimestamp)).ToArray();
                     return fresh.Length >= 4 && fresh.Select(row => row.ReceivedTimestamp).Distinct().Count() >= 2;
                 }, 2000);
+                var renderer = TachDiagnostics.Snapshot()!.RendererRecent
+                    .Where(row => row.HostWindowHandle == hwnd.ToInt64() && row.StartedTimestamp >= started)
+                    .ToArray();
+                var presented = renderer.Where(row => row.Stage == "present" && row.Result == "submitted").ToArray();
+                Assert.NotEmpty(presented);
+                Assert.All(presented, row =>
+                {
+                    Assert.True(row.SampleTimestamp is > 0 && row.SampleTimestamp <= row.StartedTimestamp);
+                    Assert.True(row.QueuedTimestamp is > 0 && row.QueuedTimestamp <= row.SampleTimestamp);
+                    Assert.Equal(0, row.HResult);
+                });
+                Assert.Contains(renderer, row => row.Stage == "draw" && row.Result == "ready" &&
+                    row.DrawCommands > 0 && row.MapCount == row.DrawCommands &&
+                    row.NativeDrawTicks > 0 && row.NativeDrawTicks >= row.MapTicks &&
+                    row.CompletedTimestamp >= row.StartedTimestamp + row.NativeDrawTicks);
             }
             else
             {

--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -13,10 +13,10 @@ namespace Wisp.App.Tests;
 
 internal static class NativeRendererIntegrationTests
 {
-    internal static void AssertOnCurrentDispatcher()
+    internal static void AssertOnCurrentDispatcher(bool cpuRendering = false)
     {
-        var hardwareAvailable = ProbeHardwareSupport();
-        var expectedStatus = hardwareAvailable
+        var hardwareAvailable = cpuRendering || ProbeHardwareSupport();
+        var expectedStatus = cpuRendering ? "Analogue renderer: CPU (WARP) / DirectComposition" : hardwareAvailable
             ? "Analogue renderer: Direct3D 11 / DirectComposition"
             : "Analogue renderer: WPF fallback (0x887A0004)";
         var expectedContentVisibility = hardwareAvailable ? Visibility.Hidden : Visibility.Visible;
@@ -26,6 +26,7 @@ internal static class NativeRendererIntegrationTests
             StartWithForza = false,
             AutomaticApplicationUpdateChecks = false,
             DebugLoggingEnabled = false,
+            CpuRenderingEnabled = cpuRendering,
             LayoutMode = HudLayoutMode.Native,
             NativeGaugeMode = NativeGaugeMode.Analogue,
             OverlayOpacity = 1,
@@ -168,6 +169,7 @@ internal static class NativeRendererIntegrationTests
                 var presented = renderer.Where(row => row.Stage == "present" && row.Result == "submitted").ToArray();
                 Assert.NotEmpty(presented);
                 Assert.All(renderer, row => Assert.True(row.NativeThreadId is > 0));
+                Assert.All(renderer, row => Assert.Equal(controller.ViewModel.ActiveCpuRendering, row.CpuRendering));
                 Assert.All(presented, row =>
                 {
                     Assert.True(row.SampleTimestamp is > 0 && row.SampleTimestamp <= row.StartedTimestamp);

--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -41,8 +41,11 @@ internal static class NativeRendererIntegrationTests
         {
             window = new OverlayWindow(controller)
             {
-                Left = SystemParameters.VirtualScreenLeft - 2000,
-                Top = SystemParameters.VirtualScreenTop - 2000
+                // Successful Present requires an unoccluded surface. An off-screen
+                // HWND can initialize D3D successfully but never submit a frame.
+                Left = SystemParameters.WorkArea.Left + 20,
+                Top = SystemParameters.WorkArea.Top + 20,
+                Topmost = true
             };
             var panel = Assert.IsType<Grid>(window.FindName("NativeAnalogPanel"));
             var gauge = Assert.IsType<NativeAnalogSpeedometer>(Assert.Single(panel.Children.Cast<UIElement>()));
@@ -164,6 +167,7 @@ internal static class NativeRendererIntegrationTests
                     .ToArray();
                 var presented = renderer.Where(row => row.Stage == "present" && row.Result == "submitted").ToArray();
                 Assert.NotEmpty(presented);
+                Assert.All(renderer, row => Assert.True(row.NativeThreadId is > 0));
                 Assert.All(presented, row =>
                 {
                     Assert.True(row.SampleTimestamp is > 0 && row.SampleTimestamp <= row.StartedTimestamp);
@@ -174,6 +178,18 @@ internal static class NativeRendererIntegrationTests
                     row.DrawCommands > 0 && row.MapCount == row.DrawCommands &&
                     row.NativeDrawTicks > 0 && row.NativeDrawTicks >= row.MapTicks &&
                     row.CompletedTimestamp >= row.StartedTimestamp + row.NativeDrawTicks);
+                Assert.Contains(renderer, row => row.Stage == "frame_wait" && row.Result == "ready" &&
+                    row.NativeWaitTicks is > 0 && row.WaitPrecheckTicks is >= 0 &&
+                    row.WaitCallTicks is >= 0 && row.WaitPostcheckTicks is >= 0 &&
+                    row.SwapChainGeneration is > 0 && row.WaitReturnCode == 1 &&
+                    row.NativeWaitTicks >= row.WaitPrecheckTicks + row.WaitCallTicks + row.WaitPostcheckTicks &&
+                    row.CompletedTimestamp >= row.StartedTimestamp + row.NativeWaitTicks);
+                Assert.All(renderer.Where(row => row.Stage != "frame_wait"), row =>
+                {
+                    Assert.Null(row.NativeWaitTicks);
+                    Assert.Null(row.WaitCallTicks);
+                    Assert.Null(row.CpuThreadTicks);
+                });
             }
             else
             {
@@ -237,7 +253,11 @@ internal static class NativeRendererIntegrationTests
             Pump();
             Thread.Sleep(10);
         }
-        Assert.True(predicate(), "Native renderer did not reach the expected bounded lifecycle state.");
+        var reached = predicate();
+        var evidence = reached ? string.Empty : string.Join(", ",
+            TachDiagnostics.Snapshot()?.RendererRecent.TakeLast(24).Select(row =>
+                $"{row.Stage}/{row.Result}:hr=0x{row.HResult:X8},wait={row.WaitReturnCode},generation={row.SwapChainGeneration}") ?? []);
+        Assert.True(reached, "Native renderer did not reach the expected bounded lifecycle state. " + evidence);
     }
 
     private static void Pump() => Dispatcher.CurrentDispatcher.Invoke(() => { }, DispatcherPriority.ContextIdle);

--- a/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
+++ b/tests/Wisp.App.Tests/ReleaseNotesCatalogTests.cs
@@ -8,7 +8,7 @@ public sealed class ReleaseNotesCatalogTests
     public void CatalogCoversEveryDocumentedPostLaunchVersionInDescendingOrder()
     {
         Assert.Equal(
-            ["1.2", "1.1.4", "1.1.3", "1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
+            ["1.2.1", "1.2", "1.1.4", "1.1.3", "1.1.2", "1.1.1", "1.1", "1.0.12", "1.0.11", "1.0.10", "1.0.8", "1.0.7", "1.0.6", "1.0.5", "1.0.4", "1.0.3", "1.0.2", "1.0.1"],
             ReleaseNotesCatalog.Entries.Select(entry => entry.Version));
         Assert.True(ReleaseNotesCatalog.Entries[0].IsCurrent);
         Assert.All(ReleaseNotesCatalog.Entries.Skip(1), entry => Assert.False(entry.IsCurrent));

--- a/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
+++ b/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
@@ -85,7 +85,7 @@ public sealed class TachDiagnosticExportTests
             Assert.True(manifest.RootElement.GetProperty("raw_lost_after_process_restart").GetBoolean());
             Assert.False(manifest.RootElement.GetProperty("gpu_presentation_measured").GetBoolean());
             Assert.False(manifest.RootElement.GetProperty("physical_display_measured").GetBoolean());
-            Assert.Equal(1, manifest.RootElement.GetProperty("renderer_schema_version").GetInt32());
+            Assert.Equal(2, manifest.RootElement.GetProperty("renderer_schema_version").GetInt32());
             Assert.Equal(5, manifest.RootElement.GetProperty("renderer").GetProperty("recent_overwritten").GetInt64());
             Assert.Equal(1, manifest.RootElement.GetProperty("renderer").GetProperty("startup_recent_duplicate_records").GetInt32());
             Assert.Contains("not displayed", manifest.RootElement.GetProperty("renderer_policy").GetString());
@@ -200,6 +200,143 @@ public sealed class TachDiagnosticExportTests
         var report = TachDiagnosticReport.Build([safe], null);
         Assert.Contains("Older builds did not record these timings", report);
         Assert.DoesNotContain("Present attempts submitted", report);
+    }
+
+    [Fact]
+    public async Task WaitDetailsSurviveRawAndPersistedArchivePaths()
+    {
+        var root = TemporaryDirectory();
+        try
+        {
+            var wait = RendererEvent() with
+            {
+                Stage = "frame_wait", Result = "ready", HResult = 0, NativeThreadId = 120,
+                NativeWaitTicks = 18, WaitPrecheckTicks = 1, WaitCallTicks = 16,
+                WaitPostcheckTicks = 0, CpuThreadTicks = 5, SwapChainGeneration = 1, WaitReturnCode = 1
+            };
+            var replacement = wait with { Sequence = 2, SwapChainGeneration = 2, CpuThreadTicks = null };
+            var capture = Capture() with { RendererStartup = [wait], RendererRecent = [wait, replacement] };
+            var counts = RendererCounts() with
+            {
+                Stage = "frame_wait", Result = "ready", TotalNativePresentMilliseconds = 0, NativeThreadId = 120,
+                NativeWaitSamples = 2, TotalNativeWaitMilliseconds = 36,
+                WaitPrecheckSamples = 2, TotalWaitPrecheckMilliseconds = 2,
+                WaitCallSamples = 2, TotalWaitCallMilliseconds = 32, MaximumWaitCallMilliseconds = 16,
+                WaitPostcheckSamples = 2, TotalWaitPostcheckMilliseconds = 0,
+                CpuThreadSamples = 1, TotalCpuThreadMilliseconds = 5,
+                SwapChainGenerationSamples = 2, MinimumSwapChainGeneration = 1, MaximumSwapChainGeneration = 2,
+                WaitReturnCode = 1
+            };
+            var interval = Interval(CurrentCaptureId, Now, 10) with { Renderer = [counts] };
+            var logs = Path.Combine(root, "logs");
+            await using (var service = new DebugLogService(logs, () => Now, tachSnapshot: () => capture))
+            {
+                Assert.True(service.TryEnable(Now + DebugLogService.EnableDuration));
+                service.TryLogTachInterval(interval);
+                var path = Path.Combine(root, "live.zip");
+                Assert.True(await service.ExportAsync(path, ApplicationVersionInfo.MachineVersion));
+                using var archive = ZipFile.OpenRead(path);
+                var raw = Read(archive, "tach-renderer-recent.ndjson").Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(value => JsonSerializer.Deserialize<TachRendererDiagnostic>(value, JsonOptions)).ToArray();
+                Assert.Equal(new[] { wait, replacement }, raw);
+                Assert.Equal(wait, JsonSerializer.Deserialize<TachRendererDiagnostic>(Read(archive, "tach-renderer-startup.ndjson"), JsonOptions));
+                Assert.Equal(counts, Assert.Single(JsonSerializer.Deserialize<TachIntervalDiagnostic>(Read(archive, "tach-intervals.ndjson"), JsonOptions)!.Renderer));
+                using var manifest = JsonDocument.Parse(Read(archive, "tach-manifest.json"));
+                Assert.Equal(2, manifest.RootElement.GetProperty("renderer_schema_version").GetInt32());
+                var policy = manifest.RootElement.GetProperty("renderer_policy").GetString()!;
+                Assert.Contains("full managed wrapper", policy);
+                Assert.Contains("coarse GetThreadTimes CPU accounting", policy);
+                Assert.Contains("error before the wait was reached", policy);
+                Assert.Contains("Missing split fields mean unavailable", policy);
+                var report = Read(archive, "tach-report.txt");
+                Assert.Contains("Native wait total: 36 ms (2 observations)", report);
+                Assert.Contains("wait call: 32 ms (2 observations)", report);
+                Assert.Contains("postcheck: 0 ms (2 observations)", report);
+                Assert.Contains("Maximum wait call: 16 ms", report);
+                Assert.Contains("Win32 wait outcome: 0x00000001", report);
+                Assert.Contains("Native render thread: 120", report);
+                Assert.Contains("swap-chain generation range: 1-2 (2 observations)", report);
+                Assert.Contains("Coarse thread CPU accounting: 5 ms (1 observations)", report);
+            }
+
+            await using var restarted = new DebugLogService(logs, () => Now, tachSnapshot: () => null);
+            var restartedPath = Path.Combine(root, "restarted.zip");
+            Assert.True(await restarted.ExportAsync(restartedPath, ApplicationVersionInfo.MachineVersion));
+            using var persisted = ZipFile.OpenRead(restartedPath);
+            Assert.Null(persisted.GetEntry("tach-renderer-recent.ndjson"));
+            Assert.Equal(counts, Assert.Single(JsonSerializer.Deserialize<TachIntervalDiagnostic>(Read(persisted, "tach-intervals.ndjson"), JsonOptions)!.Renderer));
+            Assert.Contains("Native wait total: 36 ms (2 observations)", Read(persisted, "tach-report.txt"));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void OlderRendererTimingsDoNotImplyZeroNativeWaitOrThreadCpuWork()
+    {
+        var json = $$"""
+            {"timestamp_utc":"2026-09-08T12:00:00Z","capture_id":"{{CurrentCaptureId}}","timestamp":1000,"interval_milliseconds":1000,"native_reads":[],"needles":[],"renderer":[{"control_id":1,"stage":"frame_wait","result":"ready","count":2,"mean_milliseconds":20,"maximum_milliseconds":40}]}
+            """;
+        var interval = JsonSerializer.Deserialize<TachIntervalDiagnostic>(json, JsonOptions)!;
+        var safe = Assert.IsType<TachIntervalDiagnostic>(TachDiagnosticReport.SanitizeInterval(interval));
+        var counts = Assert.Single(safe.Renderer);
+        Assert.Equal(0, counts.NativeWaitSamples);
+        Assert.Null(counts.TotalNativeWaitMilliseconds);
+        Assert.Null(counts.TotalWaitPrecheckMilliseconds);
+        Assert.Null(counts.TotalWaitCallMilliseconds);
+        Assert.Null(counts.MaximumWaitCallMilliseconds);
+        Assert.Null(counts.TotalWaitPostcheckMilliseconds);
+        Assert.Null(counts.MinimumSwapChainGeneration);
+        Assert.Null(counts.WaitReturnCode);
+        Assert.Null(counts.NativeThreadId);
+        var report = TachDiagnosticReport.Build([safe], null);
+        Assert.Contains("Native wait total: unavailable (0 observations)", report);
+        Assert.Contains("Maximum wait call: unavailable", report);
+        Assert.Contains("Coarse thread CPU accounting: unavailable (0 observations)", report);
+        var raw = JsonSerializer.Deserialize<TachRendererDiagnostic>("""{"stage":"frame_wait","result":"ready","started_timestamp":100,"completed_timestamp":120}""", JsonOptions);
+        Assert.Null(raw.NativeWaitTicks);
+        Assert.Null(raw.WaitPrecheckTicks);
+        Assert.Null(raw.WaitCallTicks);
+        Assert.Null(raw.WaitPostcheckTicks);
+        Assert.Null(raw.CpuThreadTicks);
+        Assert.Null(raw.SwapChainGeneration);
+        Assert.Null(raw.WaitReturnCode);
+        Assert.Null(raw.NativeThreadId);
+    }
+
+    [Fact]
+    public void InvalidPersistedWaitCoverageAndDurationsAreRejected()
+    {
+        var valid = RendererCounts() with
+        {
+            NativeWaitSamples = 1, TotalNativeWaitMilliseconds = 10,
+            WaitPrecheckSamples = 1, TotalWaitPrecheckMilliseconds = 1,
+            WaitCallSamples = 1, TotalWaitCallMilliseconds = 8, MaximumWaitCallMilliseconds = 8,
+            WaitPostcheckSamples = 1, TotalWaitPostcheckMilliseconds = 0,
+            SwapChainGenerationSamples = 1, MinimumSwapChainGeneration = 1, MaximumSwapChainGeneration = 2
+        };
+        var interval = Interval(CurrentCaptureId, Now, 1) with { Renderer = [valid] };
+        Assert.NotNull(TachDiagnosticReport.SanitizeInterval(interval));
+        foreach (var invalid in new[]
+        {
+            valid with { NativeWaitSamples = -1 },
+            valid with { NativeWaitSamples = 3 },
+            valid with { NativeWaitSamples = 0 },
+            valid with { TotalNativeWaitMilliseconds = -1 },
+            valid with { TotalNativeWaitMilliseconds = null },
+            valid with { TotalWaitPrecheckMilliseconds = double.NaN },
+            valid with { TotalWaitCallMilliseconds = double.PositiveInfinity },
+            valid with { MaximumWaitCallMilliseconds = 9 },
+            valid with { MaximumWaitCallMilliseconds = null },
+            valid with { TotalWaitPostcheckMilliseconds = -1 },
+            valid with { SwapChainGenerationSamples = -1 },
+            valid with { SwapChainGenerationSamples = 3 },
+            valid with { SwapChainGenerationSamples = 0 },
+            valid with { MinimumSwapChainGeneration = 0 },
+            valid with { MinimumSwapChainGeneration = null },
+            valid with { MinimumSwapChainGeneration = 3 },
+            valid with { MaximumSwapChainGeneration = null }
+        })
+            Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { Renderer = [invalid] }));
     }
 
     [Fact]

--- a/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
+++ b/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
@@ -49,6 +49,9 @@ public sealed class TachDiagnosticExportTests
                 InputRecent = [input, input with { Timestamp = 200, Sequence = 2 }],
                 InputOverwritten = 4,
                 NeedleStartup = [needle],
+                RendererStartup = [RendererEvent()],
+                RendererRecent = [RendererEvent(), RendererEvent() with { Sequence = 2, Result = "submitted" }],
+                RendererOverwritten = 5,
                 NativeContexts = [new TachNativeContext(100, "fh6-steam-test", 1, "6.440.853.0", 1, 4, false, true)]
             };
             await using var service = new DebugLogService(logs, () => Now, tachSnapshot: () => capture);
@@ -59,21 +62,33 @@ public sealed class TachDiagnosticExportTests
             Assert.True(await service.ExportAsync(destination, ApplicationVersionInfo.MachineVersion));
 
             using var archive = ZipFile.OpenRead(destination);
-            Assert.Equal(16, archive.Entries.Count);
+            Assert.Equal(18, archive.Entries.Count);
             var report = Read(archive, "tach-report.txt");
             Assert.Contains(CurrentCaptureId, report);
             Assert.DoesNotContain("177777", report);
             Assert.Contains("Selected persisted intervals: 1", report);
             Assert.Contains("physical display are not measured", report);
             Assert.Contains("validated angle changes", report);
+            Assert.Contains("Present attempts submitted/busy/occluded/error: 0/2/0/0", report);
+            Assert.Contains("Longest observed renderer operation: present/busy, 20 ms", report);
+            Assert.Contains("not why the operation waited", report);
             Assert.Equal(2, Read(archive, "tach-intervals.ndjson").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
             Assert.Equal(2, Read(archive, "tach-input-recent.ndjson").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
             Assert.Contains("fh6-steam-test", Read(archive, "tach-native-context.ndjson"));
+            Assert.Equal(2, Read(archive, "tach-renderer-recent.ndjson").Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
+            using var renderer = JsonDocument.Parse(Read(archive, "tach-renderer-startup.ndjson"));
+            Assert.Equal("busy", renderer.RootElement.GetProperty("result").GetString());
+            Assert.Equal(25, renderer.RootElement.GetProperty("queued_timestamp").GetInt64());
+            Assert.Equal(-123, renderer.RootElement.GetProperty("h_result").GetInt32());
             using var manifest = JsonDocument.Parse(Read(archive, "tach-manifest.json"));
             Assert.Equal(CurrentCaptureId, manifest.RootElement.GetProperty("selected_capture_id").GetString());
             Assert.True(manifest.RootElement.GetProperty("raw_lost_after_process_restart").GetBoolean());
             Assert.False(manifest.RootElement.GetProperty("gpu_presentation_measured").GetBoolean());
             Assert.False(manifest.RootElement.GetProperty("physical_display_measured").GetBoolean());
+            Assert.Equal(1, manifest.RootElement.GetProperty("renderer_schema_version").GetInt32());
+            Assert.Equal(5, manifest.RootElement.GetProperty("renderer").GetProperty("recent_overwritten").GetInt64());
+            Assert.Equal(1, manifest.RootElement.GetProperty("renderer").GetProperty("startup_recent_duplicate_records").GetInt32());
+            Assert.Contains("not displayed", manifest.RootElement.GetProperty("renderer_policy").GetString());
             var routePolicy = manifest.RootElement.GetProperty("needle_route_policy").GetString()!;
             Assert.Contains("WPF transform application", routePolicy);
             Assert.Contains("successful Present submissions only, excluding queue-busy and occluded attempts", routePolicy);
@@ -107,10 +122,12 @@ public sealed class TachDiagnosticExportTests
             using var archive = ZipFile.OpenRead(destination);
             Assert.Equal(8, archive.Entries.Count);
             Assert.Null(archive.GetEntry("tach-input-recent.ndjson"));
+            Assert.Null(archive.GetEntry("tach-renderer-recent.ndjson"));
             var report = Read(archive, "tach-report.txt");
             Assert.Contains(CurrentCaptureId, report);
             Assert.Contains("Raw histories are unavailable", report);
             Assert.DoesNotContain("177777", report);
+            Assert.Contains("Present attempts submitted/busy/occluded/error: 0/2/0/0", report);
             using var manifest = JsonDocument.Parse(Read(archive, "tach-manifest.json"));
             Assert.False(manifest.RootElement.GetProperty("raw_capture_available").GetBoolean());
             Assert.Equal(JsonValueKind.Null, manifest.RootElement.GetProperty("stopwatch_frequency").ValueKind);
@@ -158,13 +175,31 @@ public sealed class TachDiagnosticExportTests
         {
             NativeReads = [new TachNativeCounts("private-sentinel", "private-sentinel", "private-sentinel", "private-sentinel", 1, 1, 1)],
             Needles = [new TachNeedleCounts(1, "private-sentinel", "private-sentinel", 123, 1, 1, 1, 0, 0,
-                0, 0, 1, 1, 1, 1, 0, 0)]
+                0, 0, 1, 1, 1, 1, 0, 0)],
+            Renderer = [RendererCounts() with { Stage = "private-sentinel", Result = "private-sentinel" }]
         };
         var sanitized = Assert.IsType<TachIntervalDiagnostic>(TachDiagnosticReport.SanitizeInterval(interval));
         Assert.DoesNotContain("private-sentinel", JsonSerializer.Serialize(sanitized, JsonOptions));
         Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { CaptureId = string.Empty }));
         Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { NativeReads = null! }));
         Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { IntervalMilliseconds = double.NaN }));
+        Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { Renderer = null! }));
+        Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { Renderer = [RendererCounts() with { MeanMilliseconds = double.NaN }] }));
+        Assert.Null(TachDiagnosticReport.SanitizeInterval(interval with { Renderer = new TachRendererCounts[TachDiagnostics.RendererAggregateCapacity + 1] }));
+    }
+
+    [Fact]
+    public void OlderPersistedIntervalsWithoutRendererFieldsRemainReadable()
+    {
+        var json = $$"""
+            {"timestamp_utc":"2026-09-08T12:00:00Z","capture_id":"{{CurrentCaptureId}}","timestamp":1000,"interval_milliseconds":1000,"native_reads":[],"needles":[]}
+            """;
+        var interval = JsonSerializer.Deserialize<TachIntervalDiagnostic>(json, JsonOptions)!;
+        var safe = Assert.IsType<TachIntervalDiagnostic>(TachDiagnosticReport.SanitizeInterval(interval));
+        Assert.Empty(safe.Renderer);
+        var report = TachDiagnosticReport.Build([safe], null);
+        Assert.Contains("Older builds did not record these timings", report);
+        Assert.DoesNotContain("Present attempts submitted", report);
     }
 
     [Fact]
@@ -286,7 +321,26 @@ public sealed class TachDiagnosticExportTests
 
     private static TachIntervalDiagnostic Interval(string captureId, DateTimeOffset now, long accepted) => new(
         now, captureId, 1000, 1000, accepted, 0, accepted, 0, 10, 5, 20, 1, 2, 3, 1, 0, 8,
-        [new TachNativeCounts("Angle", "None", "Hit", "refresh", 100, 0.1, 0.2) { Changed = 10 }], []);
+        [new TachNativeCounts("Angle", "None", "Hit", "refresh", 100, 0.1, 0.2) { Changed = 10 }], [])
+    { Renderer = [RendererCounts()] };
+
+    private static TachRendererDiagnostic RendererEvent() => new()
+    {
+        ControlId = 1,
+        HostWindowHandle = 123,
+        Sequence = 1,
+        Stage = "present",
+        Result = "busy",
+        StartedTimestamp = 100,
+        CompletedTimestamp = 120,
+        SampleTimestamp = 50,
+        ReceivedTimestamp = 20,
+        QueuedTimestamp = 25,
+        HResult = -123
+    };
+
+    private static TachRendererCounts RendererCounts() => new(1, 123, "present", "busy", 2,
+        10, 20, 0, 0, 0, 0, 0, 0, 0, 20, 0, 2, 75, 80, 2, 80, 90, 2, 50, 60, 0, 0);
 
     private static TachCaptureExport Capture() => new(CurrentCaptureId, Now, 1, 2000, 1000, 2, 3,
         [], [], 0, [], [], 0, [], [], 0, [], 0);

--- a/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
+++ b/tests/Wisp.App.Tests/TachDiagnosticExportTests.cs
@@ -210,21 +210,40 @@ public sealed class TachDiagnosticExportTests
         {
             var wait = RendererEvent() with
             {
-                Stage = "frame_wait", Result = "ready", HResult = 0, NativeThreadId = 120,
-                NativeWaitTicks = 18, WaitPrecheckTicks = 1, WaitCallTicks = 16,
-                WaitPostcheckTicks = 0, CpuThreadTicks = 5, SwapChainGeneration = 1, WaitReturnCode = 1
+                Stage = "frame_wait",
+                Result = "ready",
+                HResult = 0,
+                NativeThreadId = 120,
+                NativeWaitTicks = 18,
+                WaitPrecheckTicks = 1,
+                WaitCallTicks = 16,
+                WaitPostcheckTicks = 0,
+                CpuThreadTicks = 5,
+                SwapChainGeneration = 1,
+                WaitReturnCode = 1
             };
             var replacement = wait with { Sequence = 2, SwapChainGeneration = 2, CpuThreadTicks = null };
             var capture = Capture() with { RendererStartup = [wait], RendererRecent = [wait, replacement] };
             var counts = RendererCounts() with
             {
-                Stage = "frame_wait", Result = "ready", TotalNativePresentMilliseconds = 0, NativeThreadId = 120,
-                NativeWaitSamples = 2, TotalNativeWaitMilliseconds = 36,
-                WaitPrecheckSamples = 2, TotalWaitPrecheckMilliseconds = 2,
-                WaitCallSamples = 2, TotalWaitCallMilliseconds = 32, MaximumWaitCallMilliseconds = 16,
-                WaitPostcheckSamples = 2, TotalWaitPostcheckMilliseconds = 0,
-                CpuThreadSamples = 1, TotalCpuThreadMilliseconds = 5,
-                SwapChainGenerationSamples = 2, MinimumSwapChainGeneration = 1, MaximumSwapChainGeneration = 2,
+                Stage = "frame_wait",
+                Result = "ready",
+                TotalNativePresentMilliseconds = 0,
+                NativeThreadId = 120,
+                NativeWaitSamples = 2,
+                TotalNativeWaitMilliseconds = 36,
+                WaitPrecheckSamples = 2,
+                TotalWaitPrecheckMilliseconds = 2,
+                WaitCallSamples = 2,
+                TotalWaitCallMilliseconds = 32,
+                MaximumWaitCallMilliseconds = 16,
+                WaitPostcheckSamples = 2,
+                TotalWaitPostcheckMilliseconds = 0,
+                CpuThreadSamples = 1,
+                TotalCpuThreadMilliseconds = 5,
+                SwapChainGenerationSamples = 2,
+                MinimumSwapChainGeneration = 1,
+                MaximumSwapChainGeneration = 2,
                 WaitReturnCode = 1
             };
             var interval = Interval(CurrentCaptureId, Now, 10) with { Renderer = [counts] };
@@ -308,11 +327,18 @@ public sealed class TachDiagnosticExportTests
     {
         var valid = RendererCounts() with
         {
-            NativeWaitSamples = 1, TotalNativeWaitMilliseconds = 10,
-            WaitPrecheckSamples = 1, TotalWaitPrecheckMilliseconds = 1,
-            WaitCallSamples = 1, TotalWaitCallMilliseconds = 8, MaximumWaitCallMilliseconds = 8,
-            WaitPostcheckSamples = 1, TotalWaitPostcheckMilliseconds = 0,
-            SwapChainGenerationSamples = 1, MinimumSwapChainGeneration = 1, MaximumSwapChainGeneration = 2
+            NativeWaitSamples = 1,
+            TotalNativeWaitMilliseconds = 10,
+            WaitPrecheckSamples = 1,
+            TotalWaitPrecheckMilliseconds = 1,
+            WaitCallSamples = 1,
+            TotalWaitCallMilliseconds = 8,
+            MaximumWaitCallMilliseconds = 8,
+            WaitPostcheckSamples = 1,
+            TotalWaitPostcheckMilliseconds = 0,
+            SwapChainGenerationSamples = 1,
+            MinimumSwapChainGeneration = 1,
+            MaximumSwapChainGeneration = 2
         };
         var interval = Interval(CurrentCaptureId, Now, 1) with { Renderer = [valid] };
         Assert.NotNull(TachDiagnosticReport.SanitizeInterval(interval));

--- a/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
+++ b/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
@@ -111,21 +111,32 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
         TachDiagnostics.SetEnabled(true);
         var sample = WaitSample() with
         {
-            NativeWaitTicks = Ticks(36), WaitPrecheckTicks = Ticks(3),
-            WaitCallTicks = Ticks(30), WaitPostcheckTicks = Ticks(2), CpuThreadTicks = Ticks(2)
+            NativeWaitTicks = Ticks(36),
+            WaitPrecheckTicks = Ticks(3),
+            WaitCallTicks = Ticks(30),
+            WaitPostcheckTicks = Ticks(2),
+            CpuThreadTicks = Ticks(2)
         };
         TachDiagnostics.RecordRenderer(in sample);
         var next = sample with
         {
-            Sequence = 2, NativeWaitTicks = Ticks(50), WaitPrecheckTicks = 0,
-            WaitCallTicks = Ticks(48), WaitPostcheckTicks = Ticks(1), CpuThreadTicks = 0,
+            Sequence = 2,
+            NativeWaitTicks = Ticks(50),
+            WaitPrecheckTicks = 0,
+            WaitCallTicks = Ticks(48),
+            WaitPostcheckTicks = Ticks(1),
+            CpuThreadTicks = 0,
             SwapChainGeneration = 3
         };
         TachDiagnostics.RecordRenderer(in next);
         var partial = sample with
         {
-            Sequence = 3, NativeWaitTicks = Ticks(10), WaitPrecheckTicks = Ticks(2),
-            WaitCallTicks = null, WaitPostcheckTicks = null, CpuThreadTicks = null,
+            Sequence = 3,
+            NativeWaitTicks = Ticks(10),
+            WaitPrecheckTicks = Ticks(2),
+            WaitCallTicks = null,
+            WaitPostcheckTicks = null,
+            CpuThreadTicks = null,
             SwapChainGeneration = 2
         };
         TachDiagnostics.RecordRenderer(in partial);
@@ -195,8 +206,12 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
         TachDiagnostics.SetEnabled(true);
         var invalid = WaitSample() with
         {
-            NativeWaitTicks = -1, WaitPrecheckTicks = -2, WaitCallTicks = -3,
-            WaitPostcheckTicks = -4, CpuThreadTicks = -5, SwapChainGeneration = 0
+            NativeWaitTicks = -1,
+            WaitPrecheckTicks = -2,
+            WaitCallTicks = -3,
+            WaitPostcheckTicks = -4,
+            CpuThreadTicks = -5,
+            SwapChainGeneration = 0
         };
         TachDiagnostics.RecordRenderer(in invalid);
         var clean = Assert.Single(Snapshot().RendererRecent);
@@ -372,9 +387,14 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
     };
     private static TachRendererDiagnostic WaitSample() => Sample() with
     {
-        Stage = "frame_wait", NativeWaitTicks = 0, WaitPrecheckTicks = 0,
-        WaitCallTicks = 0, WaitPostcheckTicks = 0, CpuThreadTicks = 0,
-        SwapChainGeneration = 1, WaitReturnCode = 1
+        Stage = "frame_wait",
+        NativeWaitTicks = 0,
+        WaitPrecheckTicks = 0,
+        WaitCallTicks = 0,
+        WaitPostcheckTicks = 0,
+        CpuThreadTicks = 0,
+        SwapChainGeneration = 1,
+        WaitReturnCode = 1
     };
     private static long Ticks(double milliseconds) => (long)(milliseconds * Stopwatch.Frequency / 1000d);
     private static TachCaptureExport Snapshot() => Assert.IsType<TachCaptureExport>(TachDiagnostics.Snapshot());

--- a/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
+++ b/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
@@ -1,0 +1,239 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+using Wisp.App.DebugLogging;
+using Xunit;
+
+namespace Wisp.App.Tests;
+
+[Collection("Tach diagnostics")]
+public sealed class TachRendererDiagnosticsTests : IDisposable
+{
+    public TachRendererDiagnosticsTests() => Reset();
+    public void Dispose() => Reset();
+
+    [Fact]
+    public void DisabledRendererDoesNotAllocateOrCreateCapture()
+    {
+        var sample = Sample();
+        for (var index = 0; index < 1_000; index++) TachDiagnostics.RecordRenderer(in sample);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < 10_000; index++) TachDiagnostics.RecordRenderer(in sample);
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - before);
+        Assert.Null(TachDiagnostics.Snapshot());
+    }
+
+    [Fact]
+    public void StagesIncludeFailedAttemptsAndUseOnlyAvailableInputAgeOrigins()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample() with
+        {
+            StartedTimestamp = Ticks(100),
+            CompletedTimestamp = Ticks(110),
+            SampleTimestamp = Ticks(97),
+            ReceivedTimestamp = Ticks(98),
+            QueuedTimestamp = Ticks(99),
+            DrawCommands = 7,
+            MapCount = 2,
+            MapTicks = Ticks(4),
+            MaxMapTicks = Ticks(3),
+            SceneTicks = Ticks(1),
+            NativeSetupTicks = Ticks(2),
+            NativeDrawTicks = Ticks(8),
+            NativePresentTicks = Ticks(5),
+            CpuThreadTicks = Ticks(2),
+            QueueDropped = 3
+        };
+        TachDiagnostics.RecordRenderer(in sample);
+        var next = sample with
+        {
+            Sequence = 2,
+            CompletedTimestamp = Ticks(120),
+            SampleTimestamp = null,
+            ReceivedTimestamp = Ticks(101),
+            QueuedTimestamp = 0,
+            CpuThreadTicks = null
+        };
+        TachDiagnostics.RecordRenderer(in next);
+        var busy = sample with { Sequence = 3, Stage = "present", Result = "busy", HResult = unchecked((int)0x887A000A) };
+        TachDiagnostics.RecordRenderer(in busy);
+        var other = sample with { ControlId = 2, HostWindowHandle = 456, Sequence = 4 };
+        TachDiagnostics.RecordRenderer(in other);
+
+        var interval = Interval();
+        Assert.Equal(3, interval.Renderer.Length);
+        var draw = Assert.Single(interval.Renderer, value => value.ControlId == 1 && value.Stage == "draw");
+        Assert.Equal(2, draw.Count);
+        Assert.Equal(15, draw.MeanMilliseconds, 6);
+        Assert.Equal(20, draw.MaximumMilliseconds, 6);
+        Assert.Equal(14, draw.DrawCommands);
+        Assert.Equal(4, draw.MapCount);
+        Assert.Equal(8, draw.TotalMapMilliseconds, 6);
+        Assert.Equal(3, draw.MaximumMapMilliseconds, 6);
+        Assert.Equal(2, draw.TotalSceneMilliseconds, 6);
+        Assert.Equal(4, draw.TotalNativeSetupMilliseconds, 6);
+        Assert.Equal(16, draw.TotalNativeDrawMilliseconds, 6);
+        Assert.Equal(10, draw.TotalNativePresentMilliseconds, 6);
+        Assert.Equal(6, draw.QueueDropped);
+        Assert.Equal(1, draw.QueueAgeSamples);
+        Assert.Equal(1, draw.MeanQueueAgeMilliseconds, 6);
+        Assert.Equal(1, draw.ReceiveAgeSamples);
+        Assert.Equal(2, draw.MaximumReceiveAgeMilliseconds, 6);
+        Assert.Equal(1, draw.SampleAgeSamples);
+        Assert.Equal(3, draw.MeanSampleAgeMilliseconds, 6);
+        Assert.Equal(1, draw.CpuThreadSamples);
+        Assert.Equal(2, draw.TotalCpuThreadMilliseconds, 6);
+        Assert.Equal("busy", Assert.Single(interval.Renderer, value => value.Stage == "present").Result);
+        Assert.Equal(busy.HResult, Assert.Single(interval.Renderer, value => value.Stage == "present").HResult);
+        Assert.Equal(busy.HResult, Snapshot().RendererRecent[2].HResult);
+        Assert.Empty(Interval().Renderer);
+        Assert.Equal(4, Snapshot().RendererRecent.Length);
+    }
+
+    [Fact]
+    public void DetailRingsRetainStartupAndNewestEventsWithExactOverwriteCounts()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample();
+        var count = TachDiagnostics.RendererRecentCapacity + 17;
+        for (var index = 0; index < count; index++)
+        {
+            var next = sample with { Sequence = index + 1, StartedTimestamp = sample.StartedTimestamp + index, CompletedTimestamp = sample.CompletedTimestamp + index };
+            TachDiagnostics.RecordRenderer(in next);
+        }
+        var capture = Snapshot();
+        Assert.Equal(TachDiagnostics.RendererStartupCapacity, capture.RendererStartup.Length);
+        Assert.Equal(TachDiagnostics.RendererRecentCapacity, capture.RendererRecent.Length);
+        Assert.Equal(1, capture.RendererStartup[0].Sequence);
+        Assert.Equal(TachDiagnostics.RendererStartupCapacity, capture.RendererStartup[^1].Sequence);
+        Assert.Equal(18, capture.RendererRecent[0].Sequence);
+        Assert.Equal(count, capture.RendererRecent[^1].Sequence);
+        Assert.Equal(17, capture.RendererOverwritten);
+        Assert.Equal(count, Assert.Single(Interval().Renderer).Count);
+    }
+
+    [Fact]
+    public void RendererStartupStopsAfterSixtySeconds()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample();
+        TachDiagnostics.RecordRenderer(in sample);
+        sample = sample with { StartedTimestamp = sample.StartedTimestamp + Ticks(60_001), CompletedTimestamp = sample.CompletedTimestamp + Ticks(60_001) };
+        TachDiagnostics.RecordRenderer(in sample);
+        Assert.Single(Snapshot().RendererStartup);
+        Assert.Equal(2, Snapshot().RendererRecent.Length);
+    }
+
+    [Fact]
+    public void AggregateCapacityDoesNotLoseRawEventsAndSlotsAreReusedNextInterval()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample();
+        for (var index = 0; index < TachDiagnostics.RendererAggregateCapacity + 2; index++)
+        {
+            var next = sample with { ControlId = index + 1 };
+            TachDiagnostics.RecordRenderer(in next);
+        }
+        var interval = Interval();
+        Assert.Equal(TachDiagnostics.RendererAggregateCapacity, interval.Renderer.Length);
+        Assert.Equal(2, interval.RendererAggregateOmissions);
+        Assert.Equal(TachDiagnostics.RendererAggregateCapacity + 2, Snapshot().RendererRecent.Length);
+        sample = sample with { ControlId = 999 };
+        TachDiagnostics.RecordRenderer(in sample);
+        var nextInterval = Interval();
+        Assert.Equal(999, Assert.Single(nextInterval.Renderer).ControlId);
+        Assert.Equal(2, nextInterval.RendererAggregateOmissions);
+    }
+
+    [Fact]
+    public void ContendedProducerReturnsWithoutWaitingAndRecordsItsOmission()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var capture = typeof(TachDiagnostics).GetField("_capture", BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!;
+        var gate = capture.GetType().GetField("Gate", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(capture)!;
+        var sample = Sample();
+        var completed = false;
+        var producer = new Thread(() => { TachDiagnostics.RecordRenderer(in sample); completed = true; }) { IsBackground = true };
+        lock (gate)
+        {
+            producer.Start();
+            Assert.True(producer.Join(TimeSpan.FromSeconds(2)), "Renderer recording must not wait for the collector lock.");
+        }
+        Assert.True(completed);
+        var snapshot = Snapshot();
+        Assert.Empty(snapshot.RendererRecent);
+        Assert.Equal(1, snapshot.RendererContentionOmissions);
+        Assert.Equal(1, snapshot.ContentionOmissions);
+        Assert.Equal(1, Interval().RendererContentionOmissions);
+    }
+
+    [Fact]
+    public void ReenableStartsANewHistoryAndInvalidTimingCannotCreateNegativeDurations()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample() with { CompletedTimestamp = 1 };
+        TachDiagnostics.RecordRenderer(in sample);
+        Assert.Empty(Snapshot().RendererRecent);
+        Assert.Equal(1, Interval().RendererInvalidOmissions);
+        sample = Sample() with { Stage = "private-sentinel", Result = "private-sentinel", MapTicks = -1, MapCount = -1, CpuThreadTicks = -1 };
+        TachDiagnostics.RecordRenderer(in sample);
+        var before = Snapshot();
+        var clean = Assert.Single(before.RendererRecent);
+        Assert.Equal("unknown", clean.Stage);
+        Assert.Equal("unknown", clean.Result);
+        Assert.Equal(0, clean.MapTicks);
+        Assert.Equal(0, clean.MapCount);
+        Assert.Null(clean.CpuThreadTicks);
+        Assert.DoesNotContain("private-sentinel", JsonSerializer.Serialize(before));
+        TachDiagnostics.SetEnabled(false);
+        TachDiagnostics.RecordRenderer(in sample);
+        Assert.Single(Snapshot().RendererRecent);
+        TachDiagnostics.SetEnabled(true);
+        Assert.NotEqual(before.CaptureId, Snapshot().CaptureId);
+        Assert.Empty(Snapshot().RendererRecent);
+        Assert.Equal(0, Snapshot().RendererInvalidOmissions);
+    }
+
+    [Fact]
+    public void EnabledUncontendedProducerHasNoPerEventAllocations()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample();
+        long allocated = -1;
+        Exception? failure = null;
+        var producer = new Thread(() =>
+        {
+            try
+            {
+                for (var index = 0; index < 20_000; index++) TachDiagnostics.RecordRenderer(in sample);
+                Interval();
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 20_000; index++) TachDiagnostics.RecordRenderer(in sample);
+                allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            }
+            catch (Exception exception) { failure = exception; }
+        })
+        { IsBackground = true };
+        using (ExecutionContext.SuppressFlow()) producer.Start();
+        Assert.True(producer.Join(TimeSpan.FromSeconds(10)));
+        Assert.Null(failure);
+        Assert.Equal(0, allocated);
+        Assert.Equal(20_000, Assert.Single(Interval().Renderer).Count);
+    }
+
+    private static TachRendererDiagnostic Sample() => new()
+    {
+        ControlId = 1,
+        HostWindowHandle = 123,
+        Sequence = 1,
+        Stage = "draw",
+        Result = "ready",
+        StartedTimestamp = Stopwatch.GetTimestamp(),
+        CompletedTimestamp = Stopwatch.GetTimestamp() + Ticks(1)
+    };
+    private static long Ticks(double milliseconds) => (long)(milliseconds * Stopwatch.Frequency / 1000d);
+    private static TachCaptureExport Snapshot() => Assert.IsType<TachCaptureExport>(TachDiagnostics.Snapshot());
+    private static TachIntervalDiagnostic Interval() => Assert.IsType<TachIntervalDiagnostic>(TachDiagnostics.CollectInterval(DateTimeOffset.UtcNow));
+    private static void Reset() { TachDiagnostics.SetEnabled(false); TachDiagnostics.Clear(); }
+}

--- a/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
+++ b/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
@@ -92,6 +92,130 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
     }
 
     [Fact]
+    public void WaitDetailsPreserveIndependentCoverageTotalsAndReplacementGenerations()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = WaitSample() with
+        {
+            NativeWaitTicks = Ticks(36), WaitPrecheckTicks = Ticks(3),
+            WaitCallTicks = Ticks(30), WaitPostcheckTicks = Ticks(2), CpuThreadTicks = Ticks(2)
+        };
+        TachDiagnostics.RecordRenderer(in sample);
+        var next = sample with
+        {
+            Sequence = 2, NativeWaitTicks = Ticks(50), WaitPrecheckTicks = 0,
+            WaitCallTicks = Ticks(48), WaitPostcheckTicks = Ticks(1), CpuThreadTicks = 0,
+            SwapChainGeneration = 3
+        };
+        TachDiagnostics.RecordRenderer(in next);
+        var partial = sample with
+        {
+            Sequence = 3, NativeWaitTicks = Ticks(10), WaitPrecheckTicks = Ticks(2),
+            WaitCallTicks = null, WaitPostcheckTicks = null, CpuThreadTicks = null,
+            SwapChainGeneration = 2
+        };
+        TachDiagnostics.RecordRenderer(in partial);
+
+        Assert.Equal(new[] { sample, next, partial }, Snapshot().RendererRecent);
+        var interval = Interval();
+        var count = Assert.Single(interval.Renderer);
+        Assert.Equal(3, count.Count);
+        Assert.Equal(3, count.NativeWaitSamples);
+        Assert.Equal(96, count.TotalNativeWaitMilliseconds!.Value, 6);
+        Assert.Equal(3, count.WaitPrecheckSamples);
+        Assert.Equal(5, count.TotalWaitPrecheckMilliseconds!.Value, 6);
+        Assert.Equal(2, count.WaitCallSamples);
+        Assert.Equal(78, count.TotalWaitCallMilliseconds!.Value, 6);
+        Assert.Equal(48, count.MaximumWaitCallMilliseconds!.Value, 6);
+        Assert.Equal(2, count.WaitPostcheckSamples);
+        Assert.Equal(3, count.TotalWaitPostcheckMilliseconds!.Value, 6);
+        Assert.Equal(2, count.CpuThreadSamples);
+        Assert.Equal(2, count.TotalCpuThreadMilliseconds, 6);
+        Assert.Equal(3, count.SwapChainGenerationSamples);
+        Assert.Equal(1u, count.MinimumSwapChainGeneration);
+        Assert.Equal(3u, count.MaximumSwapChainGeneration);
+        Assert.Equal(1u, count.WaitReturnCode);
+        Assert.NotNull(TachDiagnosticReport.SanitizeInterval(interval));
+        Assert.Empty(Interval().Renderer);
+    }
+
+    [Fact]
+    public void DifferentWin32WaitOutcomesRemainDistinctInPersistedCounts()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = WaitSample();
+        foreach (uint? code in new uint?[] { null, 0, 1, 258, uint.MaxValue })
+        {
+            var next = sample with { WaitReturnCode = code };
+            TachDiagnostics.RecordRenderer(in next);
+        }
+        var counts = Interval().Renderer;
+        Assert.Equal(5, counts.Length);
+        Assert.Equal(new uint?[] { null, 0, 1, 258, uint.MaxValue }, counts.Select(value => value.WaitReturnCode));
+        Assert.All(counts, value => Assert.Equal(1, value.Count));
+    }
+
+    [Fact]
+    public void RenderThreadIdentitySurvivesExportAndSeparatesWorkerRestarts()
+    {
+        TachDiagnostics.SetEnabled(true);
+        foreach (uint? thread in new uint?[] { null, 0, 120, 240 })
+        {
+            var sample = WaitSample() with { NativeThreadId = thread };
+            TachDiagnostics.RecordRenderer(in sample);
+        }
+
+        var raw = Snapshot().RendererRecent;
+        Assert.Equal(new uint?[] { null, null, 120, 240 }, raw.Select(value => value.NativeThreadId));
+        var interval = Interval();
+        Assert.Equal(new uint?[] { null, 120, 240 }, interval.Renderer.Select(value => value.NativeThreadId));
+        Assert.Equal(new long[] { 2, 1, 1 }, interval.Renderer.Select(value => value.Count));
+        var restored = JsonSerializer.Deserialize<TachIntervalDiagnostic>(JsonSerializer.Serialize(interval));
+        Assert.NotNull(restored);
+        Assert.Equal(240u, TachDiagnosticReport.SanitizeInterval(restored)!.Renderer[2].NativeThreadId);
+    }
+
+    [Fact]
+    public void NegativeWaitDetailsBecomeUnavailableWhileMeasuredZeroRemainsMeasured()
+    {
+        TachDiagnostics.SetEnabled(true);
+        var invalid = WaitSample() with
+        {
+            NativeWaitTicks = -1, WaitPrecheckTicks = -2, WaitCallTicks = -3,
+            WaitPostcheckTicks = -4, CpuThreadTicks = -5, SwapChainGeneration = 0
+        };
+        TachDiagnostics.RecordRenderer(in invalid);
+        var clean = Assert.Single(Snapshot().RendererRecent);
+        Assert.Null(clean.NativeWaitTicks);
+        Assert.Null(clean.WaitPrecheckTicks);
+        Assert.Null(clean.WaitCallTicks);
+        Assert.Null(clean.WaitPostcheckTicks);
+        Assert.Null(clean.CpuThreadTicks);
+        Assert.Null(clean.SwapChainGeneration);
+        var missing = Assert.Single(Interval().Renderer);
+        Assert.Equal(0, missing.NativeWaitSamples);
+        Assert.Null(missing.TotalNativeWaitMilliseconds);
+        Assert.Null(missing.TotalWaitPrecheckMilliseconds);
+        Assert.Null(missing.TotalWaitCallMilliseconds);
+        Assert.Null(missing.MaximumWaitCallMilliseconds);
+        Assert.Null(missing.TotalWaitPostcheckMilliseconds);
+        Assert.Equal(0, missing.SwapChainGenerationSamples);
+        Assert.Null(missing.MinimumSwapChainGeneration);
+        Assert.Null(missing.MaximumSwapChainGeneration);
+
+        var zero = WaitSample();
+        TachDiagnostics.RecordRenderer(in zero);
+        var measured = Assert.Single(Interval().Renderer);
+        Assert.Equal(1, measured.NativeWaitSamples);
+        Assert.Equal(0d, measured.TotalNativeWaitMilliseconds);
+        Assert.Equal(1, measured.WaitCallSamples);
+        Assert.Equal(0d, measured.TotalWaitCallMilliseconds);
+        Assert.Equal(0d, measured.MaximumWaitCallMilliseconds);
+        Assert.Equal(1, measured.CpuThreadSamples);
+        Assert.Equal(0, measured.TotalCpuThreadMilliseconds);
+    }
+
+    [Fact]
     public void DetailRingsRetainStartupAndNewestEventsWithExactOverwriteCounts()
     {
         TachDiagnostics.SetEnabled(true);
@@ -199,7 +323,7 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
     public void EnabledUncontendedProducerHasNoPerEventAllocations()
     {
         TachDiagnostics.SetEnabled(true);
-        var sample = Sample();
+        var sample = WaitSample();
         long allocated = -1;
         Exception? failure = null;
         var producer = new Thread(() =>
@@ -231,6 +355,12 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
         Result = "ready",
         StartedTimestamp = Stopwatch.GetTimestamp(),
         CompletedTimestamp = Stopwatch.GetTimestamp() + Ticks(1)
+    };
+    private static TachRendererDiagnostic WaitSample() => Sample() with
+    {
+        Stage = "frame_wait", NativeWaitTicks = 0, WaitPrecheckTicks = 0,
+        WaitCallTicks = 0, WaitPostcheckTicks = 0, CpuThreadTicks = 0,
+        SwapChainGeneration = 1, WaitReturnCode = 1
     };
     private static long Ticks(double milliseconds) => (long)(milliseconds * Stopwatch.Frequency / 1000d);
     private static TachCaptureExport Snapshot() => Assert.IsType<TachCaptureExport>(TachDiagnostics.Snapshot());

--- a/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
+++ b/tests/Wisp.App.Tests/TachRendererDiagnosticsTests.cs
@@ -12,6 +12,20 @@ public sealed class TachRendererDiagnosticsTests : IDisposable
     public TachRendererDiagnosticsTests() => Reset();
     public void Dispose() => Reset();
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [InlineData(null)]
+    public void ExportPreservesCpuModeAndUnknownLegacyMode(bool? cpuRendering)
+    {
+        TachDiagnostics.SetEnabled(true);
+        var sample = Sample() with { CpuRendering = cpuRendering };
+        TachDiagnostics.RecordRenderer(in sample);
+        var row = Assert.Single(TachDiagnostics.Snapshot()!.RendererRecent);
+        var restored = JsonSerializer.Deserialize<TachRendererDiagnostic>(JsonSerializer.Serialize(row));
+        Assert.Equal(cpuRendering, restored.CpuRendering);
+    }
+
     [Fact]
     public void DisabledRendererDoesNotAllocateOrCreateCapture()
     {

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -69,6 +69,8 @@ public sealed class WpfStyleRuntimeTests
                 TachNeedleDiagnosticsTests.AssertOnCurrentDispatcher();
                 OverlayPresentationTests.AssertOnCurrentDispatcher();
                 NativeRendererIntegrationTests.AssertOnCurrentDispatcher();
+                NativeRendererIntegrationTests.AssertOnCurrentDispatcher(cpuRendering: true);
+                CpuRenderingSettingsTests.AssertControllerPersistenceOnCurrentDispatcher();
                 BoostGaugeVisualsTests.AssertOnCurrentDispatcher();
                 BoostVacuumUiTests.AssertOnCurrentDispatcher();
                 ApplicationUpdateCheckPolicyTests.AssertBannerOnCurrentDispatcher();
@@ -336,6 +338,9 @@ public sealed class WpfStyleRuntimeTests
                 nativeMeter.UpdateLayout();
                 nativeGForceVisibility = nativeMeter.Visibility;
                 var mainWindow = new MainWindow(controller);
+                var cpuToggle = Assert.IsType<CheckBox>(mainWindow.FindName("CpuRenderingToggle"));
+                Assert.Same(mainWindow.FindResource("ToggleSwitchStyle"), cpuToggle.Style);
+                Assert.NotNull(cpuToggle.GetBindingExpression(System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty));
                 var tabs = Assert.IsType<TabControl>(mainWindow.FindName("RootTabs"));
                 var surface = Assert.IsAssignableFrom<FrameworkElement>(mainWindow.Content);
                 for (var tab = 0; tab < tabs.Items.Count; tab++)


### PR DESCRIPTION
Adds an optional CPU rendering toggle in Diagnostics for Analogue tachometer lag or hitching. The setting applies after exiting Wisp from the tray and reopening it; GPU remains the default.

CPU mode now reuses the unchanged dial pixels instead of repeating the dial shader each frame. Needles and live values continue drawing, with the existing artwork, smoothing and presentation queue. This also includes the tested queued-telemetry playback correction, busy-presentation retry reuse and bounded renderer diagnostics from the 1.2.1 test builds.

Validation: 3,170 .NET tests, 75 compatibility tests, repository policy, formatting, verified installer build and both actual-installer updater validators passed locally. Native GPU and CPU contract suites passed. An independent serial ABBA comparison against Test3 found 36–44% lower offscreen rendering cost and 60/60 byte-identical pixel comparisons across sizes and dynamic gauge states.

The performance comparison does not establish displayed FPS or zero hitching on the affected PC. Issue #30 remains open.