### PR TITLE
Refresh current docs and make native timing checks overflow-safe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,11 @@ checks its architecture and records its hash in diagnostic provenance.
 The runtime test checks hardware support before exercising either DirectComposition
 or the WPF fallback. An unsupported hardware adapter must still produce a working
 gauge and the exact fallback diagnostic; other initialization errors fail the test.
-The optional native pixel and presentation contracts require a hardware GPU and
-remain a separate check on a Windows desktop:
+The native pixel and presentation contracts require a hardware GPU and remain
+a separate manual check on a Windows desktop. They are required for the
+[release gate](docs/VALIDATION.md#release-gate), but normal CI and installer
+packaging do not run them. Building the native DLL does not execute these
+contracts; record the source commit and result separately before a release:
 
 ```[WINDOWS POWERSHELL]
 ./src/Wisp.NativeRenderer/Build-NativeRenderer.ps1 -RunContractTests

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ HUD settings, and Record and Compare Runs features are preserved.
 [Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
 [1.2.1 release notes](docs/releases/Wisp-1.2.1-release-notes.md)
 
-## New in Wisp 1.2
+## Record and compare runs
 
 Record a drive and compare it with another run without leaving Wisp. Start from
 Dashboard or Runs, or set a recording shortcut. Add a countdown, choose a timed
@@ -45,159 +45,8 @@ or record gameplay video.
 [Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
 [1.2 release notes](docs/releases/Wisp-1.2.0-release-notes.md)
 
-## New in Wisp 1.1.4
-
-Addresses choppy Analogue tachometer motion while Forza is focused. The live
-combustion Analogue HUD now renders through Direct3D11 and DirectComposition,
-keeping the original gauge artwork, native needle angle and blur, and existing
-playback timing. RPM fallback also uses the corrected native motion-blur
-calculation when stock needle data is unavailable.
-
-Digital and electric HUDs and Appearance previews continue using WPF. No new
-setting is required. Local debug exports include needle-source and
-render-submission timing to help investigate remaining smoothness reports.
-
-[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
-[1.1.4 release notes](docs/releases/Wisp-1.1.4-release-notes.md)
-
-## New in Wisp 1.1.3
-
-Adds native HUD support for Xbox app / Microsoft Store FH6 `3.440.853.0` on
-Windows PC. Previous Store and Steam maps remain available offline. Signed map
-updates introduced in 1.1.2 continue to support future reviewed builds within the
-existing reader; changed native layouts may still require an application update.
-
-Enable **Show vacuum pressure** in Appearance > Boost to display negative pressure
-reported by FH6. Digital and Analogue gauges support PSI and bar, including
-attached and detached layouts. The option starts off and saves with your settings
-and HUD profiles. Leave the boost gauge enabled even when you do not know a
-tune's induction setup: naturally aspirated cars show a stationary zero gauge,
-and pressure starts working once positive boost is detected. Electric vehicles
-never show the boost gauge. Vacuum requires positive boost to have been detected
-for the current car/session.
-
-Automatic application-update checks now run whenever Wisp opens and every 24
-hours while it stays open, including while waiting in the tray. An available
-update banner remains visible if a later automatic check fails.
-
-[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
-[1.1.3 release notes](docs/releases/Wisp-1.1.3-release-notes.md)
-
-## New in Wisp 1.1.2
-
-Adds support for Steam FH6 `6.440.853.0` and signed compatibility-map updates for
-future reviewed builds. Existing Steam and Store maps remain available offline.
-Unknown native layouts still require review; changes beyond the reader's
-supported schema may need an application update.
-
-[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
-[1.1.2 release notes](docs/releases/Wisp-1.1.2-release-notes.md)
-
-## New in Wisp 1.1.1
-
-[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
-[1.1.1 release notes](docs/releases/Wisp-1.1.1-release-notes.md)
-
-- **Xbox app and Microsoft Store support.** Native HUD compatibility now includes
-  the Windows PC release of FH6, build `3.430.771.0`. Steam build `6.430.771.0`
-  remains supported through its existing compatibility path.
-- **The same local setup.** Enable FH6 Data Out and complete Wisp's setup wizard.
-  No administrator access, permission changes, or game modifications are needed.
-
-This is support for the PC game, not Xbox consoles or cloud gaming. Existing
-HUD layouts, colors, profiles, and tire calibration are preserved.
-
-## New in Wisp 1.1
-
-[Download 1.1](https://github.com/Views2k/Wisp/releases/tag/v1.1.0) ·
-[1.1 release notes](docs/releases/Wisp-1.1.0-release-notes.md)
-
-- **More readable wheel speed while drifting.** Speed smoothing now follows the
-  selected amount during rapid wheel-speed changes. Zero smoothing remains immediate.
-- **Reliable saves.** Profile-save confirmation waits for a successful write and
-  offers a retry on failure. Calibration saves also track drivetrain and revision
-  changes without altering tire-learning rules.
-- **Connection and update fixes.** Windows clock changes no longer affect telemetry
-  freshness, and release details stay available when retrying a downloaded update.
-- **Setup and release-history polish.** Setup uses the website's particle material
-  and depth styling with smoother faint gradients. Version labels no longer clip.
-- **Flexible release labels.** New clients accept shortened versions while keeping
-  installer size, SHA-256, embedded-version, and downgrade checks intact. This
-  release retains the `v1.1.0` tag so older installations can discover it.
-
-Includes expired-log cleanup before debug export. Existing exported ZIPs are
-untouched. HUD layouts, saved colors, and tire calibration behavior are preserved.
-
-## New in 1.0.12
-
-[Download 1.0.12](https://github.com/Views2k/Wisp/releases/tag/v1.0.12) ·
-[Release notes](docs/releases/Wisp-1.0.12-release-notes.md)
-
-Local debug reports now separate telemetry, UI, native-data, and composition
-problems with timestamped evidence and practical next steps. Background collection
-continues during UI stalls and stays local, opt-in, and bounded. This release also
-improves native race-provider recovery after settings transitions and removes the
-update-confirmation outline.
-
-## The 1.0.10 quality-of-life update
-
-**Save your HUD setups, choose your own colors, and track more of each drive.**
-Version 1.0.10 brings the following additions and fixes since 1.0.8.
-
-### New features
-
-- **Named HUD profiles.** Save a Drift, Racing, Minimal, or Screenshot setup
-  from Appearance, then apply, update, rename, or delete it from Profiles.
-  Profiles include the layout, gauges, units, sizing, opacity, orientation,
-  and complete color combination. Tire calibration, saved screen positions,
-  telemetry, startup, update, debug, and hotkey settings stay separate.
-- **A rebuilt color editor in Extras.** Select an element on the left and edit
-  it on the right. Choose any point on the color wheel, adjust saturation,
-  brightness and opacity, or enter an exact ARGB color. Targets include the app
-  accent, backgrounds and surfaces, HUD border, and all three gauge-gradient
-  colors. The **traction hook cue now has its own color control**.
-- **Live torque and session peaks.** Torque joins horsepower on the Wheel Speed
-  Ready card with matching smoothing and typography. Choose Nm or lb-ft. Top
-  speed, peak power, and peak torque sit below their live readings; reset them
-  together or let them reset when you change cars.
-- **Update notifications and release details.** An optional startup check runs
-  no more than once every 24 hours. A Dashboard banner announces an available
-  update, and its GitHub release summary appears before you confirm the
-  download. Downloads and installation are never automatic.
-- **A customizable overlay hotkey.** Assign a global shortcut to show or hide
-  the HUD without opening Wisp.
-- **Local debug logging.** Enable it in Diagnostics to record bounded telemetry
-  and application-health samples once per second, then export an issue-ready
-  ZIP. Logging stops after 24 hours. Logs older than seven days are cleaned up
-  when Wisp starts, records logs, or exports them. Exported ZIPs remain yours
-  to keep or delete. You choose whether to share them.
-- **Release notes inside Wisp.** A dedicated sidebar page covers the documented
-  public releases. Extras also includes a direct link to star Wisp on GitHub.
-
-### Bug fixes and refinements
-
-- Detached boost and tire-temperature gauges retain their saved positions
-  across restarts and updates, including placements on secondary displays.
-- Applying a profile restores the correct saved placement when changing
-  layouts or switching between Native Digital and Native Analogue. The selected
-  torque unit is also saved and applied.
-- Expired native tachometer samples no longer repeatedly interrupt smooth
-  RPM fallback motion when the native reader stalls.
-- The traction hook cue works across Native HUD styles, and stale slip evidence
-  is cleared after stopping.
-- Color-wheel clicks and drags work throughout the wheel. Slider adjustments
-  no longer move the selected wheel position, and very dark background colors
-  remain visible and editable without sacrificing readable surfaces.
-- Color customization uses a themed element list and a larger editor instead
-  of the unstyled dropdown. The local debug logging control is styled to match.
-- The duplicate profile-save button is removed, and the save confirmation
-  dialog no longer has an outer border.
-- Simultaneous debug-log actions no longer wait indefinitely, and a failed
-  telemetry-listener start no longer leaves UI callbacks running.
-
-[Download the latest version](https://github.com/Views2k/Wisp/releases/latest) ·
-[1.0.10 release notes](docs/releases/Wisp-1.0.10-release-notes.md) ·
-[What's new on the website](https://wispoverlay.com/releases/1.0.10/)
+For earlier changes, see the [changelog](CHANGELOG.md) and
+[release history](https://github.com/Views2k/Wisp/releases).
 
 ![Wisp 1.1 Dashboard showing live FH6 telemetry, torque, and session peaks](docs/images/dashboard-1.1.png)
 
@@ -232,8 +81,11 @@ FWD, RWD, or AWD, and presents the result in a lightweight Windows overlay.
   connection status.
 - One continuous color editor for the application accent, background surfaces,
   HUD border, shared gauge gradient, and traction hook cue, plus named visual profiles.
-- Optional once-daily update discovery, a customizable HUD visibility shortcut,
-  and bounded local debug logging with ZIP export for issue reports.
+- Local run recording, graphs, and comparisons, with report images, CSV, and
+  shareable Wisp run files.
+- Optional update discovery on every open and daily while running, a customizable
+  HUD visibility shortcut, and bounded local debug logging with ZIP export for
+  issue reports.
 
 ## Gallery
 
@@ -280,11 +132,13 @@ Wisp 1.1 with custom colors. The Release Notes capture shows the 1.1 preview ent
 - Borderless fullscreen, windowed, or another desktop-composited display mode.
   Exclusive fullscreen can cover ordinary Windows overlays.
 
-Native process-derived HUD state supports Steam FH6 build `6.430.771.0` and
-Xbox app / Microsoft Store PC build `3.430.771.0`, each through its own reviewed
-build contract. Data Out reception and dashboard calculations remain independent
-of those contracts. Wisp runs on Windows alongside the game, not on Xbox consoles
-or a cloud-gaming session.
+Native process-derived HUD state supports Steam FH6 build `6.440.853.0` and
+Xbox app / Microsoft Store PC build `3.440.853.0`. Previous bundled maps remain
+available for installations that have not updated FH6. See
+[Compatibility and Update Safety](docs/COMPATIBILITY.md#current-support) for the
+complete bundled-build list and validation rules. Data Out reception and dashboard
+calculations remain independent of those contracts. Wisp runs on Windows alongside
+the game, not on Xbox consoles or a cloud-gaming session.
 
 The installer is self-contained and installs for the current user. It does not
 require administrator access or a separate .NET runtime.
@@ -375,7 +229,8 @@ builds, validation boundary, and update behavior.
 - Telemetry is accepted only from `127.0.0.1`.
 - Settings and tire profiles remain in the current user's local application data.
 - The installer is not code-signed.
-- A changed FH6 build identity requires a reviewed Wisp update.
+- A changed FH6 build identity requires a reviewed compatibility map and may
+  require an application update.
 - FH6 exposes no tune identifier. Relearn the current tires after changing wheel
   or tire diameter.
 - Software-only WPF captures do not reproduce the live Native HUD shaders.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,10 +32,12 @@ exposed.
 
 ## Application-update boundary
 
-Wisp checks for application updates at startup, at most once every 24 hours.
-These checks are enabled by default and can be disabled in **Extras**. The
-**Check for updates** action also allows a manual check. The client makes an
-anonymous HTTPS request to the latest-release API and accepts only a non-draft,
+Wisp checks for application updates whenever it opens and every 24 hours while
+it remains running, including while waiting in the tray. These checks are enabled
+by default; turn off **Automatically check on open and daily** in **Extras** to
+disable them. The **Check for updates** action also allows a manual check. The
+client makes an anonymous HTTPS request to the latest-release API and accepts
+only a non-draft,
 non-prerelease, immutable release. Exactly one versioned installer supplies its
 numeric version, uploaded state, byte length, and GitHub SHA-256 digest.
 Short numeric versions are normalized; numeric release tags must agree with the

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -2,10 +2,12 @@
 
 ## Current support
 
-Wisp 1.1.2 includes separate Native HUD compatibility contracts for:
+Wisp bundles separate Native HUD compatibility contracts for:
 
 - Steam FH6 build `6.440.853.0`, identified by its recorded executable fingerprint;
 - Steam FH6 build `6.430.771.0`, identified by its recorded executable fingerprint;
+- Xbox app / Microsoft Store Windows PC build `3.440.853.0`, identified by its
+  Store package and bounded loaded-image checks;
 - Xbox app / Microsoft Store Windows PC build `3.430.771.0`, identified by its
   Store package and bounded loaded-image checks.
 
@@ -124,10 +126,12 @@ replacement, local cache rollback by the same user, or system-clock tampering.
 ## Application updates
 
 The application updater is separate from compatibility contracts. Availability
-checks run at startup, at most once every 24 hours. They are enabled by default
-and can be disabled in **Extras**. **Check for updates** also allows a manual
-check. The client uses GitHub's anonymous latest-release endpoint and requires a
-non-draft, non-prerelease, immutable release. Exactly one uploaded
+checks run whenever Wisp opens and every 24 hours while it remains running,
+including while waiting in the tray. They are enabled by default; turn off
+**Automatically check on open and daily** in **Extras** to disable them.
+**Check for updates** also allows a manual check. The client uses GitHub's
+anonymous latest-release endpoint and requires a non-draft, non-prerelease,
+immutable release. Exactly one uploaded
 `Wisp-Setup-<version>.exe` asset provides the numeric version, byte length, and
 GitHub SHA-256 digest. One-, two-, and three-part numeric versions normalize to
 `X.Y.Z`; numeric tags must agree with the installer. Stable release titles are

--- a/docs/HOW-WISP-WAS-BUILT.md
+++ b/docs/HOW-WISP-WAS-BUILT.md
@@ -13,14 +13,16 @@ Three decisions shaped the project from the beginning:
 
 ## Architecture
 
-The solution is split into five production projects:
+The solution has five managed production projects and a C++ rendering backend:
 
 ```text
 FH6 loopback UDP
     -> Wisp.Telemetry -> validated VehicleState
-    -> Wisp.Core      -> tire model, speed, G-force, freshness
-    -> Wisp.App       -> setup, settings, diagnostics, WPF overlays
-        |                  `-> guarded read-only Native capability
+    -> Wisp.Core      -> tire model, speed, G-force, freshness, run analysis
+    -> Wisp.App       -> setup, settings, diagnostics, run recording and views
+        |             -> guarded read-only Native capability
+        |             -> WPF views and overlays
+        |             -> Wisp.NativeRenderer -> live combustion Analogue HUD
         `-> Wisp.Update -> release validation and verified download
                          -> Wisp.Updater -> apply after Wisp exits
 ```
@@ -28,7 +30,9 @@ FH6 loopback UDP
 `Wisp.Telemetry` understands the fixed FH6 packet and owns the loopback UDP
 receiver. `Wisp.Core` contains the deterministic vehicle calculations and has
 no WPF dependency. `Wisp.App` owns startup, settings, application lifecycle,
-the setup gate, and the Windows presentation layer. `Wisp.Update` owns release
+the setup gate, local run storage, and the Windows presentation layer. Its native
+rendering bridge sends analogue scenes to `Wisp.NativeRenderer`, which owns the
+Direct3D11 resources and DirectComposition surface. `Wisp.Update` owns release
 metadata, transport, and artifact verification. `Wisp.Updater` is a small
 separate executable that applies an already verified installer after Wisp has
 closed.
@@ -63,6 +67,22 @@ fallback.
 The separate **FH6 speed** option is explicit: it displays the packet's vehicle
 speed directly and bypasses tire learning. The two sources are never blended.
 
+## Recording and comparing runs
+
+`Wisp.App.Runs.RunRecordingService` consumes a bounded capture from the telemetry
+receiver and pairs samples with validated driving context and tire radii. It
+records timestamps, gaps, rejected or dropped datagrams, and marked moments.
+Recordings stop at the selected limit, with a maximum of ten minutes. The local
+`RunStore` validates and saves Wisp run files with names, tune labels, and notes;
+recording and file work do not run in the HUD render loop.
+
+`Wisp.Core.Runs` holds the recording model and deterministic analysis for selected
+intervals, whole runs, and matched acceleration ranges. It preserves gaps and
+unavailable evidence when calculating statistics and comparison findings.
+`Wisp.App.Runs` provides the graphs, selection controls, and explicit exports to
+report images, CSV, or a shareable Wisp run file. No gameplay video is recorded,
+and tune labels come from the user.
+
 ## Reconstructing the Native HUD
 
 Native mode is composed from live controls rather than a static screenshot. It
@@ -74,9 +94,10 @@ SHA-256, role, and rendering treatment.
 The asset cache loads each image once, corrects the exported alpha
 representation before WPF composition, freezes the result, and reuses tinted
 variants. Digital, Analogue, Electric Digital, and Electric Analogue controls
-then select the appropriate elements for the current state. Pixel shaders
-provide the digital RPM material, analogue dial treatment, and tachometer
-needle trail.
+then select the appropriate elements for the current state. The native analogue
+scene uses the same stock assets and gauge geometry. Shaders provide the digital
+RPM material, analogue dial treatment, and tachometer needle trail in their
+respective renderers.
 
 Wisp is a free, non-commercial companion and uses these assets for
 interoperability and HUD presentation. The repository links to Microsoft's
@@ -122,19 +143,32 @@ state; no generated gear artwork is substituted.
 ## Rendering without unnecessary work
 
 Packet arrivals schedule a UI update using the newest available telemetry,
-independently of WPF compositor callbacks. RPM samples pass through a small
-receive-time interpolation buffer so the telemetry needle can move continuously
-between real samples without predicting future RPM. When an exact Native needle
-pair is available, a separate bounded playback
-path follows its observed angle and blur samples on the same compositor clock.
-It resets instead of extrapolating across stale input, a car change, or a hidden
-render lifetime.
+independently of WPF compositor callbacks. The live combustion Analogue HUD has
+a separate render worker paced by the DXGI frame-latency wait handle. It consumes
+bounded input, builds a scene, and submits it through Direct3D11 and
+DirectComposition. A full input queue is discarded and playback resets so a
+stalled renderer cannot replay an old backlog. Busy submissions retry the pending
+frame without repeatedly drawing it, while visibility or incompatible state
+changes invalidate pending work.
 
-Native controls detach from `CompositionTarget.Rendering` while hidden,
-collapsed, minimized, or unloaded. Diagnostics refresh at a much lower cadence,
-and game-window visibility checks are bounded separately. Scrolling uses stable
-parent containers so moving through a page does not replace the page's scale
-transform on every offset change.
+GPU rendering is the default. The optional **CPU rendering** setting in
+**Diagnostics** selects Direct3D11 WARP after restarting Wisp. CPU mode caches an
+unchanged dial background while continuing to update the needle and live
+readings. It can increase CPU usage and applies only to the live combustion
+Analogue HUD. Digital and electric HUDs, Appearance previews, and the analogue
+WPF fallback retain their WPF renderer.
+
+RPM samples pass through a small receive-time interpolation buffer without
+predicting future RPM. When exact Native needle samples are available, bounded
+playback follows their observed angle and blur. Playback uses the active
+renderer's timing and resets across stale input, car changes, and hidden
+lifetimes. WPF Native controls detach from `CompositionTarget.Rendering` while
+hidden, collapsed, minimized, or unloaded; the native worker suspends its drawing
+while inactive.
+
+Diagnostics refresh at a much lower cadence, and game-window visibility checks
+are bounded separately. Scrolling uses stable parent containers so moving through
+a page does not replace the page's scale transform on every offset change.
 
 FH6 can continue sending plausible driving telemetry while a menu is open, so
 packet activity alone is not a visibility signal. Wisp combines telemetry
@@ -165,8 +199,11 @@ work to the overlay render loop.
 The test suite covers packet offsets, malformed data, listener lifecycle,
 drivetrain calculations, calibration consensus, settings migration, setup
 gating, WPF resources, native asset hashes and pixels, gauge geometry, shaders,
-render lifetime, recorded RPM traces, compatibility validation, and installer
-promotion rollback.
+render lifetime, recorded RPM traces, run recording and comparison, compatibility
+validation, and installer promotion rollback. Native pixel and presentation
+contracts remain a separate manual hardware-GPU requirement for the
+[release gate](VALIDATION.md#release-gate); normal CI and installer packaging do
+not execute that command.
 
 The opt-in UI review tool constructs the compiled WPF surfaces with isolated
 settings and deterministic sample state. It checks page layouts at multiple
@@ -182,8 +219,10 @@ unique staging directory. It validates the installer, inner checksum, two-file
 ZIP, and outer checksum before promoting the four-file bundle with durable
 recovery state.
 
-Update availability checks run at startup, at most once every 24 hours. They are
-enabled by default and can be disabled in Extras; manual checks remain available.
+Update availability checks run whenever Wisp opens and every 24 hours while it
+remains running, including while waiting in the tray. They are enabled by default;
+turn off **Automatically check on open and daily** in **Extras** to disable them.
+Manual checks remain available.
 Wisp asks for confirmation before downloading and installing an update. The
 client reads GitHub's anonymous latest-release endpoint and accepts only a stable
 immutable release with a strict tag, exact versioned installer name, uploaded

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -21,6 +21,12 @@ dotnet build tools/Wisp.UiReview/Wisp.UiReview.csproj --configuration Release --
 python -m unittest discover -s tools/tests -p "test_*.py" -v
 ```
 
+The native pixel and presentation command requires a hardware GPU on a Windows
+desktop. It remains a required manual release check: record the exact source
+commit and result alongside the release evidence. Normal CI and installer
+packaging build the native DLL but do not run `-RunContractTests`; their success
+alone does not satisfy this part of the release gate.
+
 Packaging must additionally verify the staged executable version, PE identity,
 update-helper identity, the staged `Wisp.NativeRenderer.dll`, Native asset
 manifest, bundled .NET 8.0.30 notices, and the installer/checksum pair before
@@ -111,7 +117,8 @@ GitHub Actions runs on `windows-latest` and performs:
 1. an audited NuGet restore;
 2. `dotnet format --verify-no-changes`;
 3. the complete Release .NET solution tests;
-4. a locked Release build of the UI review harness;
+4. a locked Release build of the UI review harness and bounded setup-wizard and
+   Appearance captures;
 5. the Python compatibility-audit tests.
 
 The local packaging script adds a separate installer gate. It runs the Release

--- a/src/Wisp.NativeRenderer/NativeContractTests.cpp
+++ b/src/Wisp.NativeRenderer/NativeContractTests.cpp
@@ -13,6 +13,21 @@ static void Require(bool passed, const char* name)
 {
     if (!passed) { ++failures; std::printf("FAIL: %s\n", name); }
 }
+static constexpr bool TimingsFitTotal(int64_t totalTicks, int64_t firstTicks, int64_t secondTicks, int64_t thirdTicks = 0)
+{
+    // Bound each subtraction instead of summing durations that could overflow.
+    return firstTicks >= 0 && secondTicks >= 0 && thirdTicks >= 0 &&
+        totalTicks >= firstTicks && totalTicks - firstTicks >= secondTicks &&
+        totalTicks - firstTicks - secondTicks >= thirdTicks;
+}
+static_assert(TimingsFitTotal(0, 0, 0) && TimingsFitTotal(10, 2, 3, 5), "Zero and exact-fit timings are valid.");
+static_assert(TimingsFitTotal(INT64_MAX, INT64_MAX - 2, 1, 1), "Exact fits remain valid at the signed limit.");
+static_assert(!TimingsFitTotal(9, 2, 3, 5), "Nested timings cannot exceed the total.");
+static_assert(!TimingsFitTotal(INT64_MAX, INT64_MAX, 1) &&
+    !TimingsFitTotal(INT64_MAX, INT64_MAX - 1, 1, 1), "Overflowing sums are rejected without evaluating them.");
+static_assert(!TimingsFitTotal(INT64_MIN, 0, 0) && !TimingsFitTotal(INT64_MAX, INT64_MIN, 0) &&
+    !TimingsFitTotal(INT64_MAX, 0, INT64_MIN) && !TimingsFitTotal(INT64_MAX, 0, 0, INT64_MIN),
+    "Negative timings are rejected before subtraction.");
 static WispDrawCommand Sprite(float x, float y, float width, float height, uint32_t texture = 0)
 {
     WispDrawCommand command{};
@@ -59,7 +74,7 @@ static void CheckDialCache(void* renderer, bool cpuRendering)
         Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, commands, 2, 1, &metrics)), "measured cache draw");
         Require(metrics.drawCount == expectedDraws && metrics.mapCount == expectedDraws,
             "cache metrics count only actual draws and maps");
