### PR TITLE
Fix renderer integration checks for cached dial frames

### DIFF
--- a/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
+++ b/tests/Wisp.App.Tests/NativeRendererIntegrationTests.cs
@@ -176,9 +176,16 @@ internal static class NativeRendererIntegrationTests
                     Assert.True(row.QueuedTimestamp is > 0 && row.QueuedTimestamp <= row.SampleTimestamp);
                     Assert.Equal(0, row.HResult);
                 });
-                Assert.Contains(renderer, row => row.Stage == "draw" && row.Result == "ready" &&
-                    row.DrawCommands > 0 && row.MapCount == row.DrawCommands &&
-                    row.NativeDrawTicks > 0 && row.NativeDrawTicks >= row.MapTicks &&
+                var draws = renderer.Where(row => row.Stage == "draw" && row.Result == "ready").ToArray();
+                Assert.NotEmpty(draws);
+                Assert.All(draws, row =>
+                {
+                    Assert.True(row.DrawCommands > 0);
+                    // Reusing the cached static dial skips its one buffer map;
+                    // the command count still includes that dial.
+                    Assert.InRange(row.MapCount, Math.Max(1, row.DrawCommands - 1), row.DrawCommands);
+                });
+                Assert.Contains(draws, row => row.NativeDrawTicks > 0 && row.NativeDrawTicks >= row.MapTicks &&
                     row.CompletedTimestamp >= row.StartedTimestamp + row.NativeDrawTicks);
                 Assert.Contains(renderer, row => row.Stage == "frame_wait" && row.Result == "ready" &&
                     row.NativeWaitTicks is > 0 && row.WaitPrecheckTicks is >= 0 &&

--- a/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
+++ b/tests/Wisp.App.Tests/WpfStyleRuntimeTests.cs
@@ -18,7 +18,7 @@ public sealed class WpfStyleRuntimeTests
     public WpfStyleRuntimeTests(ITestOutputHelper output) => _output = output;
 
     [Fact]
-    public void ScrollViewerCornerBrushResolvesToTheWindowBackground()
+    public void ApplicationStylesAndNativeControlsPassRuntimeChecks()
     {
         Color? resolvedColor = null;
         var nativeDigitalPixels = 0;


### PR DESCRIPTION
The native renderer deliberately skips one buffer map when it reuses the cached static dial. The resize integration test required a map for every command, so a valid cached frame could fail depending on which draws reached the diagnostic snapshot.

Validate every ready draw against the two valid map counts, while retaining the existing timing, presentation, resize and focus checks. Rename the aggregate WPF test so failures are no longer reported as a ScrollViewer-only check.

Only two test files change. Application behavior, images, version numbers and workflow protections are unchanged. Windows build/test, native integration and installer validation, and CodeQL passed.