### PR TITLE
Add Ko-fi and Buy Me a Coffee support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+ko_fi: views2k
+buy_me_a_coffee: Views2k

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
   Supports Steam and Xbox app / Microsoft Store editions on Windows PC.<br><br>
   <a href="https://github.com/Views2k/Wisp/releases/latest"><strong>Download</strong></a> ·
   <a href="CHANGELOG.md">Changelog</a> ·
-  <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a>
+  <a href="docs/HOW-WISP-WAS-BUILT.md">Architecture</a><br><br>
+  Support Wisp: <a href="https://ko-fi.com/views2k">Ko-fi</a> ·
+  <a href="https://buymeacoffee.com/Views2k">Buy Me a Coffee</a>
 </p>
 
 ## New in Wisp 1.2.1


### PR DESCRIPTION
Add Ko-fi and Buy Me a Coffee to the repository sponsorship section and the opening README links.

Validated the funding YAML and exact link destinations. The existing README artwork and navigation remain intact. No application code or release files changed.

Build and test, installer validation, and CodeQL passed.