-        Require(metrics.totalTicks >= metrics.setupTicks + metrics.mapTicks,
+        Require(TimingsFitTotal(metrics.totalTicks, metrics.setupTicks, metrics.mapTicks),
             "cache setup and maps remain disjoint nested timings");
     };
     const uint32_t cachedDraws = cpuRendering ? 1u : 2u;
@@ -235,8 +250,8 @@ int main(int argc, char** argv)
     Require(SUCCEEDED(WispRendererWaitForFrameMeasured(renderer, 100, nullptr, 1, &initialReady, &waitMetrics)),
         "initial measured queue wait");
     Require(waitMetrics.totalTicks > 0 && waitMetrics.precheckTicks >= 0 && waitMetrics.waitCallTicks > 0 &&
-        waitMetrics.postcheckTicks >= 0 && waitMetrics.totalTicks >=
-        waitMetrics.precheckTicks + waitMetrics.waitCallTicks + waitMetrics.postcheckTicks &&
+        waitMetrics.postcheckTicks >= 0 && TimingsFitTotal(waitMetrics.totalTicks,
+            waitMetrics.precheckTicks, waitMetrics.waitCallTicks, waitMetrics.postcheckTicks) &&
         waitMetrics.cpuTime100ns >= -1 && waitMetrics.swapChainGeneration == 1 &&
         waitMetrics.waitResult == (initialReady == 1 ? WAIT_TIMEOUT : WAIT_OBJECT_0),
         "wait metrics partition wall time and record initial swapchain generation");
@@ -337,7 +352,7 @@ int main(int argc, char** argv)
     Require(SUCCEEDED(WispRendererDrawForPresentation(renderer, overlap, 2, 1, &drawMetrics)), "separate measured draw");
     Require(drawMetrics.drawCount == 2 && drawMetrics.mapCount == 2 && drawMetrics.totalTicks > 0 &&
         drawMetrics.setupTicks > 0 && drawMetrics.mapTicks >= drawMetrics.maximumMapTicks &&
-        drawMetrics.totalTicks >= drawMetrics.setupTicks + drawMetrics.mapTicks,
+        TimingsFitTotal(drawMetrics.totalTicks, drawMetrics.setupTicks, drawMetrics.mapTicks),
         "CPU draw metrics include setup and each constant map");
     Require(WispRendererCapture(renderer, pixels.data(), static_cast<uint32_t>(pixels.size()), 1152) == E_INVALIDARG,
         "presentation draw does not enable readback");


### PR DESCRIPTION
Current documentation still describes older supported builds, update timing, and the earlier WPF-only rendering path. Refresh it to match the shipped application, retain the current release and Runs guidance in the README, and point older announcements to the existing release history. Native hardware-GPU contracts remain a required manual release gate, explicitly separate from CI and installer builds.

Three native test assertions also add signed 64-bit timing values before comparing them with a total. Replace those additions with guarded subtraction that rejects negative components and bounds every subtraction. Compile-time cases cover zero, exact fit, signed limits, overflowing sums, and negative inputs. Existing count, duration, and status assertions remain intact.

Validation:
- Repository policy and whitespace checks pass; all 39 affected local documentation links/anchors resolve.
- The timing predicate matched an independent arbitrary-precision sum oracle for 20,736 boundary combinations and 10,000 seeded random cases, with checked signed arithmetic reporting no overflow.
- All README image/demo markup and tracked image bytes are unchanged. Runtime code, workflows, dependencies, installer behavior, and application version are unchanged.
- Native C++ compilation and hardware-GPU contracts were not run locally because this VM lacks the required toolchain. The normal required Build and test / Build installer checks must pass before merge. This maintenance PR does not publish an application release.

Closes #56.
